### PR TITLE
Adding the deployment doc for RisingWave in k8s

### DIFF
--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -35,13 +35,13 @@ The Operator is a deployment and management system for RisingWave. It runs on to
 
 1. Create a cluster by running the following command.
 
-    ```
+    ```shell
     kind create cluster
     ```
 
 1. ***(Optional)*** Check if the cluster is created properly by running the following command.
 
-    ```
+    ```shell
     kubectl cluster-info
     ```
 
@@ -59,13 +59,14 @@ Before the deployment, ensure that the following requirements are satisfied.
 1. [Install cert-manager](https://cert-manager.io/docs/installation/).
 
 1. Install the Operator by running the following command.
-    ```
+
+    ```shell
     kubectl apply -f https://github.com/risingwavelabs/risingwave-operator/releases/latest/download/risingwave-operator.yaml
     ```
 
 1. ***(Optional)*** Check if the Pods are running by running the following commands.
 
-    ```
+    ```shell
     kubectl -n cert-manager get pods
     kubectl -n risingwave-operator-system get pods
     ```
@@ -78,13 +79,13 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs groupId="storage_selection">
-<TabItem value="minio" label="etcd+MinIO" default>
+<TabItem value="minio" label="etcd+MinIO">
 
 RisingWave supports using MinIO as the object storage.
 
 Run the following command to deploy a RisingWave instance with MinIO as the object storage.
 
-```
+```shell
 kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/examples/risingwave/risingwave-etcd-minio.yaml
 ```
 
@@ -97,7 +98,7 @@ RisingWave supports using Amazon S3 as the object storage.
 
 1. Create a Secret with the name ‘s3-credentials’ by running the following command.
 
-    ```
+    ```shell
     kubectl create secret generic s3-credentials —from-literal AccessKeyID=${ACCESS_KEY} —from-literal SecretAccessKey=${SECRET_ACCESS_KEY} —from-literal Region=${AWS_REGION}
     ```
 
@@ -105,7 +106,7 @@ RisingWave supports using Amazon S3 as the object storage.
 
 1. Deploy a RisingWave instance with S3 as the object storage by running the following command.
 
-    ```
+    ```shell
     kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/examples/risingwave/risingwave-etcd-s3.yaml
     ```
 
@@ -116,24 +117,28 @@ RisingWave supports using Amazon S3 as the object storage.
 
 You can check the status of the RisingWave instance by running the following command.
 
-```
+```shell
 kubectl get risingwave
 ```
 
 If the instance is running properly, the output should look like this:
 
 <Tabs groupId="storage_selection">
-<TabItem value="minio" label="etcd+MinIO" default>
-    ```
-    NAME                    RUNNING   STORAGE(META)   STORAGE(OBJECT)   AGE
-    risingwave-etcd-minio   True      etcd            MinIO             30s
-    ```
+<TabItem value="minio" label="etcd+MinIO">
+
+```
+NAME                    RUNNING   STORAGE(META)   STORAGE(OBJECT)   AGE
+risingwave-etcd-minio   True      etcd            MinIO             30s
+```
+
 </TabItem>
 <TabItem value="s3" label="etcd+S3">
-    ```
-    NAME                    RUNNING   STORAGE(META)   STORAGE(OBJECT)   AGE
-    risingwave-etcd-s3      True      etcd            S3                30s
-    ```
+
+```
+NAME                    RUNNING   STORAGE(META)   STORAGE(OBJECT)   AGE
+risingwave-etcd-s3      True      etcd            S3                30s
+```
+
 </TabItem>
 </Tabs>
 
@@ -141,7 +146,7 @@ If the instance is running properly, the output should look like this:
 ## Connect to RisingWave
 
 <Tabs>
-<TabItem value="clusterip" label="ClusterIP" default>
+<TabItem value="clusterip" label="ClusterIP">
 
 By default, the Operator creates a service for the frontend component, through which you can interact with RisingWave, with the type of `ClusterIP`. But it is not accessible outside Kubernetes. Therefore, you need to create a standalone Pod for PostgreSQL inside Kubernetes.
 
@@ -149,30 +154,30 @@ By default, the Operator creates a service for the frontend component, through w
 
 1. Create a Pod by running the following command.
 
-    ```
+    ```shell
     kubectl apply -f examples/psql/psql-console.yaml
     ```
 
 1. Attach to the Pod by running the following command so that you can execute commands inside the container.
 
-    ```
+    ```shell
     kubectl exec -it psql-console bash
     ```
 
 1. Connect to RisingWave via psql by running the following command.
     <Tabs groupId="storage_selection">
-    <TabItem value="minio" label="etcd+MinIO" default>
+    <TabItem value="minio" label="etcd+MinIO">
 
-        ```
-        psql -h risingwave-etcd-minio-frontend -p 4567 -d dev -U root
-        ```
+    ```shell
+    psql -h risingwave-etcd-minio-frontend -p 4567 -d dev -U root
+    ```
 
     </TabItem>
     <TabItem value="s3" label="etcd+S3">
 
-        ```
-        psql -h risingwave-etcd-s3-frontend -p 4567 -d dev -U root
-        ```
+    ```shell
+    psql -h risingwave-etcd-s3-frontend -p 4567 -d dev -U root
+    ```
 
     </TabItem>
     </Tabs>
@@ -197,28 +202,28 @@ You can connect to RisingWave from Nodes such as EC2 in Kubernetes
 
 1. Connect to RisingWave by running the following commands on the Node.
     <Tabs groupId="storage_selection">
-    <TabItem value="minio" label="etcd+MinIO" default>
+    <TabItem value="minio" label="etcd+MinIO">
 
-        ```
-        export RISINGWAVE_NAME=risingwave-etcd-minio
-        export RISINGWAVE_NAMESPACE=default
-        export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get node -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'`
-        export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].nodePort}'`
+    ```shell
+    export RISINGWAVE_NAME=risingwave-etcd-minio
+    export RISINGWAVE_NAMESPACE=default
+    export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get node -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'`
+    export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].nodePort}'`
 
