### PR TITLE
chore: use consistent terms (statement->command)

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -1,10 +1,10 @@
 ---
-id: sql-statements
-slug: /sql-statements
-title: Statements
+id: sql-commands
+slug: /sql-commands
+title: Commands
 ---
 
-RisingWave supports the following SQL statements.
+RisingWave supports the following SQL commands.
 
 * `CREATE SOURCE`
 * `CREATE MATERIALIZED VIEW`

--- a/docs/Get-Started.md
+++ b/docs/Get-Started.md
@@ -155,7 +155,7 @@ You can now issue SQL queries to manage your streams and data.
 
 ## Connect to a streaming source
 
-Use `CREATE SOURCE` statement to connect to a streaming source.
+Use `CREATE SOURCE` command to connect to a streaming source.
 
 To connect to a Kafka topic: 
 
@@ -269,7 +269,7 @@ AS
 ```
 
 
-For the complete list of supported SQL statements, see [Statements](Statements.md).
+For the complete list of supported SQL commands, see [Commands](Commands.md).
 
 
 

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -29,7 +29,7 @@ Everything you do in RisingWave is via Postgres-compatible SQL. You can:
 - See [Get started](Get-Started.md) to learn about how to get started with RisingWave. 
 - For the architecture of RisingWave, see [Architecture](Architecture.md).
 - To learn about the supported stream sources and how to connect to the sources, see [Sources](Sources.md).
-- For the supported SQL data types, operators, and statements, see [SQL overview](SQL-Overview.md).
+- For the supported SQL data types, operators, and commands, see [SQL overview](SQL-Overview.md).
 
 
 ### SQL as the interface

--- a/docs/SQL-Overview.md
+++ b/docs/SQL-Overview.md
@@ -6,9 +6,9 @@ title: Overview
 
 
 
-The implementation of SQL in RisingWave is compatible with PostgreSQL.  We are actively adding support for more statements, functions, and operators. Click the links below to find out the latest lists. 
+The implementation of SQL in RisingWave is compatible with PostgreSQL.  We are actively adding support for more operators, functions, and commands. Click the links below to find out the latest lists. 
 
 * [Data types](Data-Types.md)
 * [Operators and functions](Operators.md)
-* [Statements](Statements.md)
+* [Commands](Commands.md)
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -45,7 +45,7 @@ const sidebars = {
     label: `SQL`,
     collapsible: true,
     collapsed: false,
-    items: [`sql-ov`, `sql-data-types`, `sql-operators`, `sql-statements`,
+    items: [`sql-ov`, `sql-data-types`, `sql-operators`, `sql-commands`,
     ]
   }
  ]


### PR DESCRIPTION
Previously we use statements to refer to both commands (SQL commands without actual column names) and completed statements. Let's use commands to refer to commands (without column names, operators, and functions), and consider using statements to refer to a complete / executable SQL statement. 