### PR TITLE
add information schema (tables and columns)

### DIFF
--- a/docs/sql/info-schema.md
+++ b/docs/sql/info-schema.md
@@ -1,0 +1,66 @@
+---
+id: information-schema
+slug: /information-schema
+title: Information schema
+---
+
+The information schema consists of a set of views that contain information about the objects defined in the current database.
+
+## Tables and views
+
+The  `information_schema.tables` view contains all tables and views (including materialized views) defined in the current database. Only those tables and views that the current user has access to are shown.
+
+The `information_schema.tables` view contains the following columns.
+
+|Column|Type|Description|
+|---|---|---|
+|`table_catalog`|varchar|Name of the database that contains the table (always the current database) |
+|`table_schema` |varchar| Name of the schema that contains the table|
+|`table_name` | varchar|Name of the table |
+|`table_type` | varchar| Type of the table. `BASE TABLE` for a base table, `VIEW` for a view, `MATERIALIZED VIEW` for a materialized view, `SYSTEM TABLE` for a system table.|
+|`is_insertable_into`|varchar|`YES` if the table is insertable into, `NO` if not. Base tables are always insertable into, views not necessarily.|
+
+## Columns
+
+The `information_shcema.columns` view contains information about all table columns (or view columns) in the database. System columns (ctid, etc.) are not included. Only those columns that the current user has access to are shown.
+
+The `information_schema.tables` view contains the following columns.
+
+|Column|Type|Description|
+|---|---|---|
+|`table_catalog`|varchar| Name of the database that contains the table (always the current database)|
+|`table_schema` |varchar| Name of the schema containing the table|
+|`table_name` | varchar| Name of the table|
+|`column_name` | varchar| Name of the column|
+|`ordinal_position`|int32| Ordinal position of the column within the table (count starts at 1)|
+|`is_nullable` | varchar| `YES` if the column is possibly nullable; `NO` if it is known not nullable.|
+|`data_type` | varchar| Data type of the column|
+
+## How to use the information schema views?
+
+You can use various information schema views to determine the makeup of tables in a database. 
+
+For example, you can query for all of the tables in the current database:
+
+```sql
+SELECT table_name
+FROM information_schema.tables;
+```
+
+To query for all of the columns in a table called `taxi_trip`:
+
+```sql
+SELECT column_name
+FROM information_schema.columns
+WHERE table_name='taxi_trip';
+```
+
+To find out tables that contain a column called `trip_id':
+
+```sql
+SELECT table_name
+FROM information_schema.columns
+WHERE column_name='trip_id';
+```
+
+

--- a/docs/sql/info-schema.md
+++ b/docs/sql/info-schema.md
@@ -10,7 +10,7 @@ The information schema consists of a set of views that contain information about
 
 The  `information_schema.tables` view contains all tables and views (including materialized views) defined in the current database. Only those tables and views that the current user has access to are shown.
 
-::: note
+:::note
 
 Materialized views are specific to the information schema of RisingWave. They are not included in the information schema of PostgreSQL.
 

--- a/docs/sql/info-schema.md
+++ b/docs/sql/info-schema.md
@@ -10,15 +10,21 @@ The information schema consists of a set of views that contain information about
 
 The  `information_schema.tables` view contains all tables and views (including materialized views) defined in the current database. Only those tables and views that the current user has access to are shown.
 
+::: note
+
+Materialized views are specific to the information schema of RisingWave. They are not included in the information schema of PostgreSQL.
+
+:::
+
 The `information_schema.tables` view contains the following columns.
 
 |Column|Type|Description|
 |---|---|---|
-|`table_catalog`|varchar|Name of the database that contains the table (always the current database) |
-|`table_schema` |varchar| Name of the schema that contains the table|
-|`table_name` | varchar|Name of the table |
-|`table_type` | varchar| Type of the table. `BASE TABLE` for a base table, `VIEW` for a view, `MATERIALIZED VIEW` for a materialized view, `SYSTEM TABLE` for a system table.|
-|`is_insertable_into`|varchar|`YES` if the table is insertable into, `NO` if not. Base tables are always insertable into, views not necessarily.|
+|`table_catalog`|varchar|Name of the database that contains the table or view (always the current database) |
+|`table_schema` |varchar| Name of the schema that contains the table or view|
+|`table_name` | varchar|Name of the table or view|
+|`table_type` | varchar| Type of the table or view. `BASE TABLE` for a base table, `VIEW` for a view, `MATERIALIZED VIEW` for a materialized view, `SYSTEM TABLE` for a system table.|
+|`is_insertable_into`|varchar|`YES` if the table or view is insertable into, `NO` if not. Base tables are always insertable into, views not necessarily.|
 
 ## Columns
 
@@ -28,9 +34,9 @@ The `information_schema.tables` view contains the following columns.
 
 |Column|Type|Description|
 |---|---|---|
-|`table_catalog`|varchar| Name of the database that contains the table (always the current database)|
-|`table_schema` |varchar| Name of the schema containing the table|
-|`table_name` | varchar| Name of the table|
+|`table_catalog`|varchar| Name of the database that contains the table or view (always the current database)|
+|`table_schema` |varchar| Name of the schema containing the table or view|
+|`table_name` | varchar| Name of the table or view|
 |`column_name` | varchar| Name of the column|
 |`ordinal_position`|int32| Ordinal position of the column within the table (count starts at 1)|
 |`is_nullable` | varchar| `YES` if the column is possibly nullable; `NO` if it is known not nullable.|
@@ -40,14 +46,14 @@ The `information_schema.tables` view contains the following columns.
 
 You can use various information schema views to determine the makeup of tables in a database. 
 
-For example, you can query for all of the tables in the current database:
+For example, you can query for all of the tables, views, and materialized views in the current database:
 
 ```sql
 SELECT table_name
 FROM information_schema.tables;
 ```
 
-To query for all of the columns in a table called `taxi_trip`:
+To query for all of the columns in a table or view called `taxi_trip`:
 
 ```sql
 SELECT column_name
