### PR TITLE
Renaming source connector parameters

### DIFF
--- a/docs/sql/create-source/create-source-cdc.md
+++ b/docs/sql/create-source/create-source-cdc.md
@@ -25,7 +25,7 @@ WITH (
    connector='kafka',
    field_name='value', ...
 ) 
-ROW FORMAT DEBEZIUM JSON;
+ROW FORMAT DEBEZIUM_JSON;
 ```
 
 ### `WITH` options
@@ -33,11 +33,11 @@ ROW FORMAT DEBEZIUM JSON;
 
 |Field|	Default|	Type|	Description|	Required?|
 |---|---|---|---|---|
-|kafka.topic|None|String|Address of the Kafka topic. One source can only correspond to one topic.|True
-|kafka.brokers	|None	|String	|Address of the Kafka broker. Format: `'ip:port,ip:port'`.	|True|
-|kafka.scan.startup.mode	|earliest	|String	|The Kafka consumer starts consuming data from the commit offset. This includes two values: `'earliest'` and `'latest'`.	|False
-|kafka.time.offset	|None	|Int64	|Specify the offset in seconds from a certain point of time.	|False|
-|kafka.consumer.group	|None	|String	|Name of the Kafka consumer group	|True|
+|topic|None|String|Address of the Kafka topic. One source can only correspond to one topic.|True
+|properties.bootstrap.server	|None	|String	|Address of the Kafka broker. Format: `'ip:port,ip:port'`.	|True|
+|scan.startup.mode	|earliest	|String	|The Kafka consumer starts consuming data from the commit offset. This includes two values: `'earliest'` and `'latest'`.	|False
+|scan.startup.timestamp_millis	|None	|Int64	|Specify the offset in seconds from a certain point of time.	|False|
+|consumer.group.id	|None	|String	|Name of the Kafka consumer group	|True|
 
 
 ## Example
@@ -51,10 +51,10 @@ CREATE MATERIALIZED SOURCE [IF NOT EXISTS] source_name (
 ) 
 WITH (
    connector='kafka',
-   kafka.topic='user_test_topic',
-   kafka.brokers='172.10.1.1:9090,172.10.1.2:9090',
-   kafka.scan.startup.mode='earliest',
-   kafka.consumer.group='demo_consumer_name'
+   topic='user_test_topic',
+   properties.bootstrap.server='172.10.1.1:9090,172.10.1.2:9090',
+   scan.startup.mode='earliest',
+   consumer.group.id='demo_consumer_name'
 ) 
-ROW FORMAT DEBEZIUM JSON;
+ROW FORMAT DEBEZIUM_JSON;
 ```

--- a/docs/sql/create-source/create-source-cdc.md
+++ b/docs/sql/create-source/create-source-cdc.md
@@ -37,7 +37,7 @@ ROW FORMAT DEBEZIUM_JSON;
 |properties.bootstrap.server	|None	|String	|Address of the Kafka broker. Format: `'ip:port,ip:port'`.	|True|
 |scan.startup.mode	|earliest	|String	|The Kafka consumer starts consuming data from the commit offset. This includes two values: `'earliest'` and `'latest'`.	|False
 |scan.startup.timestamp_millis	|None	|Int64	|Specify the offset in seconds from a certain point of time.	|False|
-|consumer.group.id	|None	|String	|Name of the Kafka consumer group	|True|
+|properties.group.id	|None	|String	|Name of the Kafka consumer group	|True|
 
 
 ## Example
@@ -54,7 +54,7 @@ WITH (
    topic='user_test_topic',
    properties.bootstrap.server='172.10.1.1:9090,172.10.1.2:9090',
    scan.startup.mode='earliest',
-   consumer.group.id='demo_consumer_name'
+   properties.group.id='demo_consumer_name'
 ) 
 ROW FORMAT DEBEZIUM_JSON;
 ```

--- a/docs/sql/create-source/create-source-kafka-redpanda.md
+++ b/docs/sql/create-source/create-source-kafka-redpanda.md
@@ -28,7 +28,8 @@ ROW FORMAT JSON | PROTOBUF MESSAGE 'main_message'
 |properties.bootstrap.server	|None	|String	|Address of the Kafka broker. Format: `'ip:port,ip:port'`.	|True|
 |scan.startup.mode	|earliest	|String	|The Kafka consumer starts consuming data from the commit offset. This includes two values: `'earliest'` and `'latest'`.	|False
 |scan.startup.timestamp_millis	|None	|Int64	|Specify the offset in seconds from a certain point of time.	|False|
-|consumer.group.id	|None	|String	|Name of the Kafka consumer group	|True|
+|properties.group.id	|None	|String	|Name of the Kafka consumer group	|True|
+
 
 ## Example
 
@@ -45,7 +46,7 @@ WITH (
    properties.bootstrap.server='172.10.1.1:9090,172.10.1.2:9090',
    scan.startup.mode='latest',
    scan.startup.timestamp_millis='140000000',
-   consumer.group.id='demo_consumer_name'
+   properties.group.id='demo_consumer_name'
 )
 ROW FORMAT JSON;
 ```

