### PR TITLE
Added initial psql commands on new page

### DIFF
--- a/docs/sql/psql-commands.md
+++ b/docs/sql/psql-commands.md
@@ -10,7 +10,7 @@ RisingWave supports the following psql commands:
 
 |Command|Description|
 |---|-------|
-|\d|List all relations in the current database together with indexes (originally not supported in psql). Note: (materialized) source is currently not supported.|
+|\d|Lists all relations in the current database together with indexes (originally not supported in psql). Sources (including materialized sources) are not yet supported.|
 |\dm|List all materialized views in the current database.|
 |\dt|List all tables in the current database.|
 |\q|Quit psql.|

--- a/docs/sql/psql-commands.md
+++ b/docs/sql/psql-commands.md
@@ -1,0 +1,16 @@
+---
+id: psql-commands
+slug: /psql-commands
+title: Psql commands
+---
+
+## Supported psql commands
+
+RisingWave supports the following psql commands:
+
+|Command|Description|
+|---|-------|
+|\d|List all relations in the current database together with indexes (originally not supported in psql). Note: (materialized) source is currently not supported.|
+|\dm|List all materialized views in the current database.|
+|\dt|List all tables in the current database.|
+|\q|Quit psql.|

--- a/docs/sql/psql-commands.md
+++ b/docs/sql/psql-commands.md
@@ -4,13 +4,11 @@ slug: /psql-commands
 title: Psql commands
 ---
 
-## Supported psql commands
-
 RisingWave supports the following psql commands:
 
 |Command|Description|
 |---|-------|
 |\d|Lists all relations in the current database together with indexes (originally not supported in psql). Sources (including materialized sources) are not yet supported.|
-|\dm|List all materialized views in the current database.|
-|\dt|List all tables in the current database.|
-|\q|Quit psql.|
+|\dm|Lists all materialized views in the current database.|
+|\dt|Lists all tables in the current database.|
+|\q|Quits psql.|

--- a/sidebars.js
+++ b/sidebars.js
@@ -205,6 +205,7 @@ const sidebars = {
         
         ]
         },
+     'sql/psql-commands',
       ],
     },
 


### PR DESCRIPTION
Added initial psql commands on new page.

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Added initial psql commands on a new page.

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/5127

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/293

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [x] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [x] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary><img width="852" alt="image" src="https://user-images.githubusercontent.com/100549427/180817529-5ab18ea5-f36b-4663-8002-a43d511be7ab.png"></details>


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
