### PR TITLE
Add support for current_database function.

### DIFF
--- a/docs/sql/functions-operators/sql-function-sys-info.md
+++ b/docs/sql/functions-operators/sql-function-sys-info.md
@@ -6,5 +6,5 @@ title: System information functions
 
 |Function|Description|Example|
 |---|---|---|
-| current_database() → name |Returns the name of the current database. Also, SQL commands, functions, and operators support the current_database() function.|`current_database()` → `db_name` <br /> `count(current_database())` → `1`|
+| current_database() → name |Returns the name of the current database. SQL commands, functions, and operators support the current_database() function.|`current_database()` → `db_name` <br /> `count(current_database())` → `1`|
 | pg_typeof() → regtype |Returns the standard name of the data type of the provided value. <br /> More specifically, it returns the OID of the data type of the provided value. It returns a regtype, which is an OID alias type. Therefore it’s the same as an OID for comparison purposes but displays as a type name.|`pg_typeof(round(null))` → `double precision` <br /> `pg_typeof(row(true, 1, 'hello'))` → `record` <br /> `pg_typeof(array[1, 2])` → `integer[]`|

--- a/docs/sql/functions-operators/sql-function-sys-info.md
+++ b/docs/sql/functions-operators/sql-function-sys-info.md
@@ -6,4 +6,5 @@ title: System information functions
 
 |Function|Description|Example|
 |---|---|---|
+| current_database() → name |Returns the name of the current database. Also, SQL commands, functions, and operators support the current_database() function.|`current_database()` → `db_name` <br /> `count(current_database())` → `1`|
 | pg_typeof() → regtype |Returns the standard name of the data type of the provided value. <br /> More specifically, it returns the OID of the data type of the provided value. It returns a regtype, which is an OID alias type. Therefore it’s the same as an OID for comparison purposes but displays as a type name.|`pg_typeof(round(null))` → `double precision` <br /> `pg_typeof(row(true, 1, 'hello'))` → `record` <br /> `pg_typeof(array[1, 2])` → `integer[]`|


### PR DESCRIPTION
Add support for current_database function.

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Add support for current_database function.

- **Related code PR**: 
https://github.com/singularity-data/risingwave/pull/3650

- **Related doc issue**: 
Resolves https://github.com/singularity-data/risingwave-docs/issues/227

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [x] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [x] I have checked the doc site preview and the updated parts look all good. <details><summary>How?</summary><img width="852" alt="image" src="https://user-images.githubusercontent.com/100549427/180817529-5ab18ea5-f36b-4663-8002-a43d511be7ab.png"></details>
  - [ ] (For version-specific PR) I have confirmed that this PR is for a released version. If the software version is not released, put it on hold.


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