--- a/docs/sql/create-source/create-source-kafka-redpanda.md
+++ b/docs/sql/create-source/create-source-kafka-redpanda.md
@@ -24,11 +24,11 @@ ROW FORMAT JSON | PROTOBUF MESSAGE 'main_message'
 
 |Field|	Default|	Type|	Description|	Required?|
 |---|---|---|---|---|
-|kafka.topic|None|String|Address of the Kafka topic. One source can only correspond to one topic.|True
-|kafka.brokers	|None	|String	|Address of the Kafka broker. Format: `'ip:port,ip:port'`.	|True|
-|kafka.scan.startup.mode	|earliest	|String	|The Kafka consumer starts consuming data from the commit offset. This includes two values: `'earliest'` and `'latest'`.	|False
-|kafka.time.offset	|None	|Int64	|Specify the offset in seconds from a certain point of time.	|False|
-|kafka.consumer.group	|None	|String	|Name of the Kafka consumer group	|True|
+|topic|None|String|Address of the Kafka topic. One source can only correspond to one topic.|True
+|properties.bootstrap.server	|None	|String	|Address of the Kafka broker. Format: `'ip:port,ip:port'`.	|True|
+|scan.startup.mode	|earliest	|String	|The Kafka consumer starts consuming data from the commit offset. This includes two values: `'earliest'` and `'latest'`.	|False
+|scan.startup.timestamp_millis	|None	|Int64	|Specify the offset in seconds from a certain point of time.	|False|
+|consumer.group.id	|None	|String	|Name of the Kafka consumer group	|True|
 
 ## Example
 
@@ -41,11 +41,11 @@ CREATE MATERIALIZED SOURCE IF NOT EXISTS source_abc (
 )
 WITH (
    connector='kafka',
-   kafka.topic='demo_topic',
-   kafka.brokers='172.10.1.1:9090,172.10.1.2:9090',
-   kafka.scan.startup.mode='latest',
-   kafka.time.offset='140000000',
-   kafka.consumer.group='demo_consumer_name'
+   topic='demo_topic',
+   properties.bootstrap.server='172.10.1.1:9090,172.10.1.2:9090',
+   scan.startup.mode='latest',
+   scan.startup.timestamp_millis='140000000',
+   consumer.group.id='demo_consumer_name'
 )
 ROW FORMAT JSON;
 ```

--- a/docs/sql/create-source/create-source-kinesis.md
+++ b/docs/sql/create-source/create-source-kinesis.md
@@ -23,14 +23,14 @@ ROW FORMAT JSON | PROTOBUF MESSAGE 'main_message';
 
 |Field|	Default|	Type|	Description|	Required?|
 |---|---|---|---|---|
-|kinesis.stream.name	|None	|String|	The stream name identifies the stream.	|True|
-|kinesis.stream.region	|None	|String|	AWS service region. For example, US East (N. Virginia).	|True|
-|kinesis.endpoint	|None	|String	|The URL of the entry point for the AWS Kinesis service.| False|
-|kinesis.credentials.access	|None	|String	|Indicates the Access key ID of AWS. Must appear in pairs with kinesis.credentials.secret.	|False|
-|kinesis.credentials.secret	|None	|String	|Indicates the secret access key of AWS. Must appear in pairs with kinesis.credentials.access.	|False|
-|kinesis.credentials.session_token	|None	|String	|The session token associated with the credentials. Temporary Session Credentials.	|False|
-|kinesis.assumerole.arn	|None	|String |The Amazon Resource Name (ARN) of the role to assume.		|False|
-|kinesis.assumerole.external_id	|None	|String	|The [external id](https://aws.amazon.com/blogs/security/how-to-use-external-id-when-granting-access-to-your-aws-resources/) used to authorize access to third-party resources.	|False|
+|stream	|None	|String|	The stream name identifies the stream.	|True|
+|aws.region	|None	|String|	AWS service region. For example, US East (N. Virginia).	|True|
+|endpoint	|None	|String	|The URL of the entry point for the AWS Kinesis service.| False|
+|aws.credentials.access_key_id	|None	|String	|Indicates the Access key ID of AWS. Must appear in pairs with aws.credentials.secret_access_key.	|False|
+|aws.credentials.secret_access_key	|None	|String	|Indicates the secret access key of AWS. Must appear in pairs with aws.credentials.access_key_id.	|False|
+|aws.credentials.session_token	|None	|String	|The session token associated with the credentials. Temporary Session Credentials.	|False|
+|aws.credentials.role.arn	|None	|String |The Amazon Resource Name (ARN) of the role to assume.		|False|
+|aws.credentials.role.external_id	|None	|String	|The [external id](https://aws.amazon.com/blogs/security/how-to-use-external-id-when-granting-access-to-your-aws-resources/) used to authorize access to third-party resources.	|False|
 
 ## Example
 Here is an example of connecting RisingWave to Kinesis Data Streams to read data from individual streams.
@@ -42,12 +42,12 @@ CREATE [MATERIALIZED] SOURCE [IF NOT EXISTS] source_name (
 ) 
 WITH (
    connector='kinesis',
-   kinesis.stream.name='kafka',
-   kinesis.stream.region='user_test_topic',
-   kinesis.endpoint='172.10.1.1:9090,172.10.1.2:9090',
-   kinesis.credentials.session_token='AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/L To6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3z rkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtp Z3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE',
-   kinesis.assumerole.arn='arn:aws-cn:iam::602389639824:role/demo_role',
-   kinesis.assumerole.external_id='demo_external_id'
+   stream='kafka',
+   aws.region='user_test_topic',
+   endpoint='172.10.1.1:9090,172.10.1.2:9090',
+   aws.credentials.session_token='AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/L To6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3z rkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtp Z3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE',
+   aws.credentials.role.arn='arn:aws-cn:iam::602389639824:role/demo_role',
+   aws.credentials.role.external_id='demo_external_id'
 ) 
 ROW FORMAT JSON;
 ```

