### PR TITLE
fix url issue

### DIFF
--- a/.github/workflows/push-github-pages.yml
+++ b/.github/workflows/push-github-pages.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build
         run: |
           yarn
-          yarn build
+          yarn build --config ./docusaurus.config.prod.js
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const config = {
   title: 'Rising Wave',
   tagline: 'Get started to Rising Wave in 5 minutes',
-  url: 'https://singularity-data.com/risingwave-docs',
+  url: 'https://singularity-data.com',
   baseUrl: '/',
   trailingSlash: true,
   onBrokenLinks: 'throw',

--- a/docusaurus.config.prod.js
+++ b/docusaurus.config.prod.js
@@ -1,0 +1,8 @@
+const config = require("./docusaurus.config");
+
+/** @type {import('@docusaurus/types').Config} */
+const newConfig = {
+  baseUrl: "/risingwave-docs/"
+};
+
+module.exports = { ...config, ...newConfig };


### PR DESCRIPTION
Github pages will redirect the whole page to https://singularity-data.com/risingwave-docs. This breaks the file routing in built artifact. The solution is changing the baseUrl in `config` file. But the baseUrl for local development should remains unchanged. Thus we should have a new `config` file for production to overwrite the baseUrl setting.