### PR TITLE
Add syntax highlight for commands, and fix a bug

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -10,8 +10,6 @@ sidebar_position: 2
 This guide will help you get started with RisingWave. We will cover: 
 
 - [Install and run RisingWave](#install-and-run-risingwave)
-  - [Use the pre-built library (Linux)](#use-the-pre-built-library-linux)
-  - [Build from source (Linux & macOS)](#build-from-source-linux--macos)
 - [Connect to a streaming source](#connect-to-a-streaming-source)
 - [Query and manage data](#query-and-manage-data)
 

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -9,7 +9,9 @@ sidebar_position: 2
 
 This guide will help you get started with RisingWave. We will cover: 
 
-- [Install and run RisingWave](#install-and-start-risingwave)
+- [Install and run RisingWave](#install-and-run-risingwave)
+  - [Use the pre-built library (Linux)](#use-the-pre-built-library-linux)
+  - [Build from source (Linux & macOS)](#build-from-source-linux--macos)
 - [Connect to a streaming source](#connect-to-a-streaming-source)
 - [Query and manage data](#query-and-manage-data)
 
@@ -19,19 +21,19 @@ This guide will help you get started with RisingWave. We will cover:
 
 1. Download the pre-built library.
  
-    ```
+    ```shell
     wget https://github.com/singularity-data/risingwave/releases/download/v0.1.5/risingwave-v0.1.5-x86_64-unknown-linux.tar.gz
     ```
 
 2. Unzip the library.
 
-    ```
+    ```shell
     tar xvf risingwave-v0.1.5-x86_64-unknown-linux.tar.gz
     ```
 
 3. Start RisingWave in the test mode.
 
-    ```
+    ```shell
     ./risingwave playground
     ```
 
@@ -39,7 +41,7 @@ This guide will help you get started with RisingWave. We will cover:
 
 1. Download the source code of RisingWave.
 
-    ```
+    ```shell
     git clone https://github.com/singularity-data/risingwave.git
     ```
 
@@ -64,37 +66,37 @@ import TabItem from '@theme/TabItem';
 <TabItem value="macos" label="macOS" default>
 
 
-```
+```shell
 brew install cmake protobuf openssl postgresql tmux
 ```
 Run one of the following cammands to install [rustup](https://rustup.rs):
-```
+```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 or
-```
+```shell
 brew install rustup-init && rustup-init
 ```
 </TabItem>
 <TabItem value="linux" label="Linux">
 
-```
+```shell
 sudo apt update
 ```
 
-```
+```shell
 sudo apt upgrade
 ```
 
-```
+```shell
 sudo apt install make build-essential cmake protobuf-compiler curl openssl libssl-dev pkg-config
 ```
 
-```
+```shell
 sudo apt install postgresql-client
 ```
 
-```
+```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 </TabItem>
@@ -104,11 +106,11 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 3. Run RisingWave.
 
     To run RisingWave, in the terminal, navigate to the directory where RisingWave is downloaded, and run the following command.
-    ```
+    ```shell
     ./risedev dev # Running RisingWave in the production mode
     ```
     or
-    ```
+    ```shell
     ./risedev playground # Running RisingWave in the test mode. 
     ```
     :::tip
@@ -122,19 +124,19 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
     :::info
 
     The default stream connector frontend has a temporary limitation. It only accepts Amazon Kinesis. To connect to other sources, you need to use the legacy stream connector frontend. To run RisingWave with the legacy stream connector frontend, ensure that you have Java 11 installed in your environment, and run the following command in your terminal:
-    ```
+    ```shell
     ./risedev configure enable legacy-frontend
     ```
 
     :::
 
     You can stop RisingWave with the following command.
-    ```
+    ```shell
     ./risedev kill
     ```
 
 4. After RisingWave services are started, run the PostgreSQL interactive terminal.
-    ```
+    ```shell
     psql -h localhost -p 4566 -d dev
     ```
     You can now issue SQL statements to manage your streams and data. 

--- a/docs/Operators.md
+++ b/docs/Operators.md
@@ -61,7 +61,7 @@ title: Operators and functions
 
 ## String matching operators
 
-```
+```sql
 string NOT LIKE pattern
 String LIKE pattern
 ```
@@ -72,7 +72,7 @@ If the pattern does not contain percent signs or underscores, then the pattern o
 
 Examples:
 
-```
+```sql
 'abc' LIKE 'abc'           true
 'abc' LIKE 'a%'            true
 'abc' LIKE '_b_'           true

--- a/docs/Sources.md
+++ b/docs/Sources.md
@@ -24,7 +24,7 @@ Please see below for the streaming sources that RisingWave supports.
 :::info
 
 The default stream connector frontend has a temporary limitation. It only accepts Amazon Kinesis. To connect to other sources, you need to use the legacy stream connector frontend. To run RisingWave with the legacy stream connector frontend, ensure that you have Java 11 installed in your environment, and run the following command in your terminal:
-```
+```shell
 ./risedev configure enable legacy-frontend
 ```
 

--- a/generator_instructions/docusaurus_intro.md
+++ b/generator_instructions/docusaurus_intro.md
@@ -17,7 +17,7 @@ Generate a new Docusaurus site using the **classic template**.
 
 The classic template will automatically be added to your project after you run the command:
 
-```bash
+```shell
 npm init docusaurus@latest my-website classic
 ```
 
@@ -29,7 +29,7 @@ The command also installs all necessary dependencies you need to run Docusaurus.
 
 Run the development server:
 
-```bash
+```shell
 cd my-website
 npm run start
 ```

--- a/generator_instructions/tutorial-basics/deploy-your-site.md
+++ b/generator_instructions/tutorial-basics/deploy-your-site.md
@@ -12,7 +12,7 @@ It builds your site as simple **static HTML, JavaScript and CSS files**.
 
 Build your site **for production**:
 
-```bash
+```shell
 npm run build
 ```
 
@@ -22,7 +22,7 @@ The static files are generated in the `build` folder.
 
 Test your production build locally:
 
-```bash
+```shell
 npm run serve
 ```
 

--- a/generator_instructions/tutorial-extras/manage-docs-versions.md
+++ b/generator_instructions/tutorial-extras/manage-docs-versions.md
@@ -10,7 +10,7 @@ Docusaurus can manage multiple versions of your docs.
 
 Release a version 1.0 of your project:
 
-```bash
+```shell
 npm run docusaurus docs:version 1.0
 ```
 

--- a/generator_instructions/tutorial-extras/translate-your-site.md
+++ b/generator_instructions/tutorial-extras/translate-your-site.md
@@ -23,7 +23,7 @@ module.exports = {
 
 Copy the `docs/intro.md` file to the `i18n/fr` folder:
 
-```bash
+```shell
 mkdir -p i18n/fr/docusaurus-plugin-content-docs/current/
 
 cp docs/intro.md i18n/fr/docusaurus-plugin-content-docs/current/intro.md
@@ -35,7 +35,7 @@ Translate `i18n/fr/docusaurus-plugin-content-docs/current/intro.md` in French.
 
 Start your site on the French locale:
 
-```bash
+```shell
 npm run start -- --locale fr
 ```
 
@@ -77,12 +77,12 @@ The locale dropdown now appears in your navbar:
 
 Build your site for a specific locale:
 
-```bash
+```shell
 npm run build -- --locale fr
 ```
 
 Or build your site to include all the locales at once:
 
-```bash
+```shell
 npm run build
 ```

--- a/versioned_docs/version-1.0.0/intro.md
+++ b/versioned_docs/version-1.0.0/intro.md
@@ -23,7 +23,7 @@ Generate a new Docusaurus site using the **classic template**.
 
 The classic template will automatically be added to your project after you run the command:
 
-```bash
+```shell
 npm init docusaurus@latest my-website classic
 ```
 
@@ -35,7 +35,7 @@ The command also installs all necessary dependencies you need to run Docusaurus.
 
 Run the development server:
 
-```bash
+```shell
 cd my-website
 npm run start
 ```

--- a/versioned_docs/version-1.0.0/tutorial-basics/deploy-your-site.md
+++ b/versioned_docs/version-1.0.0/tutorial-basics/deploy-your-site.md
@@ -12,7 +12,7 @@ It builds your site as simple **static HTML, JavaScript and CSS files**.
 
 Build your site **for production**:
 
-```bash
+```shell
 npm run build
 ```
 
@@ -22,7 +22,7 @@ The static files are generated in the `build` folder.
 
 Test your production build locally:
 
-```bash
+```shell
 npm run serve
 ```
 

--- a/versioned_docs/version-1.0.0/tutorial-extras/manage-docs-versions.md
+++ b/versioned_docs/version-1.0.0/tutorial-extras/manage-docs-versions.md
@@ -10,7 +10,7 @@ Docusaurus can manage multiple versions of your docs.
 
 Release a version 1.0 of your project:
 
-```bash
+```shell
 npm run docusaurus docs:version 1.0
 ```
 

--- a/versioned_docs/version-1.0.0/tutorial-extras/translate-your-site.md
+++ b/versioned_docs/version-1.0.0/tutorial-extras/translate-your-site.md
@@ -23,7 +23,7 @@ module.exports = {
 
 Copy the `docs/intro.md` file to the `i18n/fr` folder:
 
-```bash
+```shell
 mkdir -p i18n/fr/docusaurus-plugin-content-docs/current/
 
 cp docs/intro.md i18n/fr/docusaurus-plugin-content-docs/current/intro.md
@@ -35,7 +35,7 @@ Translate `i18n/fr/docusaurus-plugin-content-docs/current/intro.md` in French.
 
 Start your site on the French locale:
 
-```bash
+```shell
 npm run start -- --locale fr
 ```
 
@@ -77,12 +77,12 @@ The locale dropdown now appears in your navbar:
 
 Build your site for a specific locale:
 
-```bash
+```shell
 npm run build -- --locale fr
 ```
 
 Or build your site to include all the locales at once:
 
-```bash
+```shell
 npm run build
 ```


### PR DESCRIPTION
1. Add syntax highlight
2. In RisingWave, we use ```shell, so I think here we can also use this format.
3. Fix a bug related to the link? Not sure whether the bug is valid.