--- a/docs/sql/create-source/create-source-pulsar.md
+++ b/docs/sql/create-source/create-source-pulsar.md
@@ -24,11 +24,11 @@ ROW FORMAT JSON | PROTOBUF MESSAGE 'main_message';
 
 |Field|	Default|	Type|	Description|	Required?|
 |---|---|---|---|---|
-|pulsar.topic	|None	|String	|Address of the Pulsar topic. One source can only correspond to one topic.	|True|
-|pulsar.service.url	|None	|String	|Address of the Pulsar service	|True|
-|pulsar.admin.url	|None	|String	|Address of the Pulsar admin	|True|
-|pulsar.scan.startup.mode	|earliest	|String	|The Pulsar consumer starts consuming data from the commit offset. This includes two values: `'earliest'` and `'latest'`.	|False|
-|pulsar.time.offset	|None	|Int64	|Specify the offset in seconds from a certain point of time.	|False|
+|topic	|None	|String	|Address of the Pulsar topic. One source can only correspond to one topic.	|True|
+|service.url	|None	|String	|Address of the Pulsar service	|True|
+|admin.url	|None	|String	|Address of the Pulsar admin	|True|
+|scan.startup.mode	|earliest	|String	|The Pulsar consumer starts consuming data from the commit offset. This includes two values: `'earliest'` and `'latest'`.	|False|
+|scan.startup.timestamp_millis	|None	|Int64	|Specify the offset in seconds from a certain point of time.	|False|
 
 ## Example
 Here is an example of connecting RisingWave to a Pulsar broker to read data from individual topics.
@@ -40,11 +40,11 @@ CREATE MATERIALIZED SOURCE IF NOT EXISTS source_abc (
 )
 WITH (
    connector='pulsar',
-   pulsar.topic='demo_topic',
-   pulsar.service.url='pulsar://localhost:6650/',
-   pulsar.admin.url='http://localhost:8080',
-   pulsar.scan.startup.mode='latest',
-   pulsar.time.offset='140000000'
+   topic='demo_topic',
+   service.url='pulsar://localhost:6650/',
+   admin.url='http://localhost:8080',
+   scan.startup.mode='latest',
+   scan.startup.timestamp_millis='140000000'
 )
 ROW FORMAT PROTOBUF MESSAGE 'FooMessage'
 ROW SCHEMA LOCATION 'https://demo_bucket_name.s3-us-west-2.amazonaws.com/demo.proto';

