### PR TITLE
removed the outdated tip

### DIFF
--- a/docs/Sources.md
+++ b/docs/Sources.md
@@ -20,14 +20,6 @@ Please see below for the streaming sources that RisingWave supports.
 |PostgreSQL CDC|	10, 11, 12, 13, 14|	JSON|	Materialized only|	Must have primary key|
 |MySQL CDC|	5.7, 8.0|	JSON|	Materialized only|	Must have primary key|
 
-:::info
-
-The default stream connector frontend has a temporary limitation. It only accepts Amazon Kinesis. To connect to other sources, you need to use the legacy stream connector frontend. To run RisingWave with the legacy stream connector frontend, ensure that you have Java 11 installed in your environment, and run the following command in your terminal:
-```shell
-./risedev configure enable legacy-frontend
-```
-
-:::
 
 
 ## Connect to a source


### PR DESCRIPTION
We had a tip about the new frontend only supporting Kinesis. The issue was fixed so we need to remove the tip.