### PR TITLE
Add At Time Zone operator

### DIFF
--- a/docs/sql/functions-operators/sql-function-datetime.md
+++ b/docs/sql/functions-operators/sql-function-datetime.md
@@ -40,7 +40,7 @@ title: Date and time functions and operators
 
 | Operation | Description | Example |
 | ----------- | ----------- | ----------- |
-| *timestamp_value* AT TIME ZONE *zone* → *timestamptz_value* | Converts times between timestamp and timestamptz. Invalid local time during daylight saving forward is not supported. Ambiguous local time during daylight saving backward is interpreted as after the transition. | `'2021-12-31 16:00:00'::timestamp AT TIME ZONE 'us/pacific'` → `2022-01-01 00:00:00+00:00` |
+| *timestamp_value* AT TIME ZONE *zone* → *timestamptz_value* <br /><br /> *timestamptz_value* AT TIME ZONE *zone* → *timestamp_value* | Converts times from timestamp to timestamptz (i.e., timestamp with time zone) or timestamptz to timestamp. Invalid local time during daylight saving forward is not supported. Ambiguous local time during daylight saving backward is interpreted as after the transition. | `'2021-12-31 16:00:00'::timestamp AT TIME ZONE 'us/pacific'` → `2022-01-01 00:00:00+00:00` <br /><br /> `'2022-01-01 00:00:00Z'::timestamptz AT TIME ZONE 'us/pacific'` → `2021-12-31 16:00:00` |
 | timestamptz + *interval_fixed* → timestamptz | Adds a fixed interval to a timestamp with time zone. See note below. | `'2022-03-13 01:00:00Z'::timestamp with time zone + interval '24' hour` → `2022-03-14 01:00:00+00:00` |
 | timestamptz - *interval_fixed* → timestamptz | Subtracts a fixed interval from a timestamp with time zone. See note below. | `'2022-03-14 01:00:00Z'::timestamp with time zone - interval '24' hour` → `2022-03-13 01:00:00+00:00` |
 

--- a/docs/sql/functions-operators/sql-function-datetime.md
+++ b/docs/sql/functions-operators/sql-function-datetime.md
@@ -40,6 +40,7 @@ title: Date and time functions and operators
 
 | Operation | Description | Example |
 | ----------- | ----------- | ----------- |
+| *timestamp_value* AT TIME ZONE *zone* → *timestamptz_value* | Converts times between timestamp and timestamptz. Invalid local time during daylight saving forward is not supported. Ambiguous local time during daylight saving backward is interpreted as after the transition. | `'2021-12-31 16:00:00'::timestamp AT TIME ZONE 'us/pacific'` → `2022-01-01 00:00:00+00:00` |
 | timestamptz + *interval_fixed* → timestamptz | Adds a fixed interval to a timestamp with time zone. See note below. | `'2022-03-13 01:00:00Z'::timestamp with time zone + interval '24' hour` → `2022-03-14 01:00:00+00:00` |
 | timestamptz - *interval_fixed* → timestamptz | Subtracts a fixed interval from a timestamp with time zone. See note below. | `'2022-03-14 01:00:00Z'::timestamp with time zone - interval '24' hour` → `2022-03-13 01:00:00+00:00` |
 


### PR DESCRIPTION
Add At Time Zone operator.

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Add At Time Zone operator.

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/5968

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/373

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
