### PR TITLE
Adjusted CREATE TABLE example for consistency

### DIFF
--- a/docs/sql/commands/sql-create-table.md
+++ b/docs/sql/commands/sql-create-table.md
@@ -31,7 +31,7 @@ The statement below creates a table that has three columns.
 CREATE TABLE taxi_trips(
     id VARCHAR,
     distance DOUBLE PRECISION,
-    duration DOUBLE PRECISION
+    city VARCHAR
 ) WITH ('appendonly' = true);
 ```
 

--- a/docs/sql/commands/sql-create-table.md
+++ b/docs/sql/commands/sql-create-table.md
@@ -32,7 +32,7 @@ CREATE TABLE taxi_trips(
     id VARCHAR,
     distance DOUBLE PRECISION,
     city VARCHAR
-) WITH ('appendonly' = true);
+) WITH (appendonly = true);
 ```
 
 The statement below creates a table that includes nested tables.

--- a/docs/sql/commands/sql-create-table.md
+++ b/docs/sql/commands/sql-create-table.md
@@ -10,8 +10,7 @@ Use the `CREATE TABLE` command to create a new table.
 ## Syntax
 
 ```sql
-CREATE TABLE table_name (col_name data_type [, col_name data_type ...])
-    [ WITH ( 'storage_parameter' = value [, ... ] ) ];
+CREATE TABLE table_name (col_name data_type [, col_name data_type ...]);
 ```
 
 ## Parameters
@@ -21,7 +20,6 @@ CREATE TABLE table_name (col_name data_type [, col_name data_type ...])
 |*table_name*    |The name of the table. If a schema name is given (for example, `CREATE TABLE <schema>.<table> ...`), then the table is created in the specified schema. Otherwise it is created in the current schema.|
 |*col_name*      |The name of a column.|
 |*data_type*|The data type of a column. With the `struct` data type, you can create a nested table. Elements in a nested table need to be enclosed with angle brackets ("<\>"). |
-|*storage_parameter*| Set options for the table. Supported options: <ul><li>appendonly<ul><li>`'appendonly' = true` specifies that only INSERT operations on the table are allowed. If you create a materialized view on an append-only table, the corresponding stream query plan will be optimized for the append-only workload.</li></ul></li></ul>|
 
 ## Examples
 
@@ -32,7 +30,7 @@ CREATE TABLE taxi_trips(
     id VARCHAR,
     distance DOUBLE PRECISION,
     city VARCHAR
-) WITH (appendonly = true);
+) WITH;
 ```
 
 The statement below creates a table that includes nested tables.


### PR DESCRIPTION
Adjusted the first example in CREATE TABLE so it's consistent with the first example in INSERT

## Info
- **Description**: 
First example table created now has columns "id, duration, city" to be consistent with first example given under INSERT.

- **Related doc issue**: 
Resolves (https://github.com/risingwavelabs/risingwave-docs/issues/326)

- **Notes**: 
Have not combed through the rest of the examples for consistency but fixed the issue pointed out.

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