-        psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
-        ```
+    psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
+    ```
 
     </TabItem>
     <TabItem value="s3" label="etcd+S3">
 
-        ```
-        export RISINGWAVE_NAME=risingwave-etcd-s3
-        export RISINGWAVE_NAMESPACE=default
-        export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get node -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'`
-        export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].nodePort}'`
+    ```shell
+    export RISINGWAVE_NAME=risingwave-etcd-s3
+    export RISINGWAVE_NAMESPACE=default
+    export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get node -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'`
+    export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].nodePort}'`
 
-        psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
-        ```
+    psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
+    ```
 
     </TabItem>
     </Tabs>
@@ -242,34 +247,32 @@ If you are using EKS, GCP, or other managed Kubernetes services provided by clou
     ```
 
 1. Connect to RisingWave with the following commands.
-    <div style={{marginLeft:"2rem"}}>
     <Tabs groupId="storage_selection">
-    <TabItem value="minio" label="etcd+MinIO" default>
+    <TabItem value="minio">
 
-        ```
-        export RISINGWAVE_NAME=risingwave-etcd-minio
-        export RISINGWAVE_NAMESPACE=default
-        export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}'`
-        export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].port}'`
+    ```shell
+    export RISINGWAVE_NAME=risingwave-etcd-minio
+    export RISINGWAVE_NAMESPACE=default
+    export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}'`
+    export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].port}'`
 
-        psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
-        ```
+    psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
+    ```
 
     </TabItem>
-    <TabItem value="s3" label="etcd+S3">
+    <TabItem value="s3">
 
-        ```
-        export RISINGWAVE_NAME=risingwave-etcd-s3
-        export RISINGWAVE_NAMESPACE=default
-        export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}'`
-        export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].port}'`
+    ```shell
+    export RISINGWAVE_NAME=risingwave-etcd-s3
+    export RISINGWAVE_NAMESPACE=default
+    export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}'`
+    export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].port}'`
 
-        psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
-        ```
+    psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
+    ```
 
     </TabItem>
     </Tabs>
-    </div>
 
 </TabItem>
 </Tabs>

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -11,38 +11,27 @@ The Operator is a deployment and management system for RisingWave. It runs on to
 
 ## Prerequisites
 
