### PR TITLE
fix docker-compose error

### DIFF
--- a/docs/tutorials/real-time-ad-performance-analysis.md
+++ b/docs/tutorials/real-time-ad-performance-analysis.md
@@ -42,6 +42,15 @@ cd ad-ctr
 docker-compose up -d
 ```
 
+If error occurs as below:
+```shell
+ERROR: The Compose file './docker-compose.yml' is invalid because:
+'name' does not match any of the regexes: '^x-'
+```
+You may use `docker compose` instead of `docker-compose`,
+or enable "Use Docker Compose V2" in Docker Desktop.
+For more info about the command, please check [Docker's doc](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command).
+
 Necessary RisingWave components, including frontend node, compute node, metadata node, and MinIO, will be started. The workload generator will start to generate random data and feed them into Kafka topics.
 
 

--- a/docs/tutorials/real-time-ad-performance-analysis.md
+++ b/docs/tutorials/real-time-ad-performance-analysis.md
@@ -42,14 +42,18 @@ cd ad-ctr
 docker-compose up -d
 ```
 
-If error occurs as below:
+:::note
+
+If the following error occurs:
 ```shell
 ERROR: The Compose file './docker-compose.yml' is invalid because:
 'name' does not match any of the regexes: '^x-'
 ```
-You may use `docker compose` instead of `docker-compose`,
-or enable "Use Docker Compose V2" in Docker Desktop.
-For more info about the command, please check [Docker's doc](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command).
+Use `docker compose` instead of `docker-compose`, or enable **Use Docker Compose V2** on the Settings page of Docker Desktop.
+
+For more information, see [Docker Documentation](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command).
+
+:::
 
 Necessary RisingWave components, including frontend node, compute node, metadata node, and MinIO, will be started. The workload generator will start to generate random data and feed them into Kafka topics.
 


### PR DESCRIPTION
We may also just keep `docker compose` instead.

closes #134 