### PR TITLE
updated image and file versions and a small fix

### DIFF
--- a/docs/install-run-connect.md
+++ b/docs/install-run-connect.md
@@ -16,19 +16,14 @@ You can install and run RisingWave in one of these ways:
 1. Download the pre-built library.
 
     ```shell
-    wget https://github.com/risingwavelabs/risingwave/releases/download/v0.1.11/risingwave-v0.1.11-x86_64-unknown-linux.tar.gz
+    wget https://github.com/risingwavelabs/risingwave/releases/download/v0.1.13/risingwave-v0.1.13-x86_64-unknown-linux.tar.gz
     ```
         
-    :::note
-
-    The pre-built library is not available for the latest release (v0.1.12).
-
-    :::
 
 2. Unzip the library.
 
     ```shell
-    tar xvf risingwave-v0.1.11-x86_64-unknown-linux.tar.gz
+    tar xvf risingwave-v0.1.13-x86_64-unknown-linux.tar.gz
     ```
   
 3. Run RisingWave.
@@ -51,7 +46,7 @@ You can install and run RisingWave in one of these ways:
   Start RisingWave in single-binary playground mode:
     
 ```shell
-docker run -it --pull=always -p 4566:4566 -p 5691:5691 ghcr.io/risingwavelabs/risingwave:v0.1.12 playground
+docker run -it --pull=always -p 4566:4566 -p 5691:5691 ghcr.io/risingwavelabs/risingwave:v0.1.13 playground
 ```
     
 </details>

--- a/docs/sql/create-source/create-source-cdc.md
+++ b/docs/sql/create-source/create-source-cdc.md
@@ -25,7 +25,7 @@ WITH (
    connector='kafka',
    field_name='value', ...
 ) 
-ROW FORMAT DEBEZIUM JSON;
+ROW FORMAT DEBEZIUM_JSON;
 ```
 
 ### `WITH` options


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Update the versions from 0.1.12 (and 0.1.11) to 0.1.13, removed a note about prebuilt library being not available for 0.1.12, and small fix for CDC debezium_json format.

- **Related code PR**: 
[ Provide the link to the code PR here. For example, https://github.com/risingwavelabs/risingwave/pull/4085. Delete this part if there's no code PR related. ]

- **Related doc issue**: 
Resolves [ Provide the link to the doc issue here. ]

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary><img width="852" alt="image" src="https://user-images.githubusercontent.com/100549427/180817529-5ab18ea5-f36b-4663-8002-a43d511be7ab.png"></details>


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