-* Install kubectl
+* **[Install kubectl](http://pwittrock.github.io/docs/tasks/tools/install-kubectl/)**
+
+    Ensure that the Kubernetes command-line tool [kubectl](https://kubernetes.io/docs/reference/kubectl/) is installed in your environment.
+
+* **[Install psql](https://www.postgresql.org/download/)**
+
+    Ensure that the PostgreSQL interactive terminal [psql](https://www.postgresql.org/docs/current/app-psql.html) is installed in your environment.
+
+* **[Install and run Docker Desktop](https://docs.docker.com/get-docker/)**
     
-    kubectl is a Kubernetes command-line tool for deploying and managing applications on Kubernetes.
-
-    Ensure that kubectl is installed in your environment. See [Install and Set Up kubectl](http://pwittrock.github.io/docs/tasks/tools/install-kubectl/) for instructions.
-
-* Install psql
-
-    Ensure that the PostgreSQL interactive terminal [psql](https://www.postgresql.org/docs/current/app-psql.html) is installed in your environment. See [PostgreSQL Downloads](https://www.postgresql.org/download/) for instructions.
-
-* Install and run Docker Desktop
-    
-    Ensure that [Docker Desktop](https://www.docker.com/products/docker-desktop/) is installed in your environment and running. See [Get Docker](https://docs.docker.com/get-docker/) for instructions.
+    Ensure that [Docker Desktop](https://www.docker.com/products/docker-desktop/) is installed in your environment and running.
 
 
 
 ## Create a Kubernetes cluster
 
-Before deployment, ensure that the following requirements are satisfied.
+**Steps:**
 
-* [Docker](https://docs.docker.com/install/) version ≥ 18.09
-* [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version ≥ 1.12
-* [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) version ≥ 0.8.0
-* For Linux, set the value of the sysctl parameter [net.ipv4.ip_forward](https://linuxconfig.org/how-to-turn-on-off-ip-forwarding-in-linux) to 1.
+1. [Install kind](https://kind.sigs.k8s.io/docs/user/quick-start#installation).
 
-Follow the steps to create a Kubernetes cluster.
-
-1. Install kind.
-
-    [kind](https://kind.sigs.k8s.io/) is a tool for running local Kubernetes clusters using Docker containers as cluster nodes. 
-
-    See [kind Installation](https://kind.sigs.k8s.io/docs/user/quick-start#installation) for instructions. You can see the available tags of kind on [Docker Hub](https://hub.docker.com/r/kindest/node/tags).
+    [kind](https://kind.sigs.k8s.io/) is a tool for running local Kubernetes clusters using Docker containers as cluster nodes. You can see the available tags of kind on [Docker Hub](https://hub.docker.com/r/kindest/node/tags).
 
 1. Create a cluster by running the following command.
 
@@ -50,7 +39,7 @@ Follow the steps to create a Kubernetes cluster.
     kind create cluster
     ```
 
-1. ***(Optional)*** Check if the cluster is created successfully by running the following command.
+1. ***(Optional)*** Check if the cluster is created properly by running the following command.
 
     ```
     kubectl cluster-info
@@ -58,7 +47,16 @@ Follow the steps to create a Kubernetes cluster.
 
 ## Deploy the Operator
 
-1. Install [cert-manager](https://cert-manager.io/docs/installation/).
+Before the deployment, ensure that the following requirements are satisfied.
+
+* Docker version ≥ 18.09
+* kubectl version ≥ 1.12
+* kind version ≥ 0.8.0
+* For Linux, set the value of the sysctl parameter [net.ipv4.ip_forward](https://linuxconfig.org/how-to-turn-on-off-ip-forwarding-in-linux) to 1.
+
+**Steps:**
+
+1. [Install cert-manager](https://cert-manager.io/docs/installation/).
 
 1. Install the Operator by running the following command.
     ```
@@ -74,6 +72,8 @@ Follow the steps to create a Kubernetes cluster.
 
 ## Deploy a RisingWave instance
 
+Select an object storage service for data persistence.
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -82,7 +82,7 @@ import TabItem from '@theme/TabItem';
 
 RisingWave supports using MinIO as the object storage.
 
-Deploy a RisingWave instance with MinIO as the object storage by running the following command.
+Run the following command to deploy a RisingWave instance with MinIO as the object storage.
 
 ```
 kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/examples/risingwave/risingwave-etcd-minio.yaml
@@ -92,6 +92,8 @@ kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-ope
 <TabItem value="s3" label="etcd+S3" default>
 
 RisingWave supports using Amazon S3 as the object storage.
+
+**Steps:**
 
 1. Create a Secret with the name ‘s3-credentials’ by running the following command.
 
@@ -110,6 +112,7 @@ RisingWave supports using Amazon S3 as the object storage.
 </TabItem>
 </Tabs>
 
+<br />
 
 You can check the status of the RisingWave instance by running the following command.
 
@@ -146,6 +149,8 @@ risingwave-etcd-s3      True      etcd            S3                30s
 
 By default, the Operator creates a service for the frontend component, through which you can interact with RisingWave, with the type of `ClusterIP`. But it is not accessible outside Kubernetes. Therefore, you need to create a standalone Pod for PostgreSQL inside Kubernetes.
 
+**Steps:**
+
 1. Create a Pod by running the following command.
 
     ```
@@ -159,15 +164,30 @@ By default, the Operator creates a service for the frontend component, through w
     ```
 
 1. Connect to RisingWave via psql by running the following command.
+<Tabs groupId="storage_selection">
+<TabItem value="minio" label="etcd+MinIO" default>
 
     ```
-    psql -h risingwave-etcd-s3/minio-frontend -p 4567 -d dev -U root
+    psql -h risingwave-etcd-minio-frontend -p 4567 -d dev -U root
     ```
+
+</TabItem>
+<TabItem value="s3" label="etcd+S3" default>
+
+    ```
+    psql -h risingwave-etcd-s3-frontend -p 4567 -d dev -U root
+    ```
+
+</TabItem>
+</Tabs>
+
 
 </TabItem>
 <TabItem value="nodeport" label="NodePort" default>
 
 You can connect to RisingWave from Nodes such as EC2 in Kubernetes
+
+**Steps:**
 
 1. Set the Service type to `NodePort`.
 
@@ -180,9 +200,11 @@ You can connect to RisingWave from Nodes such as EC2 in Kubernetes
     ```
 
 1. Connect to RisingWave by running the following commands on the Node.
+<Tabs groupId="storage_selection">
+<TabItem value="minio" label="etcd+MinIO" default>
 
     ```
-    export RISINGWAVE_NAME=risingwave-etcd-s3/minio
+    export RISINGWAVE_NAME=risingwave-etcd-minio
     export RISINGWAVE_NAMESPACE=default
     export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get node -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'`
     export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].nodePort}'`
@@ -191,9 +213,27 @@ You can connect to RisingWave from Nodes such as EC2 in Kubernetes
     ```
 
 </TabItem>
+<TabItem value="s3" label="etcd+S3" default>
+
+    ```
+    export RISINGWAVE_NAME=risingwave-etcd-s3
+    export RISINGWAVE_NAMESPACE=default
+    export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get node -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'`
+    export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].nodePort}'`
+
+    psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
+    ```
+
+</TabItem>
+</Tabs>
+
+
+</TabItem>
 <TabItem value="loadbalancer" label="LoadBalancer" default>
 
 If you are using EKS, GCP, or other managed Kubernetes services provided by cloud vendors, you can expose the Service to the public network with a load balancer in the cloud. 
+
+**Steps:**
 
 1. Set the Service type to `LoadBalancer`.
 
@@ -206,9 +246,11 @@ If you are using EKS, GCP, or other managed Kubernetes services provided by clou
     ```
 
 1. Connect to RisingWave with the following commands.
+<Tabs groupId="storage_selection">
+<TabItem value="minio" label="etcd+MinIO" default>
 
     ```
-    export RISINGWAVE_NAME=risingwave-etcd-s3/minio
+    export RISINGWAVE_NAME=risingwave-etcd-minio
     export RISINGWAVE_NAMESPACE=default
     export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}'`
     export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].port}'`
@@ -216,11 +258,28 @@ If you are using EKS, GCP, or other managed Kubernetes services provided by clou
     psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
     ```
 
+</TabItem>
+<TabItem value="s3" label="etcd+S3" default>
+
+    ```
+    export RISINGWAVE_NAME=risingwave-etcd-s3
+    export RISINGWAVE_NAMESPACE=default
+    export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}'`
+    export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].port}'`
+
+    psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
+    ```
 
 </TabItem>
 </Tabs>
 
-    
+
+
+</TabItem>
+</Tabs>
+
+<br />
+
 You can now [connect a streaming source to RisingWave](sql/commands/sql-create-source.md) and [issue SQL queries to manage your data](query-manage-data.md).
 
 

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -248,7 +248,7 @@ If you are using EKS, GCP, or other managed Kubernetes services provided by clou
 
 1. Connect to RisingWave with the following commands.
     <Tabs groupId="storage_selection">
-    <TabItem value="minio">
+    <TabItem value="minio" label="etcd+MinIO">
 
     ```shell
     export RISINGWAVE_NAME=risingwave-etcd-minio
@@ -260,7 +260,7 @@ If you are using EKS, GCP, or other managed Kubernetes services provided by clou
     ```
 
     </TabItem>
-    <TabItem value="s3">
+    <TabItem value="s3" label="etcd+S3">
 
     ```shell
     export RISINGWAVE_NAME=risingwave-etcd-s3

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -124,20 +124,16 @@ If the instance is running properly, the output should look like this:
 
 <Tabs groupId="storage_selection">
 <TabItem value="minio" label="etcd+MinIO" default>
-
-```
-NAME                    RUNNING   STORAGE(META)   STORAGE(OBJECT)   AGE
-risingwave-etcd-minio   True      etcd            MinIO             30s
-```
-
+    ```
+    NAME                    RUNNING   STORAGE(META)   STORAGE(OBJECT)   AGE
+    risingwave-etcd-minio   True      etcd            MinIO             30s
+    ```
 </TabItem>
 <TabItem value="s3" label="etcd+S3">
-
-```
-NAME                    RUNNING   STORAGE(META)   STORAGE(OBJECT)   AGE
-risingwave-etcd-s3      True      etcd            S3                30s
-```
-
+    ```
+    NAME                    RUNNING   STORAGE(META)   STORAGE(OBJECT)   AGE
+    risingwave-etcd-s3      True      etcd            S3                30s
+    ```
 </TabItem>
 </Tabs>
 
@@ -172,7 +168,7 @@ By default, the Operator creates a service for the frontend component, through w
     ```
 
 </TabItem>
-<TabItem value="s3" label="etcd+S3" >
+<TabItem value="s3" label="etcd+S3">
 
     ```
     psql -h risingwave-etcd-s3-frontend -p 4567 -d dev -U root

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -1,0 +1,226 @@
+---
+id: deploy-kubernetes
+title: Deploy a RisingWave cluster in Kubernetes
+description: Deploy a RisingWave cluster in Kubernetes with the Kubernetes Operator for RisingWave.
+slug: /deploy-kubernetes
+---
+
+You can use the [Kubernetes Operator for RisingWave](https://github.com/risingwavelabs/risingwave-operator) (hereinafter ‘the Operator’) to deploy a RisingWave cluster in Kubernetes.
+
+The Operator is a deployment and management system for RisingWave. It runs on top of Kubernetes and provides functionalities like provisioning, upgrading, scaling, and destroying the RisingWave instances inside the cluster. 
+
+## Prerequisites
+
+* Install kubectl
+    
+    kubectl is a Kubernetes command-line tool for deploying and managing applications on Kubernetes.
+
+    Ensure that kubectl is installed in your environment. See [Install and Set Up kubectl](http://pwittrock.github.io/docs/tasks/tools/install-kubectl/) for instructions.
+
+* Install psql
+
+    Ensure that the PostgreSQL interactive terminal [psql](https://www.postgresql.org/docs/current/app-psql.html) is installed in your environment. See [PostgreSQL Downloads](https://www.postgresql.org/download/) for instructions.
+
+* Install and run Docker Desktop
+    
+    Ensure that [Docker Desktop](https://www.docker.com/products/docker-desktop/) is installed in your environment and running. See [Get Docker](https://docs.docker.com/get-docker/) for instructions.
+
+
+
+## Create a Kubernetes cluster
+
+Before deployment, ensure that the following requirements are satisfied.
+
+* [Docker](https://docs.docker.com/install/) version ≥ 18.09
+* [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version ≥ 1.12
+* [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) version ≥ 0.8.0
+* For Linux, set the value of the sysctl parameter [net.ipv4.ip_forward](https://linuxconfig.org/how-to-turn-on-off-ip-forwarding-in-linux) to 1.
+
+Follow the steps to create a Kubernetes cluster.
+
+1. Install kind.
+
+    [kind](https://kind.sigs.k8s.io/) is a tool for running local Kubernetes clusters using Docker containers as cluster nodes. 
+
+    See [kind Installation](https://kind.sigs.k8s.io/docs/user/quick-start#installation) for instructions. You can see the available tags of kind on [Docker Hub](https://hub.docker.com/r/kindest/node/tags).
+
+1. Create a cluster by running the following command.
+
+    ```
+    kind create cluster
+    ```
+
+1. ***(Optional)*** Check if the cluster is created successfully by running the following command.
+
+    ```
+    kubectl cluster-info
+    ```
+
+## Deploy the Operator
+
+1. Install [cert-manager](https://cert-manager.io/docs/installation/).
+
+1. Install the Operator by running the following command.
+    ```
+    kubectl apply -f https://github.com/risingwavelabs/risingwave-operator/releases/latest/download/risingwave-operator.yaml
+    ```
+
+1. ***(Optional)*** Check if the Pods are running by running the following commands.
+
+    ```
+    kubectl -n cert-manager get pods
+    kubectl -n risingwave-operator-system get pods
+    ```
+
+## Deploy a RisingWave instance
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs groupId="storage_selection">
+<TabItem value="minio" label="etcd+MinIO" default>
+
+RisingWave supports using MinIO as the object storage.
+
+Deploy a RisingWave instance with MinIO as the object storage by running the following command.
+
+```
+kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/examples/risingwave/risingwave-etcd-minio.yaml
+```
+
+</TabItem>
+<TabItem value="s3" label="etcd+S3" default>
+
+RisingWave supports using Amazon S3 as the object storage.
+
+1. Create a Secret with the name ‘s3-credentials’ by running the following command.
+
+    ```
+    kubectl create secret generic s3-credentials —from-literal AccessKeyID=${ACCESS_KEY} —from-literal SecretAccessKey=${SECRET_ACCESS_KEY} —from-literal Region=${AWS_REGION}
+    ```
+
+1. On the S3 console, [create a bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html) with the name ‘hummock001’.
+
+1. Deploy a RisingWave instance with S3 as the object storage by running the following command.
+
+    ```
+    kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/examples/risingwave/risingwave-etcd-s3.yaml
+    ```
+
+</TabItem>
+</Tabs>
+
+
+You can check the status of the RisingWave instance by running the following command.
+
+```
+kubectl get risingwave
+```
+
+If the instance is running properly, the output should look like this:
+
+<Tabs groupId="storage_selection">
+<TabItem value="minio" label="etcd+MinIO" default>
+
+```
+NAME                    RUNNING   STORAGE(META)   STORAGE(OBJECT)   AGE
+risingwave-etcd-minio   True      etcd            MinIO             30s
+```
+
+</TabItem>
+<TabItem value="s3" label="etcd+S3" default>
+
+```
+NAME                    RUNNING   STORAGE(META)   STORAGE(OBJECT)   AGE
+risingwave-etcd-s3      True      etcd            S3                30s
+```
+
+</TabItem>
+</Tabs>
+
+
+## Connect to RisingWave
+
+<Tabs>
+<TabItem value="clusterip" label="ClusterIP" default>
+
+By default, the Operator creates a service for the frontend component, through which you can interact with RisingWave, with the type of `ClusterIP`. But it is not accessible outside Kubernetes. Therefore, you need to create a standalone Pod for PostgreSQL inside Kubernetes.
+
+1. Create a Pod by running the following command.
+
+    ```
+    kubectl apply -f examples/psql/psql-console.yaml
+    ```
+
+1. Attach to the Pod by running the following command so that you can execute commands inside the container.
+
+    ```
+    kubectl exec -it psql-console bash
+    ```
+
+1. Connect to RisingWave via psql by running the following command.
+
+    ```
+    psql -h risingwave-etcd-s3/minio-frontend -p 4567 -d dev -U root
+    ```
+
+</TabItem>
+<TabItem value="nodeport" label="NodePort" default>
+
+You can connect to RisingWave from Nodes such as EC2 in Kubernetes
+
+1. Set the Service type to `NodePort`.
+
+    ```
+    # ...
+    spec:
+      global:
+        serviceType: NodePort
+    # ...
+    ```
+
+1. Connect to RisingWave by running the following commands on the Node.
+
+    ```
+    export RISINGWAVE_NAME=risingwave-etcd-s3/minio
+    export RISINGWAVE_NAMESPACE=default
+    export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get node -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'`
+    export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].nodePort}'`
+
+    psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
+    ```
+
+</TabItem>
+<TabItem value="loadbalancer" label="LoadBalancer" default>
+
+If you are using EKS, GCP, or other managed Kubernetes services provided by cloud vendors, you can expose the Service to the public network with a load balancer in the cloud. 
+
+1. Set the Service type to `LoadBalancer`.
+
+    ```
+    # ...
+    spec:
+      global:
+        serviceType: LoadBalancer
+    # ...
+    ```
+
+1. Connect to RisingWave with the following commands.
+
+    ```
+    export RISINGWAVE_NAME=risingwave-etcd-s3/minio
+    export RISINGWAVE_NAMESPACE=default
+    export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}'`
+    export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].port}'`
+
+    psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
+    ```
+
+
+</TabItem>
+</Tabs>
+
+    
+You can now [connect a streaming source to RisingWave](sql/commands/sql-create-source.md) and [issue SQL queries to manage your data](query-manage-data.md).
+
+

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -160,22 +160,22 @@ By default, the Operator creates a service for the frontend component, through w
     ```
 
 1. Connect to RisingWave via psql by running the following command.
-<Tabs groupId="storage_selection">
-<TabItem value="minio" label="etcd+MinIO" default>
+    <Tabs groupId="storage_selection">
+    <TabItem value="minio" label="etcd+MinIO" default>
 
-    ```
-    psql -h risingwave-etcd-minio-frontend -p 4567 -d dev -U root
-    ```
+        ```
+        psql -h risingwave-etcd-minio-frontend -p 4567 -d dev -U root
+        ```
 
-</TabItem>
-<TabItem value="s3" label="etcd+S3">
+    </TabItem>
+    <TabItem value="s3" label="etcd+S3">
 
-    ```
-    psql -h risingwave-etcd-s3-frontend -p 4567 -d dev -U root
-    ```
+        ```
+        psql -h risingwave-etcd-s3-frontend -p 4567 -d dev -U root
+        ```
 
-</TabItem>
-</Tabs>
+    </TabItem>
+    </Tabs>
 
 
 </TabItem>
@@ -196,32 +196,32 @@ You can connect to RisingWave from Nodes such as EC2 in Kubernetes
     ```
 
 1. Connect to RisingWave by running the following commands on the Node.
-<Tabs groupId="storage_selection">
-<TabItem value="minio" label="etcd+MinIO" default>
+    <Tabs groupId="storage_selection">
+    <TabItem value="minio" label="etcd+MinIO" default>
 
-    ```
-    export RISINGWAVE_NAME=risingwave-etcd-minio
-    export RISINGWAVE_NAMESPACE=default
-    export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get node -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'`
-    export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].nodePort}'`
+        ```
+        export RISINGWAVE_NAME=risingwave-etcd-minio
+        export RISINGWAVE_NAMESPACE=default
+        export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get node -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'`
+        export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].nodePort}'`
 
-    psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
-    ```
+        psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
+        ```
 
-</TabItem>
-<TabItem value="s3" label="etcd+S3">
+    </TabItem>
+    <TabItem value="s3" label="etcd+S3">
 
-    ```
-    export RISINGWAVE_NAME=risingwave-etcd-s3
-    export RISINGWAVE_NAMESPACE=default
-    export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get node -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'`
-    export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].nodePort}'`
+        ```
+        export RISINGWAVE_NAME=risingwave-etcd-s3
+        export RISINGWAVE_NAMESPACE=default
+        export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get node -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'`
+        export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].nodePort}'`
 
-    psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
-    ```
+        psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
+        ```
 
-</TabItem>
-</Tabs>
+    </TabItem>
+    </Tabs>
 
 
 </TabItem>
@@ -242,34 +242,34 @@ If you are using EKS, GCP, or other managed Kubernetes services provided by clou
     ```
 
 1. Connect to RisingWave with the following commands.
-<Tabs groupId="storage_selection">
-<TabItem value="minio" label="etcd+MinIO" default>
+    <div style={{marginLeft:"2rem"}}>
+    <Tabs groupId="storage_selection">
+    <TabItem value="minio" label="etcd+MinIO" default>
 
-    ```
-    export RISINGWAVE_NAME=risingwave-etcd-minio
-    export RISINGWAVE_NAMESPACE=default
-    export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}'`
-    export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].port}'`
+        ```
+        export RISINGWAVE_NAME=risingwave-etcd-minio
+        export RISINGWAVE_NAMESPACE=default
+        export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}'`
+        export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].port}'`
 
-    psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
-    ```
+        psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
+        ```
 
-</TabItem>
-<TabItem value="s3" label="etcd+S3">
+    </TabItem>
+    <TabItem value="s3" label="etcd+S3">
 
-    ```
-    export RISINGWAVE_NAME=risingwave-etcd-s3
-    export RISINGWAVE_NAMESPACE=default
-    export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}'`
-    export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].port}'`
+        ```
+        export RISINGWAVE_NAME=risingwave-etcd-s3
+        export RISINGWAVE_NAMESPACE=default
+        export RISINGWAVE_HOST=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}'`
+        export RISINGWAVE_PORT=`kubectl -n ${RISINGWAVE_NAMESPACE} get svc -l risingwave/name=${RISINGWAVE_NAME},risingwave/component=frontend -o jsonpath='{.items[0].spec.ports[0].port}'`
 
