### PR TITLE
use docker compose v2

### DIFF
--- a/docs/Get-Started.md
+++ b/docs/Get-Started.md
@@ -92,7 +92,18 @@ cd docker
 docker-compose up -d
 ```
 
-If you are on mac and receive an error about an invalid `docker-compose.yaml`, make sure to `Use Docker Compose V2` in docker desktop. 
+:::note
+
+If the following error occurs:
+```shell
+ERROR: The Compose file './docker-compose.yml' is invalid because:
+'name' does not match any of the regexes: '^x-'
+```
+Use `docker compose` instead of `docker-compose`, or enable **Use Docker Compose V2** on the Settings page of Docker Desktop.
+
+For more information, see [Docker Documentation](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command).
+
+:::
 
 ### Build from source (Linux & macOS)
 

--- a/docs/Get-Started.md
+++ b/docs/Get-Started.md
@@ -92,6 +92,8 @@ cd docker
 docker-compose up -d
 ```
 
+If you are on mac and receive an error about an invalid `docker-compose.yaml`, make sure to `Use Docker Compose V2` in docker desktop. 
+
 ### Build from source (Linux & macOS)
 
 You can build from source on both x86_64 and ARM64 systems (including macOS devices with an Apple M1 chip).


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Inform user that docker compose v2 is necessary on Mac 

- **Related code PR**: 
non

- **Related doc issue**: 
non

- **Notes**: 
I got the following error before switching to V2
```
docker-compose up -d
ERROR: The Compose file './docker-compose.yml' is invalid because:
'name' does not match any of the regexes: '^x-'
```

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview and the updated parts look all good. <details><summary>How?</summary><img width="852" alt="image" src="https://user-images.githubusercontent.com/100549427/180817529-5ab18ea5-f36b-4663-8002-a43d511be7ab.png"></details>
  - [ ] (For version-specific PR) I have confirmed that this PR is for a released version. If the software version is not released, put it on hold.


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
