### PR TITLE
doc updates about struct

### DIFF
--- a/docs/sql/commands/sql-create-table.md
+++ b/docs/sql/commands/sql-create-table.md
@@ -20,7 +20,7 @@ CREATE TABLE <table> (<col> <data_type> [, <col> <data_type>...])
 |-----------|-------------|
 |*table*    |The name of the table. If a schema name is given (for example, `CREATE TABLE <schema>.<table> ...`), then the table is created in the specified schema. Otherwise it is created in the current schema.|
 |*col*      |The name of a column.|
-|*data_type*|The data type of a column. |
+|*data_type*|The data type of a column. With the `struct` data type, you can create a nested table. Elements in a nested table need to be enclosed with angle brackets ("<>"). |
 |*storage_parameter*| Set options for the table. Supported options: <ul><li>appendonly<ul><li>`'appendonly' = true` specifies that only INSERT operations on the table are allowed. If you create a materialized view on an append-only table, the corresponding stream query plan will be optimized for the append-only workload.</li></ul></li></ul>|
 
 ## Examples
@@ -35,3 +35,13 @@ CREATE TABLE taxi_trips(
 ) WITH ('appendonly' = true);
 ```
 
+The statement below creates a table that includes nested tables.
+
+```sql
+CREATE TABLE taxi_trips(
+    id VARCHAR,
+    distance DOUBLE PRECISION,
+    duration DOUBLE PRECISION,
+    fare STRUCT<initial_charge DOUBLE PRECISION, subsequent_charge DOUBLE PRECISION, surcharge DOUBLE PRECISION, tolls DOUBLE PRECISION>
+);
+```

--- a/docs/sql/commands/sql-create-table.md
+++ b/docs/sql/commands/sql-create-table.md
@@ -20,7 +20,7 @@ CREATE TABLE <table> (<col> <data_type> [, <col> <data_type>...])
 |-----------|-------------|
 |*table*    |The name of the table. If a schema name is given (for example, `CREATE TABLE <schema>.<table> ...`), then the table is created in the specified schema. Otherwise it is created in the current schema.|
 |*col*      |The name of a column.|
-|*data_type*|The data type of a column. With the `struct` data type, you can create a nested table. Elements in a nested table need to be enclosed with angle brackets ("<>"). |
+|*data_type*|The data type of a column. With the `struct` data type, you can create a nested table. Elements in a nested table need to be enclosed with angle brackets ("\<\>"). |
 |*storage_parameter*| Set options for the table. Supported options: <ul><li>appendonly<ul><li>`'appendonly' = true` specifies that only INSERT operations on the table are allowed. If you create a materialized view on an append-only table, the corresponding stream query plan will be optimized for the append-only workload.</li></ul></li></ul>|
 
 ## Examples

--- a/docs/sql/commands/sql-create-table.md
+++ b/docs/sql/commands/sql-create-table.md
@@ -20,7 +20,7 @@ CREATE TABLE <table> (<col> <data_type> [, <col> <data_type>...])
 |-----------|-------------|
 |*table*    |The name of the table. If a schema name is given (for example, `CREATE TABLE <schema>.<table> ...`), then the table is created in the specified schema. Otherwise it is created in the current schema.|
 |*col*      |The name of a column.|
-|*data_type*|The data type of a column. With the `struct` data type, you can create a nested table. Elements in a nested table need to be enclosed with angle brackets ("\<\>"). |
+|*data_type*|The data type of a column. With the `struct` data type, you can create a nested table. Elements in a nested table need to be enclosed with angle brackets ("<\>"). |
 |*storage_parameter*| Set options for the table. Supported options: <ul><li>appendonly<ul><li>`'appendonly' = true` specifies that only INSERT operations on the table are allowed. If you create a materialized view on an append-only table, the corresponding stream query plan will be optimized for the append-only workload.</li></ul></li></ul>|
 
 ## Examples

--- a/docs/sql/sql-data-types.md
+++ b/docs/sql/sql-data-types.md
@@ -23,5 +23,6 @@ RisingWave supports the following data types:
 |timestamp without time zone|timestamp|Date and time (no time zone)|
 |timestamp with time zone | |Timestamp with time zone|
 |interval| |Time span|
+|struct| |<p>Use this type to define a nested table. A nested table is a table that is embedded in another table.</p><p>Example:</p><p>`CREATE TABLE t1 (v1 int, v2 struct<v3 int, v4 int>);`</p>|
 
 


### PR DESCRIPTION
Add "struct" to the list of data types, and also to the "CREATE TABLE" command page. The syntax does not reflect the nested structure yet, as we use angle brackets to represent parameters and nested tables are enclosed with angle brackets. It would be confusing if we include nested tables in the syntax at the moment. We'll customize the styling of the syntax blocks, and will add nested tables to the syntax when it's ready. 