-    psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
-    ```
+        psql -h ${RISINGWAVE_HOST} -p ${RISINGWAVE_PORT} -d dev -U root
+        ```
 
-</TabItem>
-</Tabs>
-
-
+    </TabItem>
+    </Tabs>
+    </div>
 
 </TabItem>
 </Tabs>

--- a/docs/deploy-kubernetes.md
+++ b/docs/deploy-kubernetes.md
@@ -89,7 +89,7 @@ kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-ope
 ```
 
 </TabItem>
-<TabItem value="s3" label="etcd+S3" default>
+<TabItem value="s3" label="etcd+S3">
 
 RisingWave supports using Amazon S3 as the object storage.
 
@@ -131,7 +131,7 @@ risingwave-etcd-minio   True      etcd            MinIO             30s
 ```
 
 </TabItem>
-<TabItem value="s3" label="etcd+S3" default>
+<TabItem value="s3" label="etcd+S3">
 
 ```
 NAME                    RUNNING   STORAGE(META)   STORAGE(OBJECT)   AGE
@@ -172,7 +172,7 @@ By default, the Operator creates a service for the frontend component, through w
     ```
 
 </TabItem>
-<TabItem value="s3" label="etcd+S3" default>
+<TabItem value="s3" label="etcd+S3" >
 
     ```
     psql -h risingwave-etcd-s3-frontend -p 4567 -d dev -U root
@@ -183,7 +183,7 @@ By default, the Operator creates a service for the frontend component, through w
 
 
 </TabItem>
-<TabItem value="nodeport" label="NodePort" default>
+<TabItem value="nodeport" label="NodePort" >
 
 You can connect to RisingWave from Nodes such as EC2 in Kubernetes
 
@@ -213,7 +213,7 @@ You can connect to RisingWave from Nodes such as EC2 in Kubernetes
     ```
 
 </TabItem>
