### PR TITLE
removed outdated tip about legacy frontend & update supported Kafka source versions

### DIFF
--- a/docs/Sources.md
+++ b/docs/Sources.md
@@ -13,9 +13,9 @@ Please see below for the streaming sources that RisingWave supports.
 
 | Source | Version | Data format | Materialized? | Limitations |
 |---------|---------|---------|---------|---------|
-|Kafka|0.11.0 or higher	|JSON, protobuf|	Materialized & non-materialized|-
+|Kafka|3.1.0 or later versions	|JSON, protobuf|	Materialized & non-materialized|-
 |Redpanda|Latest|JSON, protobuf	|Materialized & non-materialized|	-
-|Pulsar|	2.8.0 or higher|	JSON, protobuf|	Materialized & non-materialized|	-
+|Pulsar|	2.8.0 or later versions|	JSON, protobuf|	Materialized & non-materialized|	-
 |Kinesis|	Latest|	JSON, protobuf|	Materialized & non-materialized|	-
 |PostgreSQL CDC|	10, 11, 12, 13, 14|	JSON|	Materialized only|	Must have primary key|
 |MySQL CDC|	5.7, 8.0|	JSON|	Materialized only|	Must have primary key|

--- a/docs/Sources.md
+++ b/docs/Sources.md
@@ -20,14 +20,6 @@ Please see below for the streaming sources that RisingWave supports.
 |PostgreSQL CDC|	10, 11, 12, 13, 14|	JSON|	Materialized only|	Must have primary key|
 |MySQL CDC|	5.7, 8.0|	JSON|	Materialized only|	Must have primary key|
 
-:::info
-
-The default stream connector frontend has a temporary limitation. It only accepts Amazon Kinesis. To connect to other sources, you need to use the legacy stream connector frontend. To run RisingWave with the legacy stream connector frontend, ensure that you have Java 11 installed in your environment, and run the following command in your terminal:
-```shell
-./risedev configure enable legacy-frontend
-```
-
-:::
 
 
 ## Connect to a source


### PR DESCRIPTION
Removed the outdated tip about legacy frontend and updated the Kafka source versions to match what we actually tested