### PR TITLE
Document where the data is stored in the tutorial

### DIFF
--- a/docs/tutorials/clickstream-analysis.md
+++ b/docs/tutorials/clickstream-analysis.md
@@ -49,7 +49,7 @@ For more information, see [Docker Documentation](https://docs.docker.com/compose
 
 :::
 
-Necessary RisingWave components will be started, including the frontend node, compute node, metadata node, and MinIO. The workload generator will start to generate random data and feed them into Kafka topics. In this demo cluster, the data generated will be stored in the MinIO instance.
+Necessary RisingWave components will be started, including the frontend node, compute node, metadata node, and MinIO. The workload generator will start to generate random data and feed them into Kafka topics. In this demo cluster, the data will be stored in the MinIO instance.
 
 Now connect to RisingWave to manage data streams and perform data analysis.
 

--- a/docs/tutorials/clickstream-analysis.md
+++ b/docs/tutorials/clickstream-analysis.md
@@ -49,7 +49,7 @@ For more information, see [Docker Documentation](https://docs.docker.com/compose
 
 :::
 
-Necessary RisingWave components will be started, including the frontend node, compute node, metadata node, and MinIO. The workload generator will start to generate random data and feed them into Kafka topics.
+Necessary RisingWave components will be started, including the frontend node, compute node, metadata node, and MinIO. The workload generator will start to generate random data and feed them into Kafka topics. In this demo cluster, the data generated will be stored in the MinIO instance.
 
 Now connect to RisingWave to manage data streams and perform data analysis.
 
@@ -183,7 +183,7 @@ When you finish, run the following command to disconnect RisingWave.
 \q
 ```
 
-Run the following command to remove the Docker containers and the generated data.
+Optional: Remove the containers and the data generated with the following command.
 
 ```shell
 docker-compose down -v

--- a/docs/tutorials/clickstream-analysis.md
+++ b/docs/tutorials/clickstream-analysis.md
@@ -49,7 +49,7 @@ For more information, see [Docker Documentation](https://docs.docker.com/compose
 
 :::
 
-Necessary RisingWave components will be started, including the frontend node, compute node, metadata node, and MinIO. The workload generator will start to generate random data and feed them into Kafka topics. In this demo cluster, the data will be stored in the MinIO instance.
+Necessary RisingWave components will be started, including the frontend node, compute node, metadata node, and MinIO. The workload generator will start to generate random data and feed them into Kafka topics. In this demo cluster, data of materialized views will be stored in the MinIO instance.
 
 Now connect to RisingWave to manage data streams and perform data analysis.
 
@@ -183,7 +183,7 @@ When you finish, run the following command to disconnect RisingWave.
 \q
 ```
 
-Optional: Remove the containers and the data generated with the following command.
+Optional: To remove the containers and the data generated, use the following command.
 
 ```shell
 docker-compose down -v

--- a/docs/tutorials/fast-twitter-events-processing.md
+++ b/docs/tutorials/fast-twitter-events-processing.md
@@ -47,7 +47,7 @@ For more information, see [Docker Documentation](https://docs.docker.com/compose
 
 :::
 
-Necessary RisingWave components will be started, including the frontend node, compute node, metadata node, and MinIO. The workload generator will start to generate random data and feed them into Kafka topics.
+Necessary RisingWave components will be started, including the frontend node, compute node, metadata node, and MinIO. The workload generator will start to generate random data and feed them into Kafka topics. In this demo cluster, data of materialized views will be stored in the MinIO instance.
 
 Now connect to RisingWave to manage data streams and perform data analysis.
 
@@ -180,7 +180,7 @@ When you finish, run the following command to disconnect RisingWave.
 \q
 ```
 
-Run the following command to remove the Docker containers and the generated data.
+Optional: To remove the containers and the data generated, use the following command.
 
 ```shell
 docker-compose down -v

--- a/docs/tutorials/live-stream-metrics-analysis.md
+++ b/docs/tutorials/live-stream-metrics-analysis.md
@@ -48,7 +48,7 @@ For more information, see [Docker Documentation](https://docs.docker.com/compose
 
 :::
 
-Necessary RisingWave components will be started, including the frontend node, compute node, metadata node, and MinIO. The workload generator will start to generate random data and feed them into Kafka topics.
+Necessary RisingWave components will be started, including the frontend node, compute node, metadata node, and MinIO. The workload generator will start to generate random data and feed them into Kafka topics. In this demo cluster, data of materialized views will be stored in the MinIO instance.
 
 Now connect to RisingWave to manage data streams and perform data analysis.
 
@@ -213,7 +213,7 @@ When you finish, run the following command to disconnect RisingWave.
 \q
 ```
 
-Run the following command to remove the Docker containers and the generated data.
+Optional: To remove the containers and the data generated, use the following command.
 
 ```shell
 docker-compose down -v

--- a/docs/tutorials/real-time-ad-performance-analysis.md
+++ b/docs/tutorials/real-time-ad-performance-analysis.md
@@ -55,7 +55,7 @@ For more information, see [Docker Documentation](https://docs.docker.com/compose
 
 :::
 
-Necessary RisingWave components, including frontend node, compute node, metadata node, and MinIO, will be started. The workload generator will start to generate random data and feed them into Kafka topics.
+Necessary RisingWave components, including frontend node, compute node, metadata node, and MinIO, will be started. The workload generator will start to generate random data and feed them into Kafka topics. In this demo cluster, data of materialized views will be stored in the MinIO instance.
 
 
 ## Step 2: Connect RisingWave to data streams
@@ -252,13 +252,16 @@ SELECT * FROM ad_ctr_5min;
 
 You can rerun the query a couple of minutes later to see if the results are updated.
 
-When you finish, run the following command to remove the Docker containers.
+When you finish, run the following command to disconnect RisingWave.
+```shell
+\q
+```
+
+Optional: To remove the containers and the data generated, use the following command.
 
 ```shell
 docker-compose down
 ```
-
-
 
 ## Summary
 

--- a/docs/tutorials/server-performance-anomaly-detection.md
+++ b/docs/tutorials/server-performance-anomaly-detection.md
@@ -57,7 +57,7 @@ For more information, see [Docker Documentation](https://docs.docker.com/compose
 
 :::
 
-Necessary RisingWave components will be started, including the frontend node, compute node, metadata node, and MinIO. The workload generator will start to generate random data and feed them into Kafka topics.
+Necessary RisingWave components will be started, including the frontend node, compute node, metadata node, and MinIO. The workload generator will start to generate random data and feed them into Kafka topics. In this demo cluster, data of materialized views will be stored in the MinIO instance.
 
 ## Step 2: Connect RisingWave to data streams
 
@@ -249,7 +249,8 @@ When you finish, run the following command to disconnect RisingWave.
 \q
 ```
 
-Run the following command to remove the Docker containers and the generated data.
+Optional: To remove the containers and the data generated, use the following command.
+
 ```shell
 docker-compose down -v
 ```


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Added info on where data is stored and made the final "docker-compose down" step optional. Made these changes to 1 tutorial. Will change the rest of the tutorials after given feedback.

- **Related code PR**: 
[ Provide the link to the code PR here. For example, https://github.com/risingwavelabs/risingwave/pull/4085. Delete this part if there's no code PR related. ]

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/347

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
