### PR TITLE
Support timestamp with time zone for tumble and hop

### DIFF
--- a/docs/sql/functions-operators/sql-function-time-window.md
+++ b/docs/sql/functions-operators/sql-function-time-window.md
@@ -28,6 +28,7 @@ SELECT [ ALL | DISTINCT ] [ * | expression [ AS output_name ] [, expression [ AS
 FROM TUMBLE(table_or_source, start_time, window_size);
 ```
 
+*start_time* can be in either timestamp or timestamp with time zone format. Example of timestamp with time zone format: 2022-01-01 10:00:00+00:00.
 
 *window_size* is in the format of `INTERVAL 'interval'`. Example: `INTERVAL '2 MINUTES'`. The standard SQL format, which places time units outside of quotation marks (for example, `INTERVAL '2' MINUTE`), is also supported.
 
@@ -78,6 +79,8 @@ See below for the syntax of the `hop()` window function.
 SELECT [ ALL | DISTINCT] [ * | expression [ AS output_name ] [, expression [ AS output_name ]...] ]
 FROM HOP(table_or_source, start_time, hop_size, window_size);
 ```
+
+*start_time* can be in either timestamp or timestamp with time zone format. Example of timestamp with time zone format: 2022-01-01 10:00:00+00:00.
 
 Both *hop_size* and *window_size* are in the format of `INTERVAL '<interval>'`. For example: `INTERVAL '2 MINUTES'`. The standard SQL format, which places time units outside of quotation marks (for example, `INTERVAL '2' MINUTE`), is also supported.
 


### PR DESCRIPTION
Support timestamp with time zone for tumble and hop.

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Support timestamp with time zone for tumble and hop

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/5855

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/337

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