--- a/docs/tutorials/clickstream-analysis.md
+++ b/docs/tutorials/clickstream-analysis.md
@@ -72,9 +72,9 @@ CREATE SOURCE user_behaviors (
     parent_target_id VARCHAR
 ) WITH (
     connector = 'kafka',
-    kafka.topic = 'user_behaviors',
-    kafka.brokers = 'message_queue:29092',
-    kafka.scan.startup.mode = 'earliest'
+    topic = 'user_behaviors',
+    properties.bootstrap.server = 'message_queue:29092',
+    scan.startup.mode = 'earliest'
 ) ROW FORMAT JSON;
 ```
 

--- a/docs/tutorials/fast-twitter-events-processing.md
+++ b/docs/tutorials/fast-twitter-events-processing.md
@@ -93,9 +93,9 @@ CREATE SOURCE twitter (
     followers INT >
 ) WITH (
     connector = 'kafka',
-    kafka.topic = 'twitter',
-    kafka.brokers = 'message_queue:29092',
-    kafka.scan.startup.mode = 'earliest'
+    topic = 'twitter',
+    properties.bootstrap.server = 'message_queue:29092',
+    scan.startup.mode = 'earliest'
 ) ROW FORMAT JSON;
 ```
 

--- a/docs/tutorials/real-time-ad-performance-analysis.md
+++ b/docs/tutorials/real-time-ad-performance-analysis.md
@@ -98,9 +98,9 @@ CREATE SOURCE ad_impression (
     impression_timestamp TIMESTAMP
 ) WITH (
     connector = 'kafka',
-    kafka.topic = 'ad_impression',
-    kafka.brokers = 'message_queue:29092',
-    kafka.scan.startup.mode = 'earliest'
+    topic = 'ad_impression',
+    properties.bootstrap.server = 'message_queue:29092',
+    scan.startup.mode = 'earliest'
 ) ROW FORMAT JSON;
 ```
 
@@ -110,14 +110,14 @@ CREATE SOURCE ad_click (
     click_timestamp TIMESTAMP
 ) WITH (
     connector = 'kafka',
-    kafka.topic = 'ad_click',
-    kafka.brokers = 'message_queue:29092',
-    kafka.scan.startup.mode = 'earliest'
+    topic = 'ad_click',
+    properties.bootstrap.server = 'message_queue:29092',
+    scan.startup.mode = 'earliest'
 ) ROW FORMAT JSON;
 ```
 
 :::tip
-`kafka.scan.startup.mode = 'earliest'` means the source will start streaming from the earliest entry in Kafka. Internally, RisingWave will record the consumed offset in the persistent state so that during a failure recovery, it will resume from the last consumed offset.
+`scan.startup.mode = 'earliest'` means the source will start streaming from the earliest entry in Kafka. Internally, RisingWave will record the consumed offset in the persistent state so that during a failure recovery, it will resume from the last consumed offset.
 :::
 
 Now we have connected RisingWave to the streams, but RisingWave has not started to consume data yet. For data to be processed, we need to define materialized views. After a materialized view is created, RisingWave will start to consume data from the specified offset.

--- a/docs/tutorials/server-performance-anomaly-detection.md
+++ b/docs/tutorials/server-performance-anomaly-detection.md
@@ -79,9 +79,9 @@ CREATE SOURCE nics_metrics (
     metric_value DOUBLE PRECISION
 ) WITH (
     connector = 'kafka',
-    kafka.topic = 'nics_metrics',
-    kafka.brokers = 'message_queue:29092',
-    kafka.scan.startup.mode = 'earliest'
+    topic = 'nics_metrics',
+    properties.bootstrap.server = 'message_queue:29092',
+    scan.startup.mode = 'earliest'
 ) ROW FORMAT JSON;
 ```
 
@@ -93,9 +93,9 @@ CREATE SOURCE tcp_metrics (
     metric_value DOUBLE PRECISION
 ) WITH (
     connector = 'kafka',
-    kafka.topic = 'tcp_metrics',
-    kafka.brokers = 'message_queue:29092',
-    kafka.scan.startup.mode = 'earliest'
+    topic = 'tcp_metrics',
+    properties.bootstrap.server = 'message_queue:29092',
+    scan.startup.mode = 'earliest'
 ) ROW FORMAT JSON;
 ```
 


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Updating the source connector properties in CREATE SOURCE and the tutorials.

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/4503

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/258
Resolves #309 

- **Notes**: 
Connector property names in CREATE SINK are not changed.
To-do:
Update the tutorials (blogs) on the official website. For example https://www.risingwave-labs.com/blog/tutorial-pulsar-risingwave-for-fast-twitter-events-processing/:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/100549427/194977128-bd855b84-cbf0-496f-b69c-2c099eaa18fa.png">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/100549427/194977150-df05c21b-f272-483c-abdc-b5153118cb6a.png">


<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary><img width="852" alt="image" src="https://user-images.githubusercontent.com/100549427/180817529-5ab18ea5-f36b-4663-8002-a43d511be7ab.png"></details>


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