-<TabItem value="s3" label="etcd+S3" default>
+<TabItem value="s3" label="etcd+S3">
 
     ```
     export RISINGWAVE_NAME=risingwave-etcd-s3
@@ -229,7 +229,7 @@ You can connect to RisingWave from Nodes such as EC2 in Kubernetes
 
 
 </TabItem>
-<TabItem value="loadbalancer" label="LoadBalancer" default>
+<TabItem value="loadbalancer" label="LoadBalancer">
 
 If you are using EKS, GCP, or other managed Kubernetes services provided by cloud vendors, you can expose the Service to the public network with a load balancer in the cloud. 
 
@@ -259,7 +259,7 @@ If you are using EKS, GCP, or other managed Kubernetes services provided by clou
     ```
 
 </TabItem>
-<TabItem value="s3" label="etcd+S3" default>
+<TabItem value="s3" label="etcd+S3">
 
     ```
     export RISINGWAVE_NAME=risingwave-etcd-s3

--- a/docs/sql/commands/sql-create-user.md
+++ b/docs/sql/commands/sql-create-user.md
@@ -26,7 +26,7 @@ CREATE USER user_name
 | <ul><li>SUPERUSER</li><li>NOSUPERUSER</li></ul> | Grants/denies the user superuser permission. A superuser can override all access restrictions. <br/> NOSUPERUSER is the default value. |
 | <ul><li>CREATEDB</li><li>NOCREATEDB</li></ul> | Grants/denies the user the ability to create databases. <br/> NOCREATEDB is the default value. |
 | <ul><li>CREATEUSER</li><li>NOCREATEUSER</li></ul> | Grants/denies the user the ability to create new users and/or alter and drop existing users. <br/> NOCREATEUSER is the default value. |
-| <ul><li>LOGIN</li><li>NOLOGIN</li></ul> | Grants/denies the user the ability to log in when [establishing connection with RisingWave](../Get-Started.md/#connect-to-risingwave). <br/> LOGIN is the default value. |
+| <ul><li>LOGIN</li><li>NOLOGIN</li></ul> | Grants/denies the user the ability to log in when [establishing connection with RisingWave](../install-run-connect.md/#step-2-connect-to-risingwave). <br/> LOGIN is the default value. |
 | <ul><li>[ ENCRYPTED ] PASSWORD ' password '</li><li>PASSWORD NULL</li></ul> | Sets the password for the user account. You need to provide the password for authentication when during login. <br/> If you do not want password authentication for the user, omit the PASSWORD option. <br/> Currently, a null password or empty string password means password authentication is not needed. | <!-- Behavior for a null/empty password might change in the future. Track: https://github.com/risingwavelabs/risingwave/issues/4428 -->
 
 

--- a/docs/sql/commands/sql-create-user.md
+++ b/docs/sql/commands/sql-create-user.md
@@ -26,7 +26,7 @@ CREATE USER user_name
 | <ul><li>SUPERUSER</li><li>NOSUPERUSER</li></ul> | Grants/denies the user superuser permission. A superuser can override all access restrictions. <br/> NOSUPERUSER is the default value. |
 | <ul><li>CREATEDB</li><li>NOCREATEDB</li></ul> | Grants/denies the user the ability to create databases. <br/> NOCREATEDB is the default value. |
 | <ul><li>CREATEUSER</li><li>NOCREATEUSER</li></ul> | Grants/denies the user the ability to create new users and/or alter and drop existing users. <br/> NOCREATEUSER is the default value. |
-| <ul><li>LOGIN</li><li>NOLOGIN</li></ul> | Grants/denies the user the ability to log in when [establishing connection with RisingWave](/docs/install-run-connect.md/#step-2-connect-to-risingwave). <br/> LOGIN is the default value. |
+| <ul><li>LOGIN</li><li>NOLOGIN</li></ul> | Grants/denies the user the ability to log in when [establishing connection with RisingWave](/install-run-connect.md/#step-2-connect-to-risingwave). <br/> LOGIN is the default value. |
 | <ul><li>[ ENCRYPTED ] PASSWORD ' password '</li><li>PASSWORD NULL</li></ul> | Sets the password for the user account. You need to provide the password for authentication when during login. <br/> If you do not want password authentication for the user, omit the PASSWORD option. <br/> Currently, a null password or empty string password means password authentication is not needed. | <!-- Behavior for a null/empty password might change in the future. Track: https://github.com/risingwavelabs/risingwave/issues/4428 -->
 
 

--- a/docs/sql/commands/sql-create-user.md
+++ b/docs/sql/commands/sql-create-user.md
@@ -26,7 +26,7 @@ CREATE USER user_name
 | <ul><li>SUPERUSER</li><li>NOSUPERUSER</li></ul> | Grants/denies the user superuser permission. A superuser can override all access restrictions. <br/> NOSUPERUSER is the default value. |
 | <ul><li>CREATEDB</li><li>NOCREATEDB</li></ul> | Grants/denies the user the ability to create databases. <br/> NOCREATEDB is the default value. |
 | <ul><li>CREATEUSER</li><li>NOCREATEUSER</li></ul> | Grants/denies the user the ability to create new users and/or alter and drop existing users. <br/> NOCREATEUSER is the default value. |
-| <ul><li>LOGIN</li><li>NOLOGIN</li></ul> | Grants/denies the user the ability to log in when [establishing connection with RisingWave](../install-run-connect.md/#step-2-connect-to-risingwave). <br/> LOGIN is the default value. |
+| <ul><li>LOGIN</li><li>NOLOGIN</li></ul> | Grants/denies the user the ability to log in when [establishing connection with RisingWave](/docs/install-run-connect.md/#step-2-connect-to-risingwave). <br/> LOGIN is the default value. |
 | <ul><li>[ ENCRYPTED ] PASSWORD ' password '</li><li>PASSWORD NULL</li></ul> | Sets the password for the user account. You need to provide the password for authentication when during login. <br/> If you do not want password authentication for the user, omit the PASSWORD option. <br/> Currently, a null password or empty string password means password authentication is not needed. | <!-- Behavior for a null/empty password might change in the future. Track: https://github.com/risingwavelabs/risingwave/issues/4428 -->
 
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -51,7 +51,7 @@ const sidebars = {
           link: {type: 'doc', id: 'install-run-connect'},
           label: 'Install, run, and connect to RisingWave',
           collapsible: true,
-          collapsed: false,
+          collapsed: true,
           items: [
             {
               type: 'doc',

--- a/sidebars.js
+++ b/sidebars.js
@@ -47,9 +47,18 @@ const sidebars = {
       collapsed: false,
       items: [
         {
-          type: 'doc',
-          id: 'install-run-connect',
+          type: 'category',
+          link: {type: 'doc', id: 'install-run-connect'},
           label: 'Install, run, and connect to RisingWave',
+          collapsible: true,
+          collapsed: false,
+          items: [
+            {
+              type: 'doc',
+              id: 'deploy-kubernetes',
+              label: 'Deploy in Kubernetes',
+            }
+          ]
         },
         {
           type: 'category', 


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Preview**: 
https://pr-348.d2fbku9n2b6wde.amplifyapp.com/docs/latest/deploy-kubernetes/


<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
