### PR TITLE
Convert string interval to time.

### DIFF
--- a/docs/sql/functions-operators/sql-function-datetime.md
+++ b/docs/sql/functions-operators/sql-function-datetime.md
@@ -10,7 +10,6 @@ title: Date/time functions and operators
 
 | Operation | Description | Example |
 | ----------- | ----------- | ----------- |
-| interval → time | Convert string interval to time. | `interval '4 hour'` → `04:00:00` <br /> `interval '3 day'` → `3 days 00:00:00` |
 | date + interval → timestamp | Add an interval to a date. | `date '2022-04-08' + interval '10 hour'` → `2022-04-08 10:00:00` |
 | date - interval → timestamp | Subtract an interval to a date. | `date '2022-04-08' - interval '10 hour'` → `2022-04-07 14:00:00` |
 

--- a/docs/sql/functions-operators/sql-function-datetime.md
+++ b/docs/sql/functions-operators/sql-function-datetime.md
@@ -10,6 +10,7 @@ title: Date/time functions and operators
 
 | Operation | Description | Example |
 | ----------- | ----------- | ----------- |
+| interval → time | Convert string interval to time. | `interval '4 hour'` → `04:00:00` <br /> `interval '3 day'` → `3 days 00:00:00` |
 | date + interval → timestamp | Add an interval to a date. | `date '2022-04-08' + interval '10 hour'` → `2022-04-08 10:00:00` |
 | date - interval → timestamp | Subtract an interval to a date. | `date '2022-04-08' - interval '10 hour'` → `2022-04-07 14:00:00` |
 

--- a/docs/sql/sql-data-types.md
+++ b/docs/sql/sql-data-types.md
@@ -22,7 +22,7 @@ RisingWave supports the following data types:
 |time| |Time of day (no time zone)|
 |timestamp without time zone|timestamp|Date and time (no time zone)|
 |timestamp with time zone | |Timestamp with time zone|
-|interval| |Time span. Input in string format. Units include: second/s, minute/s, hour/s, day/s, month/s, and year/s.<p>Examples:</p><p>`interval '4 hour'` → `04:00:00` <br /> `interval '3 day'` → `3 days 00:00:00`</p>|
+|interval| |Time span. Input in string format. Units include: second/seconds/s, minute/minutes/min/m, hour/hours/hr/h, day/days/d, month/months/mon, and year/years/yr/y.<p>Examples:</p><p>`interval '4 hour'` → `04:00:00` <br /> `interval '3 day'` → `3 days 00:00:00`</p>|
 |struct| |<p>Use this type to define a nested table. A nested table is a table that is embedded in another table.</p><p>Example:</p><p>`CREATE TABLE t1 (v1 int, v2 struct<v3 int, v4 struct<v5 varchar, v6 date>>);`</p>|
 
 

--- a/docs/sql/sql-data-types.md
+++ b/docs/sql/sql-data-types.md
@@ -22,7 +22,7 @@ RisingWave supports the following data types:
 |time| |Time of day (no time zone)|
 |timestamp without time zone|timestamp|Date and time (no time zone)|
 |timestamp with time zone | |Timestamp with time zone|
-|interval| |Time span. Input in string format. Units include: second/s, minute/s, hour/s, day/s, month/s, and year/s).<p>Examples:</p><p>`interval '4 hour'` → `04:00:00` <br /> `interval '3 day'` → `3 days 00:00:00`</p>||
+|interval| |Time span. Input in string format. Units include: second/s, minute/s, hour/s, day/s, month/s, and year/s.<p>Examples:</p><p>`interval '4 hour'` → `04:00:00` <br /> `interval '3 day'` → `3 days 00:00:00`</p>|
 |struct| |<p>Use this type to define a nested table. A nested table is a table that is embedded in another table.</p><p>Example:</p><p>`CREATE TABLE t1 (v1 int, v2 struct<v3 int, v4 struct<v5 varchar, v6 date>>);`</p>|
 
 

--- a/docs/sql/sql-data-types.md
+++ b/docs/sql/sql-data-types.md
@@ -22,7 +22,7 @@ RisingWave supports the following data types:
 |time| |Time of day (no time zone)|
 |timestamp without time zone|timestamp|Date and time (no time zone)|
 |timestamp with time zone | |Timestamp with time zone|
-|interval| |Time span|
+|interval| |Time span. Input in string format. Units include: second/s, minute/s, hour/s, day/s, month/s, and year/s).</p><p>Examples:</p><p>`interval '4 hour'` → `04:00:00` <br /> `interval '3 day'` → `3 days 00:00:00`</p>||
 |struct| |<p>Use this type to define a nested table. A nested table is a table that is embedded in another table.</p><p>Example:</p><p>`CREATE TABLE t1 (v1 int, v2 struct<v3 int, v4 struct<v5 varchar, v6 date>>);`</p>|
 
 

--- a/docs/sql/sql-data-types.md
+++ b/docs/sql/sql-data-types.md
@@ -22,7 +22,7 @@ RisingWave supports the following data types:
 |time| |Time of day (no time zone)|
 |timestamp without time zone|timestamp|Date and time (no time zone)|
 |timestamp with time zone | |Timestamp with time zone|
-|interval| |Time span. Input in string format. Units include: second/s, minute/s, hour/s, day/s, month/s, and year/s).</p><p>Examples:</p><p>`interval '4 hour'` → `04:00:00` <br /> `interval '3 day'` → `3 days 00:00:00`</p>||
+|interval| |Time span. Input in string format. Units include: second/s, minute/s, hour/s, day/s, month/s, and year/s).<p>Examples:</p><p>`interval '4 hour'` → `04:00:00` <br /> `interval '3 day'` → `3 days 00:00:00`</p>||
 |struct| |<p>Use this type to define a nested table. A nested table is a table that is embedded in another table.</p><p>Example:</p><p>`CREATE TABLE t1 (v1 int, v2 struct<v3 int, v4 struct<v5 varchar, v6 date>>);`</p>|
 
 


### PR DESCRIPTION
Convert string interval to time. Support input such as interval '5 days'.

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Convert string interval to time. Support string interval input.

- **Related code PR**: 
https://github.com/singularity-data/risingwave/pull/3037

- **Related doc issue**: 
Resolves https://github.com/singularity-data/risingwave-docs/issues/144

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked related doc issue to this PR in **Development**.
  - [x] I have accquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview and the updated parts look all good. <details><summary>How?</summary><img width="852" alt="image" src="https://user-images.githubusercontent.com/100549427/180817529-5ab18ea5-f36b-4663-8002-a43d511be7ab.png"></details>
  - [ ] (For version-specific PR) I have confirmed that this PR is for a released version. If the software version is not released, put it on hold.


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
