### PR TITLE
feat: (sticky-table-header): fit dark mode and light mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -123,27 +123,62 @@ h2 {
   border-bottom: 1px solid #dbdbdb;
 }
 
-@media (max-width: 1000px) {
-  table {
-    position: relative;
-  }
+table {
+  position: relative;
+}
 
-  [data-theme="dark"] table thead th {
-    background-color: #474748;
-  }
+[data-theme="dark"] table thead th {
+  background-color: #474748;
+}
 
-  table thead th {
-    position: sticky;
-    top: 0;
-    z-index: 10;
-    background-color: #d0d0d0;
-    border: 1px solid transparent;
-  }
+table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background-color: #d0d0d0;
+  border: 1px solid transparent;
+}
 
-  table {
-    height: 50vh;
-    overflow: auto;
-  }
+table {
+  height: 50vh;
+  overflow: auto;
+}
+
+table::-webkit-scrollbar {
+  width: 5px;
+  height: 5px;
+  background-color: #f5f5f5;
+}
+
+table::-webkit-scrollbar-track {
+  border-radius: 10px;
+  background-color: #ddd;
+}
+
+table::-webkit-scrollbar-thumb {
+  border-radius: 10px;
+  background-color: #666;
+}
+
+table::-webkit-scrollbar-thumb:window-inactive {
+  border-radius: 10px;
+  background-color: transparent;
+}
+
+[data-theme="dark"] table::-webkit-scrollbar {
+  width: 4px;
+  height: 4px;
+  background-color: #f5f5f5;
+}
+
+[data-theme="dark"] table::-webkit-scrollbar-track {
+  border-radius: 10px;
+  background-color: #c1c1c1;
+}
+
+[data-theme="dark"] table::-webkit-scrollbar-thumb {
+  border-radius: 10px;
+  background-color: #707070;
 }
 
 /* ol{

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -135,7 +135,7 @@ h2 {
   table thead th {
     position: sticky;
     top: 0;
-    z-index: 9999;
+    z-index: 10;
     background-color: #d0d0d0;
     border: 1px solid transparent;
   }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -58,8 +58,7 @@ h4 {
 
 @font-face {
   font-family: NotoSans-Medium;
-  src: local("NotoSans-Medium"),
-    url(/static/font/NotoSans-Medium.ttf) format("ttf"),
+  src: local("NotoSans-Medium"), url(/static/font/NotoSans-Medium.ttf) format("ttf"),
     url(/static/font/NotoSans-Medium.woff) format("woff");
   font-weight: normal;
   font-style: normal;
@@ -75,8 +74,7 @@ h4 {
 
 @font-face {
   font-family: NotoSans-SemiBold;
-  src: local("NotoSans-SemiBold"),
-    url(/static/font/NotoSans-SemiBold.ttf) format("ttf"),
+  src: local("NotoSans-SemiBold"), url(/static/font/NotoSans-SemiBold.ttf) format("ttf"),
     url(/static/font/NotoSans-SemiBold.woff) format("woff");
   font-weight: normal;
   font-style: normal;
@@ -84,8 +82,7 @@ h4 {
 
 @font-face {
   font-family: NotoSans-ExtraLight;
-  src: local("NotoSans-ExtraLight"),
-    url(/static/font/NotoSans-ExtraLight.ttf) format("ttf"),
+  src: local("NotoSans-ExtraLight"), url(/static/font/NotoSans-ExtraLight.ttf) format("ttf"),
     url(/static/font/NotoSans-ExtraLight.woff) format("woff");
   font-weight: normal;
   font-style: normal;
@@ -124,6 +121,29 @@ h4 {
 h2 {
   padding-bottom: 10px;
   border-bottom: 1px solid #dbdbdb;
+}
+
+@media (max-width: 1000px) {
+  table {
+    position: relative;
+  }
+
+  [data-theme="dark"] table thead th {
+    background-color: #474748;
+  }
+
+  table thead th {
+    position: sticky;
+    top: 0;
+    z-index: 9999;
+    background-color: #d0d0d0;
+    border: 1px solid transparent;
+  }
+
+  table {
+    height: 50vh;
+    overflow: auto;
+  }
 }
 
 /* ol{


### PR DESCRIPTION
~~use position: sticky and media query to stick the table header when user's screen width is less than 1000px~~

it supports all devices now, when the table's height is more than 50vh, it will show the scroll bar and sticky table header

~~known bug: when the table header is sticked and then click the nav bar, you'll get:~~



Close #61 