### PR TITLE
feat: Add appendonly option to CREATE TABLE

### DIFF
--- a/docs/sql/commands/sql-create-table.md
+++ b/docs/sql/commands/sql-create-table.md
@@ -11,7 +11,7 @@ Use the `CREATE TABLE` command to create a new table.
 
 ```sql
 CREATE TABLE <table> (<col> <data_type> [, <col> <data_type>...])
-    [ WITH ( 'storage_parameter'=value [, ... ] ) ];
+    [ WITH ( '<storage_parameter>' = value [, ... ] ) ];
 ```
 
 ## Parameters
@@ -21,7 +21,7 @@ CREATE TABLE <table> (<col> <data_type> [, <col> <data_type>...])
 |*table*    |The name of the table. If a schema name is given (for example, `CREATE TABLE <schema>.<table> ...`), then the table is created in the specified schema. Otherwise it is created in the current schema.|
 |*col*      |The name of a column.|
 |*data_type*|The data type of a column. |
-|*storage_parameter*| The storage parameter can be used to set options for the table. Currently we support *appendonly* option, `'appendonly' = true` specifies that there is only INSERT operations to the table. If user creates a materialized view on an append-only table, the corresponding stream query plan will be optimized for append-only workload. |
+|*storage_parameter*| Set options for the table. Supported options: <ul><li>appendonly<ul><li>`'appendonly' = true` specifies that only INSERT operations on the table are allowed. If you create a materialized view on an append-only table, the corresponding stream query plan will be optimized for the append-only workload.</li></ul></li></ul>|
 
 ## Examples
 

--- a/docs/sql/commands/sql-create-table.md
+++ b/docs/sql/commands/sql-create-table.md
@@ -10,7 +10,8 @@ Use the `CREATE TABLE` command to create a new table.
 ## Syntax
 
 ```sql
-CREATE TABLE <table> (<col> <data_type> [, <col> <data_type>...]);
+CREATE TABLE <table> (<col> <data_type> [, <col> <data_type>...])
+    [ WITH ( 'storage_parameter'=value [, ... ] ) ];
 ```
 
 ## Parameters
@@ -20,6 +21,7 @@ CREATE TABLE <table> (<col> <data_type> [, <col> <data_type>...]);
 |*table*    |The name of the table. If a schema name is given (for example, `CREATE TABLE <schema>.<table> ...`), then the table is created in the specified schema. Otherwise it is created in the current schema.|
 |*col*      |The name of a column.|
 |*data_type*|The data type of a column. |
+|*storage_parameter*| The storage parameter can be used to set options for the table. Currently we support *appendonly* option, `'appendonly' = true` specifies that there is only INSERT operations to the table. If user creates a materialized view on an append-only table, the corresponding stream query plan will be optimized for append-only workload. |
 
 ## Examples
 
@@ -30,6 +32,6 @@ CREATE TABLE taxi_trips(
     id VARCHAR,
     distance DOUBLE PRECISION,
     duration DOUBLE PRECISION
-);
+) WITH ('appendonly' = true);
 ```
 


### PR DESCRIPTION
Example:

```
dev=> CREATE TABLE t1(
    id VARCHAR,
    distance DOUBLE PRECISION,
    duration DOUBLE PRECISION
) WITH ('appendonly' = true);
CREATE_TABLE
dev=> describe t1;
   Name   |  Type
----------+---------
 id       | Varchar
 distance | Float64
 duration | Float64
(3 rows)

dev=> explain create materialized view mv1 as select id, max(distance) as max_d from t1 group by id;
                                       QUERY PLAN
----------------------------------------------------------------------------------------
 StreamMaterialize { columns: [id, agg#0(hidden), max_d], pk_columns: [id] }
   StreamAppendOnlyHashAgg { group_keys: [$0], aggs: [count, max($1)] }
     StreamExchange { dist: HashShard([0]) }
       StreamTableScan { table: t1, columns: [id, distance, _row_id], pk_indices: [2] }
(4 rows)

```

related issue https://github.com/singularity-data/risingwave/issues/2962
