### PR TITLE
feat: font fallback for special symbol such as →

### DIFF
--- a/src/components/FeedbackForm/index.module.css
+++ b/src/components/FeedbackForm/index.module.css
@@ -37,7 +37,7 @@
 
 button.footerButton {
   color: #7798ef;
-  font-family: NotoSans;
+  font-family: NotoSans NotoSansSC-Regular;
   font-size: 14px;
   text-transform: none;
   border: 1px solid #7798ef;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -17,7 +17,7 @@
   --ifm-code-font-size: 90%;
   --ifm-font-size-base: 92%;
   --ifm-z-index-fixed: 200;
-  --ifm-font-family-base: NotoSans;
+  --ifm-font-family-base: NotoSans, NotoSansSC-Regular, sans-serif;
   --ifm-paragraph-margin-bottom: 0.5rem;
   --ifm-list-paragraph-margin: 0.2rem;
   letter-spacing: 0px;
@@ -52,6 +52,7 @@ h4 {
     url(/static/font/NotoSans-Regular.woff) format("woff");
   font-weight: normal;
   font-style: normal;
+  unicode-range: U+020-622;
 }
 
 @font-face {
@@ -84,6 +85,12 @@ h4 {
     url(/static/font/NotoSans-ExtraLight.woff) format("woff");
   font-weight: normal;
   font-style: normal;
+}
+
+@font-face {
+  font-family: NotoSansSC-Regular;
+  src: local("NotoSansSC-Regular"), url(/static/font/NotoSansSC-Regular.otf) format("opentype");
+  unicode-range: U+020-622;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */

--- a/src/theme/DocItem/styles.module.css
+++ b/src/theme/DocItem/styles.module.css
@@ -11,7 +11,7 @@
 }
 
 button.requestButton {
-  font-family: NotoSans;
+  font-family: NotoSans NotoSansSC-Regular;
   text-transform: none;
   font-size: 13px;
   color: #7798ef;


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**:  add font `NotoSans SC`
<!-- [ What's changed? ] -->

- **Related code PR**: /
<!--[ Provide link to the code PR here. For example, https://github.com/risingwavelabs/risingwave/pull/4085. Delete this part if there's no code PR related. ]  -->

- **Related doc issue**: 
Resolves #246 
<!-- [ Provide link to the doc issue here. ] -->

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview and the updated parts look all good. <details><summary>How?</summary><img width="852" alt="image" src="https://user-images.githubusercontent.com/100549427/180817529-5ab18ea5-f36b-4663-8002-a43d511be7ab.png"></details>
  - [ ] (For version-specific PR) I have confirmed that this PR is for a released version. If the software version is not released, put it on hold.


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
