### PR TITLE
Allow implicit cast from single-quoted literals.

### DIFF
--- a/docs/sql/functions-operators/sql-function-mathematical.md
+++ b/docs/sql/functions-operators/sql-function-mathematical.md
@@ -25,6 +25,7 @@ title: Mathematical functions and operators
 | ABS (x) | Returns the absolute value of *x*. | ABS(-3) → 3 |
 | ROUND (x numeric, y int) → numeric | Rounds *x* to *y* decimal places. *y* cannot be negative. | ROUND(1.23559, 2) → 1.24 |
 | ROUND (numeric) → numeric <br /> ROUND (double precision) → double precision | Rounds to nearest integer. | ROUND(1.23559) → 1 |
+| ROUND (string) → numeric | Rounds to nearest integer. Allows implicit cast from single-quoted literals. | ROUND('4.5') → 5 |
 | FLOOR (numeric) → numeric <br /> FLOOR (double precision) → double precision | Returns the nearest integer less than or equal to the argument. | FLOOR(1.23559) → 1 <br /> FLOOR(-1.23559) → -2 |
 | CEIL (numeric) → numeric <br /> FLOOR (double precision) → double precision | Returns the nearest integer greater than or equal to the argument. | CEIL(1.23559) → 2 <br /> CEIL(-1.23559) → -1 |
 

--- a/docs/sql/functions-operators/sql-function-mathematical.md
+++ b/docs/sql/functions-operators/sql-function-mathematical.md
@@ -25,7 +25,7 @@ title: Mathematical functions and operators
 | ABS (x) | Returns the absolute value of *x*. | ABS(-3) → 3 |
 | ROUND (x numeric, y int) → numeric | Rounds *x* to *y* decimal places. *y* cannot be negative. | ROUND(1.23559, 2) → 1.24 |
 | ROUND (numeric) → numeric <br /> ROUND (double precision) → double precision | Rounds to nearest integer. | ROUND(1.23559) → 1 |
-| ROUND (string) → numeric | Rounds to nearest integer. Allows implicit cast from single-quoted literals. | ROUND('4.5') → 5 |
+| ROUND (string) → numeric | Casts and rounds a string to the nearest integer. | ROUND('4.5') → 5 |
 | FLOOR (numeric) → numeric <br /> FLOOR (double precision) → double precision | Returns the nearest integer less than or equal to the argument. | FLOOR(1.23559) → 1 <br /> FLOOR(-1.23559) → -2 |
 | CEIL (numeric) → numeric <br /> FLOOR (double precision) → double precision | Returns the nearest integer greater than or equal to the argument. | CEIL(1.23559) → 2 <br /> CEIL(-1.23559) → -1 |
 


### PR DESCRIPTION
Allow implicit cast from single-quoted literals.

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Allow implicit cast from single-quoted literals.

- **Related code PR**: 
https://github.com/singularity-data/risingwave/pull/3487

- **Related doc issue**: 
Resolves https://github.com/singularity-data/risingwave-docs/issues/149

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked related doc issue to this PR in **Development**.
  - [ ] I have accquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview and the updated parts look all good. <details><summary>How?</summary><img width="852" alt="image" src="https://user-images.githubusercontent.com/100549427/180817529-5ab18ea5-f36b-4663-8002-a43d511be7ab.png"></details>
  - [ ] (For version-specific PR) I have confirmed that this PR is for a released version. If the software version is not released, put it on hold.


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
