### PR TITLE
Adding notes to alert users of the docker error

### DIFF
--- a/docs/tutorials/fast-twitter-events-processing.md
+++ b/docs/tutorials/fast-twitter-events-processing.md
@@ -34,6 +34,19 @@ cd risingwave-demo/twitter
 docker-compose up -d
 ```
 
+:::note
+
+If the following error occurs:
+```shell
+ERROR: The Compose file './docker-compose.yml' is invalid because:
+'name' does not match any of the regexes: '^x-'
+```
+Use `docker compose` instead of `docker-compose`, or enable **Use Docker Compose V2** on the Settings page of Docker Desktop.
+
+For more information, see [Docker Documentation](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command).
+
+:::
+
 Necessary RisingWave components will be started, including the frontend node, compute node, metadata node, and MinIO. The workload generator will start to generate random data and feed them into Kafka topics.
 
 Now connect to RisingWave to manage data streams and perform data analysis.

--- a/docs/tutorials/real-time-ad-performance-analysis.md
+++ b/docs/tutorials/real-time-ad-performance-analysis.md
@@ -38,7 +38,7 @@ git clone https://github.com/risingwavelabs/risingwave-demo.git
 Now navigate to the `ad-ctr` directory and start the demo cluster from the docker compose file. 
 
 ```shell
-cd ad-ctr
+cd risingwave-demo/ad-ctr
 docker-compose up -d
 ```
 

--- a/docs/tutorials/server-performance-anomaly-detection.md
+++ b/docs/tutorials/server-performance-anomaly-detection.md
@@ -40,9 +40,22 @@ git clone https://github.com/risingwavelabs/risingwave-demo.git
 Now navigate to the `cdn-metrics` directory and start the demo cluster from the docker compose file. 
 
 ```shell
-cd cdn-metrics
+cd risingwave-demo/cdn-metrics
 docker-compose up -d
 ```
+
+:::note
+
+If the following error occurs:
+```shell
+ERROR: The Compose file './docker-compose.yml' is invalid because:
+'name' does not match any of the regexes: '^x-'
+```
+Use `docker compose` instead of `docker-compose`, or enable **Use Docker Compose V2** on the Settings page of Docker Desktop.
+
+For more information, see [Docker Documentation](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command).
+
+:::
 
 Necessary RisingWave components will be started, including the frontend node, compute node, metadata node, and MinIO. The workload generator will start to generate random data and feed them into Kafka topics.
 


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Adding notes to alert users of the docker error.

An FAQ section is the better solution. But before we have that, let's simply add notes. FAQ content should be more flexible than the normal user docs. Ideally, the FAQ items are easy to add, edit, tag, search, and reference in the docs. We might need to explore a few options.

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/264

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary><img width="852" alt="image" src="https://user-images.githubusercontent.com/100549427/180817529-5ab18ea5-f36b-4663-8002-a43d511be7ab.png"></details>


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
