### PR TITLE
fix: twitter link

### DIFF
--- a/src/components/LinkGroup/index.js
+++ b/src/components/LinkGroup/index.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import styles from "./index.module.css";
-import { Stack, Collapse } from "@mui/material";
+import Collapse from "@mui/material/Collapse";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import styled from "@emotion/styled";
 
@@ -93,7 +93,7 @@ export default function LinkGroup(props) {
           imgUrl={useBaseUrl("/img/home/github.png")}
         />
         <LinkItem
-          link="https://twitter.com/SingularityData"
+          link="https://twitter.com/risingwavelabs"
           focusing={twitterFocus}
           setFocus={setTwitterFocus}
           label="Follow us on Twitter"


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
change twitter link to RisingWave Labs instead of Singularity Data

- **Related code PR**: 
/

- **Related doc issue**: 
Fix #310 

- **Notes**: 
/

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary><img width="852" alt="image" src="https://user-images.githubusercontent.com/100549427/180817529-5ab18ea5-f36b-4663-8002-a43d511be7ab.png"></details>


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
