### PR TITLE
Minor fixes to the Twitter tutorial- addresses

### DIFF
--- a/docs/tutorials/fast-twitter-events-processing.md
+++ b/docs/tutorials/fast-twitter-events-processing.md
@@ -24,13 +24,13 @@ In the demo cluster, we packaged RisingWave and a workload generator. The worklo
 First, clone the [risingwave-demo](https://github.com/singularity-data/risingwave-demo) repository to the environment.
 
 ```shell
-git clone https://github.com/singularity-data/risingwave-demo.git
+git clone https://github.com/risingwavelabs/risingwave-demo.git
 ```
 
 Now navigate to the `twitter` directory and start the demo cluster from the docker compose file. 
 
 ```shell
-cd twitter
+cd risingwave-demo/twitter
 docker-compose up -d
 ```
 


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Updating the repo address.
Fixing the directory of the `twitter` folder. Because after cloning the repo, the user has to enter `risingwave-demo` and then `twitter`, otherwise, the terminal throws an error.

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview and the updated parts look all good. <details><summary>How?</summary><img width="852" alt="image" src="https://user-images.githubusercontent.com/100549427/180817529-5ab18ea5-f36b-4663-8002-a43d511be7ab.png"></details>
  - [ ] (For version-specific PR) I have confirmed that this PR is for a released version. If the software version is not released, put it on hold.


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