@@ -55,7 +61,7 @@ FROM information_schema.columns
 WHERE table_name='taxi_trip';
 ```
 
-To find out tables that contain a column called `trip_id':
+To find out tables and views that contain a column called `trip_id`:
 
 ```sql
 SELECT table_name

--- a/docs/sql/info-schema.md
+++ b/docs/sql/info-schema.md
@@ -8,7 +8,7 @@ The information schema consists of a set of views that contain information about
 
 ## Tables and views
 
-The  `information_schema.tables` view contains all tables and views (including materialized views) defined in the current database.
+The  `information_schema.tables` view contains all tables, views, and materialized views defined in the current database.
 
 :::note
 
@@ -22,13 +22,13 @@ The `information_schema.tables` view contains the following columns.
 |---|---|---|
 |`table_catalog`|varchar|Name of the database that contains the table or view (always the current database) |
 |`table_schema` |varchar| Name of the schema that contains the table or view|
-|`table_name` | varchar|Name of the table or view|
-|`table_type` | varchar| Type of the table or view. `BASE TABLE` for a base table, `VIEW` for a view, `MATERIALIZED VIEW` for a materialized view, `SYSTEM TABLE` for a system table.|
-|`is_insertable_into`|varchar|`YES` if the table or view is insertable into, `NO` if not. Base tables are always insertable into, views not necessarily.|
+|`table_name` | varchar|Name of the table, view, or materialized view|
+|`table_type` | varchar| Type of the table, view, or materialized view. `BASE TABLE` for a base table, `VIEW` for a view, `MATERIALIZED VIEW` for a materialized view, `SYSTEM TABLE` for a system table.|
+|`is_insertable_into`|varchar|`YES` if the table or view is insertable into, `NO` if not. Base tables are always insertable into, views and materialized views not necessarily.|
 
 ## Columns
 
-The `information_shcema.columns` view contains information about all table columns (or view columns) in the database. System columns such as `ctid` are not included.
+The `information_shcema.columns` view contains information about columns of all tables, views, and materialized views in the database. System columns such as `ctid` are not included.
 
 The `information_schema.tables` view contains the following columns.
 
@@ -36,7 +36,7 @@ The `information_schema.tables` view contains the following columns.
 |---|---|---|
 |`table_catalog`|varchar| Name of the database that contains the table or view (always the current database)|
 |`table_schema` |varchar| Name of the schema containing the table or view|
-|`table_name` | varchar| Name of the table or view|
+|`table_name` | varchar| Name of the table, view, or materialized view|
 |`column_name` | varchar| Name of the column|
 |`ordinal_position`|int32| Ordinal position of the column within the table (count starts at 1)|
 |`is_nullable` | varchar| `YES` if the column is possibly nullable; `NO` if it is known not nullable.|
@@ -44,7 +44,7 @@ The `information_schema.tables` view contains the following columns.
 
 ## How to use the information schema views?
 
-You can use various information schema views to determine the makeup of tables in a database. 
+You can use various information schema views to determine the makeup of tables, views, and materialized views in a database. 
 
 For example, you can query for all of the tables, views, and materialized views in the current database:
 
@@ -53,7 +53,7 @@ SELECT table_name
 FROM information_schema.tables;
 ```
 
-To query for all of the columns in a table or view called `taxi_trip`:
+To query for all of the columns in a table, view, or materialized view called `taxi_trip`:
 
 ```sql
 SELECT column_name
@@ -61,7 +61,7 @@ FROM information_schema.columns
 WHERE table_name='taxi_trip';
 ```
 
