### PR TITLE
fix: anchor default color

### DIFF
--- a/src/theme/NotifyButton/style.css
+++ b/src/theme/NotifyButton/style.css
@@ -2,14 +2,6 @@
   width: 100%;
 }
 
-a {
-  color: inherit;
-}
-
-a:hover {
-  color: #95adee;
-}
-
 .container {
   display: flex;
   flex-direction: column;

--- a/src/theme/RollButton/style.css
+++ b/src/theme/RollButton/style.css
@@ -74,7 +74,7 @@
 }
 
 .button-3:hover .circle {
-  width: 100%;
+  width: 10rem;
 }
 
 .button-3:hover .circle .icon.arrow {


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
remove the unused style for the anchor

- **Related code PR**: 


- **Related doc issue**: 


- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