-To find out tables and views that contain a column called `trip_id`:
+To find out tables, views, and materialized views that contain a column called `trip_id`:
 
 ```sql
 SELECT table_name

--- a/docs/sql/info-schema.md
+++ b/docs/sql/info-schema.md
@@ -28,7 +28,7 @@ The `information_schema.tables` view contains the following columns.
 
 ## Columns
 
-The `information_shcema.columns` view contains information about columns of all tables, views, and materialized views in the database. System columns such as `ctid` are not included.
+The `information_shcema.columns` view contains information about columns of all tables, views, and materialized views in the database.
 
 The `information_schema.tables` view contains the following columns.
 

--- a/docs/sql/info-schema.md
+++ b/docs/sql/info-schema.md
@@ -8,7 +8,7 @@ The information schema consists of a set of views that contain information about
 
 ## Tables and views
 
-The  `information_schema.tables` view contains all tables and views (including materialized views) defined in the current database. Only those tables and views that the current user has access to are shown.
+The  `information_schema.tables` view contains all tables and views (including materialized views) defined in the current database.
 
 :::note
 
@@ -28,7 +28,7 @@ The `information_schema.tables` view contains the following columns.
 
 ## Columns
 
-The `information_shcema.columns` view contains information about all table columns (or view columns) in the database. System columns (ctid, etc.) are not included. Only those columns that the current user has access to are shown.
+The `information_shcema.columns` view contains information about all table columns (or view columns) in the database. System columns such as `ctid` are not included.
 
 The `information_schema.tables` view contains the following columns.
 

--- a/docs/sql/info-schema.md
+++ b/docs/sql/info-schema.md
@@ -20,11 +20,11 @@ The `information_schema.tables` view contains the following columns.
 
 |Column|Type|Description|
 |---|---|---|
-|`table_catalog`|varchar|Name of the database that contains the table or view (always the current database) |
-|`table_schema` |varchar| Name of the schema that contains the table or view|
+|`table_catalog`|varchar|Name of the current database |
+|`table_schema` |varchar| Name of the schema that contains the table, view, or materialized view. The default schema for user-created objects is `public`.|
 |`table_name` | varchar|Name of the table, view, or materialized view|
-|`table_type` | varchar| Type of the table, view, or materialized view. `BASE TABLE` for a base table, `VIEW` for a view, `MATERIALIZED VIEW` for a materialized view, `SYSTEM TABLE` for a system table.|
-|`is_insertable_into`|varchar|`YES` if the table or view is insertable into, `NO` if not. Base tables are always insertable into, views and materialized views not necessarily.|
+|`table_type` | varchar| Type of the table, view, or materialized view. `BASE TABLE` for a user-defined table, `VIEW` for a non-materialized view, `MATERIALIZED VIEW` for a materialized view, and `SYSTEM TABLE` for a system table.|
+|`is_insertable_into`|varchar|`YES` if the table or view is insertable into, `NO` if not. User-defined tables are always insertable, while views and materialized views are not necessarily.|
 
 ## Columns
 
@@ -34,8 +34,8 @@ The `information_schema.tables` view contains the following columns.
 
 |Column|Type|Description|
 |---|---|---|
-|`table_catalog`|varchar| Name of the database that contains the table or view (always the current database)|
-|`table_schema` |varchar| Name of the schema containing the table or view|
+|`table_catalog`|varchar| Name of the current database|
+|`table_schema` |varchar| Name of the schema that contains the table, view, or materialized view. The default schema for user-created objects is `public`.|
 |`table_name` | varchar| Name of the table, view, or materialized view|
 |`column_name` | varchar| Name of the column|
 |`ordinal_position`|int32| Ordinal position of the column within the table (count starts at 1)|
@@ -46,10 +46,10 @@ The `information_schema.tables` view contains the following columns.
 
 You can use various information schema views to determine the makeup of tables, views, and materialized views in a database. 
 
-For example, you can query for all of the tables, views, and materialized views in the current database:
+For example, you can query for names and types of all the tables, views, and materialized views in the current database:
 
 ```sql
-SELECT table_name
+SELECT table_name, table_type
 FROM information_schema.tables;
 ```
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -151,11 +151,6 @@ const sidebars = {
       collapsed: true,
       items: 
       [ 
-        {type: 'ref', 
-        label: 'Use time window functions', 
-        id: 'sql/functions-operators/sql-function-time-window'
-        },
-
         {
           type: 'doc',
           id: 'guides/nested-columns-arrays',
@@ -257,6 +252,7 @@ const sidebars = {
         
         ]
         },
+     'sql/information-schema',
      'sql/psql-commands',
       ],
     },


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Document information schema (the `tables` view and the `columns` view)

- **Related code PR**: 
[ Provide the link to the code PR here. For example, https://github.com/risingwavelabs/risingwave/pull/4085. Delete this part if there's no code PR related. ]

- **Related doc issue**: 
Resolves #363 

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
