### PR TITLE
feat: default and ligth notify buttons

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,16 +5,18 @@ description: New features and important bug fixes in each release of RisingWave.
 slug: /release-notes
 ---
 
-This page summarizes changes in each version of RisingWave, including new features and important bug fixes. 
+This page summarizes changes in each version of RisingWave, including new features and important bug fixes.
 
 ## v0.1.14
 
-This version was released on December 1, 2022. 
+This version was released on December 1, 2022.
+
+<defaultNotify note="hello" text="defaultNotify"/>
+<lightNotify note="hello" text="lightNotify" block/>
 
 ### Main changes
 
 #### SQL features
-
 
 - `PRIMARY KEY` constraint checks can be performed on materialized sources and tables but not on non-materialized sources. For tables or materialized sources that enabled `PRIMARY KEY` constraints, if you insert data to an existing key, the new data will overwrite the old data. [#6320](https://github.com/risingwavelabs/risingwave/pull/6320) [#6435](https://github.com/risingwavelabs/risingwave/pull/6435)
 - Adds support for timestamp with time zone data type. You can use this data type in time window functions, and convert between it and timestamp (without time zone). [#5855](https://github.com/risingwavelabs/risingwave/pull/5855) [#5910](https://github.com/risingwavelabs/risingwave/pull/5910) [#5968](https://github.com/risingwavelabs/risingwave/pull/5968)
@@ -32,7 +34,6 @@ This version was released on December 1, 2022.
 - Adds support for Confluent Schema Registry for Kafka data in Avro and Protobuf formats. [#6289](https://github.com/risingwavelabs/risingwave/pull/6289)
 - Adds two options to the Kinesis connector. Users can specify the startup mode and optionally the sequence number to start with. [#6317](https://github.com/risingwavelabs/risingwave/pull/6317)
 
-
 ## v0.1.13
 
 This version was released on October 17, 2022.
@@ -42,57 +43,47 @@ This version was released on October 17, 2022.
 #### SQL features
 
 - SQL commands:
-    - Improves the formatting of response messages of `EXPLAIN` statements. [#5541](https://github.com/risingwavelabs/risingwave/pull/5541)
+
+  - Improves the formatting of response messages of `EXPLAIN` statements. [#5541](https://github.com/risingwavelabs/risingwave/pull/5541)
 
 - SQL functions:
-    - `to_char()` now supports specifying output format in lowercase. [#5032](https://github.com/risingwavelabs/risingwave/pull/5032)<br/>
-        
-        `to_char(timestamp '2006-01-02 15:04:05', 'yyyy-mm-dd hh24:mi:ss')` → `2006-01-02 15:04:05`
-        
-    - `generate_series` now supports negative steps. [#5231](https://github.com/risingwavelabs/risingwave/pull/5231)<br/>
-        
-        ```sql
-        SELECT * FROM generate_series(5,1,-2);
-        generate_series 
-        -----------------
-                       5
-                       3
-                       1
-        (3 rows)
-        ```
-        
-    - Adds support for sum/min/max functions over interval-type data. [#5105](https://github.com/risingwavelabs/risingwave/pull/5105), [#5549](https://github.com/risingwavelabs/risingwave/pull/5549)
-    - Adds support for array concatenation. [#5060](https://github.com/risingwavelabs/risingwave/pull/5060), [#5345](https://github.com/risingwavelabs/risingwave/pull/5345)
-    - Adds support for specifying empty arrays. [#5402](https://github.com/risingwavelabs/risingwave/pull/5402)
-    - Casting from array to varchar is now supported. [#5081](https://github.com/risingwavelabs/risingwave/pull/5081)<br/>
-        
-        `array[1,2]::varchar` → `{1,2}`
-        
-    - Casting from varchar to integer allows leading and trailing spaces. [#5452](https://github.com/risingwavelabs/risingwave/pull/5452)<br/>
-        
-        `' 1 '::int` → `1`
-        
+  - `to_char()` now supports specifying output format in lowercase. [#5032](https://github.com/risingwavelabs/risingwave/pull/5032)<br/>
+    `to_char(timestamp '2006-01-02 15:04:05', 'yyyy-mm-dd hh24:mi:ss')` → `2006-01-02 15:04:05`
+  - `generate_series` now supports negative steps. [#5231](https://github.com/risingwavelabs/risingwave/pull/5231)<br/>
+    ```sql
+    SELECT * FROM generate_series(5,1,-2);
+    generate_series
+    -----------------
+                   5
+                   3
+                   1
+    (3 rows)
+    ```
+  - Adds support for sum/min/max functions over interval-type data. [#5105](https://github.com/risingwavelabs/risingwave/pull/5105), [#5549](https://github.com/risingwavelabs/risingwave/pull/5549)
+  - Adds support for array concatenation. [#5060](https://github.com/risingwavelabs/risingwave/pull/5060), [#5345](https://github.com/risingwavelabs/risingwave/pull/5345)
+  - Adds support for specifying empty arrays. [#5402](https://github.com/risingwavelabs/risingwave/pull/5402)
+  - Casting from array to varchar is now supported. [#5081](https://github.com/risingwavelabs/risingwave/pull/5081)<br/>
+    `array[1,2]::varchar` → `{1,2}`
+  - Casting from varchar to integer allows leading and trailing spaces. [#5452](https://github.com/risingwavelabs/risingwave/pull/5452)<br/>
+    `' 1 '::int` → `1`
 - Adds new system catalog and psql meta-commands. [#5127](https://github.com/risingwavelabs/risingwave/pull/5127), [#5742](https://github.com/risingwavelabs/risingwave/pull/5742)
-    - `\d`: Lists all relations in the current database. (Materialized) sources are not supported yet.
-    - `\dt`: Lists all tables in the current database.
-    - `\dm`: Lists all materialized views in the current database.
-    - `\di`: Lists all indexes in the current database.
-    - `pg_catalog.pg_index`: Contains information about indexes.
-    
-    
+  - `\d`: Lists all relations in the current database. (Materialized) sources are not supported yet.
+  - `\dt`: Lists all tables in the current database.
+  - `\dm`: Lists all materialized views in the current database.
+  - `\di`: Lists all indexes in the current database.
+  - `pg_catalog.pg_index`: Contains information about indexes.
+
 #### Connectors
 
 - Nested columns are now supported for the datagen connector. [#5550](https://github.com/risingwavelabs/risingwave/pull/5550)
 
-
 ### Assets
 
-* Run this version from Docker:<br/>
-    `docker run -it --pull=always -p 4566:4566 -p 5691:5691 ghcr.io/risingwavelabs/risingwave:v0.1.13 playground`
-* [Prebuilt library for Linux](https://github.com/risingwavelabs/risingwave/releases/download/v0.1.13/risingwave-v0.1.13-x86_64-unknown-linux.tar.gz)
-* [Source code (zip)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.13.zip)
-* [Source code (tar.gz)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.13.tar.gz)
-
+- Run this version from Docker:<br/>
+  `docker run -it --pull=always -p 4566:4566 -p 5691:5691 ghcr.io/risingwavelabs/risingwave:v0.1.13 playground`
+- [Prebuilt library for Linux](https://github.com/risingwavelabs/risingwave/releases/download/v0.1.13/risingwave-v0.1.13-x86_64-unknown-linux.tar.gz)
+- [Source code (zip)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.13.zip)
+- [Source code (tar.gz)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.13.tar.gz)
 
 ## v0.1.12
 
@@ -102,57 +93,56 @@ This version was released on September 7, 2022.
 
 #### SQL features
 
-* SQL commands:
-    * `EXPLAIN` now supports specifying options. Supported options: `trace`, `verbose`, and `type`. Unlike PostgreSQL, each option should be separated by a comma and wrapped by parentheses as a whole. [#4730](https://github.com/risingwavelabs/risingwave/pull/4730)
-    * Adds support for `ALTER USER`. [#4261](https://github.com/risingwavelabs/risingwave/pull/4261)
-    * `CREATE/ALTER USER` now has new options `CREATEUSER` and `NOCREATEUSER`, which specifiy whether or not the user has the privilege to create, alter, or drop other users. [#4447](https://github.com/risingwavelabs/risingwave/pull/4447)
-    * Adds support for EXPLAIN CREATE SINK. [#4430](https://github.com/risingwavelabs/risingwave/pull/4430)
-* SQL functions:
-    * Adds support for new system information functions: `current_schema`, `current_schema()`, and `session_user`. [#4358](https://github.com/risingwavelabs/risingwave/pull/4358)
-* The `pg_namespace` catalog now has a new namespace column `nspacl` for storing access privileges. [#4326](https://github.com/risingwavelabs/risingwave/pull/4326)
+- SQL commands:
+  - `EXPLAIN` now supports specifying options. Supported options: `trace`, `verbose`, and `type`. Unlike PostgreSQL, each option should be separated by a comma and wrapped by parentheses as a whole. [#4730](https://github.com/risingwavelabs/risingwave/pull/4730)
+  - Adds support for `ALTER USER`. [#4261](https://github.com/risingwavelabs/risingwave/pull/4261)
+  - `CREATE/ALTER USER` now has new options `CREATEUSER` and `NOCREATEUSER`, which specifiy whether or not the user has the privilege to create, alter, or drop other users. [#4447](https://github.com/risingwavelabs/risingwave/pull/4447)
+  - Adds support for EXPLAIN CREATE SINK. [#4430](https://github.com/risingwavelabs/risingwave/pull/4430)
+- SQL functions:
+  - Adds support for new system information functions: `current_schema`, `current_schema()`, and `session_user`. [#4358](https://github.com/risingwavelabs/risingwave/pull/4358)
+- The `pg_namespace` catalog now has a new namespace column `nspacl` for storing access privileges. [#4326](https://github.com/risingwavelabs/risingwave/pull/4326)
 
 #### Connectors
 
-* Some connector parameters were renamed. The old parameter names are still functional but may be deprecated in the future. [#4503](https://github.com/risingwavelabs/risingwave/pull/4503)
+- Some connector parameters were renamed. The old parameter names are still functional but may be deprecated in the future. [#4503](https://github.com/risingwavelabs/risingwave/pull/4503)
 
-    * Kafka & Redpanda
-        * `kafka.brokers` -> `properties.bootstrap.server`
-        * `kafka.topic` -> `topic`
-        * `kafka.scan.startup.mode` -> `scan.starup.mode`
-        * `kafka.time.offset` -> `scan.startup.timestamp_millis`
-        * `kafka.consumer.group` -> `consumer.group.id`
+  - Kafka & Redpanda
 
-    * Kinesis
-        * `kinesis.stream.name` -> `stream`
-        * `kinesis.stream.region` -> `aws.region`
-        * `kinesis.endpoint` -> `endpoint`
-        * `kinesis.credentials.access` -> `aws.credentials.access_key_id`
-        * `kinesis.credentials.secret` -> `aws.credentials.secret_access_key`
-        * `kinesis.credentials.session_token` -> `aws.credentials.session_token`
-        * `kinesis.assumerole.arn` -> `aws.credentials.role.arn`
-        * `kinesis.assumerole.external_id` -> `aws.credentials.role.external_id`
-    * Pulsar
-        * `pulsar.topic` -> `topic`
-        * `pulsar.admin.url` -> `admin.url`
-        * `pulsar.service.url` -> `service.url`
-        * `pulsar.scan.startup.mode` -> `scan.startup.mode`
-        * `pulsar.time.offset` -> `scan.startup.timestamp_millis`
-* The row format name, `debezium json`, for CDC stream sources, has been renamed to `debezium_json`. [#4494](https://github.com/risingwavelabs/risingwave/pull/4494)
+    - `kafka.brokers` -> `properties.bootstrap.server`
+    - `kafka.topic` -> `topic`
+    - `kafka.scan.startup.mode` -> `scan.starup.mode`
+    - `kafka.time.offset` -> `scan.startup.timestamp_millis`
+    - `kafka.consumer.group` -> `consumer.group.id`
+
+  - Kinesis
+    - `kinesis.stream.name` -> `stream`
+    - `kinesis.stream.region` -> `aws.region`
+    - `kinesis.endpoint` -> `endpoint`
+    - `kinesis.credentials.access` -> `aws.credentials.access_key_id`
+    - `kinesis.credentials.secret` -> `aws.credentials.secret_access_key`
+    - `kinesis.credentials.session_token` -> `aws.credentials.session_token`
+    - `kinesis.assumerole.arn` -> `aws.credentials.role.arn`
+    - `kinesis.assumerole.external_id` -> `aws.credentials.role.external_id`
+  - Pulsar
+    - `pulsar.topic` -> `topic`
+    - `pulsar.admin.url` -> `admin.url`
+    - `pulsar.service.url` -> `service.url`
+    - `pulsar.scan.startup.mode` -> `scan.startup.mode`
+    - `pulsar.time.offset` -> `scan.startup.timestamp_millis`
+
+- The row format name, `debezium json`, for CDC stream sources, has been renamed to `debezium_json`. [#4494](https://github.com/risingwavelabs/risingwave/pull/4494)
 
 #### Configuration changes
 
-* The default batch query execution mode was changed from distributed to local. [#4789](https://github.com/risingwavelabs/risingwave/pull/4789)
-
+- The default batch query execution mode was changed from distributed to local. [#4789](https://github.com/risingwavelabs/risingwave/pull/4789)
 
 ### Assets
 
-* Run this version from Docker:
-    `docker run -it --pull=always -p 4566:4566 -p 5691:5691 ghcr.io/risingwavelabs/risingwave:v0.1.12 playground`
-* Prebuilt library for Linux is not available in this release.
-* [Source code (zip)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.12.zip)
-* [Source code (tar.gz)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.12.tar.gz)
-
-
+- Run this version from Docker:
+  `docker run -it --pull=always -p 4566:4566 -p 5691:5691 ghcr.io/risingwavelabs/risingwave:v0.1.12 playground`
+- Prebuilt library for Linux is not available in this release.
+- [Source code (zip)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.12.zip)
+- [Source code (tar.gz)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.12.tar.gz)
 
 ## v0.1.11
 
@@ -162,37 +152,33 @@ This version was released on July 29, 2022.
 
 #### SQL features
 
-* New SQL functions:
-    * `overlay()`: Replaces a substring. [#3671](https://github.com/risingwavelabs/risingwave/pull/3671)
-    * `generate_series()`: Generates a series of values from the starting point to the ending point. [#4030](https://github.com/risingwavelabs/risingwave/pull/4030)
-    * `regexp_match()`, `regexp_matches()`: Compares a string against a regular expression pattern and returns matched substrings. [#3702](https://github.com/risingwavelabs/risingwave/pull/3702) [#4062](https://github.com/risingwavelabs/risingwave/pull/4062)
-    * `string_agg ()`: Concatenates the values into a string. [#3952](https://github.com/risingwavelabs/risingwave/pull/3952) [#4183](https://github.com/risingwavelabs/risingwave/pull/4183)
-    * `current_database()`: Returns the current database.  [#3650](https://github.com/risingwavelabs/risingwave/pull/3650)
-* New SQL commands:
-    * `SHOW ALL`: Lists all configuration parameters. Use `SHOW parameter` to show the value of a configuration parameter. [#3694](https://github.com/risingwavelabs/risingwave/pull/3694) [#3664](https://github.com/risingwavelabs/risingwave/pull/3664)
-    * `CREATE SINK`: Sinks data to Kafka. [#3923](https://github.com/risingwavelabs/risingwave/pull/3923) [#3682](https://github.com/risingwavelabs/risingwave/pull/3682) [#3674](https://github.com/risingwavelabs/risingwave/pull/3674)
-    * `EXPLAIN TRACE`: Traces each optimization stage of the optimizer. [#3945](https://github.com/risingwavelabs/risingwave/pull/3945)
-* Support for lookup joins. Currently, lookup joins can only be performed in local query mode. To use lookup joins, users need to set the configuration parameter `rw_batch_enable_lookup_join`  to true.  [#3859](https://github.com/risingwavelabs/risingwave/pull/3859) [#3763](https://github.com/risingwavelabs/risingwave/pull/3763)
-* An `ORDER BY` clause in the `CREATE MATERIALIZED VIEW` statement is allowed but not considered as part of the definition of the materialized view. It is only used in the initial creation of the materialized view. It is not used during refreshes. This is a behavior change due to the introduction of parallel table scans. [#3670](https://github.com/risingwavelabs/risingwave/pull/3670)
-* Support for filter clauses on aggregate functions. [#4114](https://github.com/risingwavelabs/risingwave/pull/4114)
+- New SQL functions:
+  - `overlay()`: Replaces a substring. [#3671](https://github.com/risingwavelabs/risingwave/pull/3671)
+  - `generate_series()`: Generates a series of values from the starting point to the ending point. [#4030](https://github.com/risingwavelabs/risingwave/pull/4030)
+  - `regexp_match()`, `regexp_matches()`: Compares a string against a regular expression pattern and returns matched substrings. [#3702](https://github.com/risingwavelabs/risingwave/pull/3702) [#4062](https://github.com/risingwavelabs/risingwave/pull/4062)
+  - `string_agg ()`: Concatenates the values into a string. [#3952](https://github.com/risingwavelabs/risingwave/pull/3952) [#4183](https://github.com/risingwavelabs/risingwave/pull/4183)
+  - `current_database()`: Returns the current database. [#3650](https://github.com/risingwavelabs/risingwave/pull/3650)
+- New SQL commands:
+  - `SHOW ALL`: Lists all configuration parameters. Use `SHOW parameter` to show the value of a configuration parameter. [#3694](https://github.com/risingwavelabs/risingwave/pull/3694) [#3664](https://github.com/risingwavelabs/risingwave/pull/3664)
+  - `CREATE SINK`: Sinks data to Kafka. [#3923](https://github.com/risingwavelabs/risingwave/pull/3923) [#3682](https://github.com/risingwavelabs/risingwave/pull/3682) [#3674](https://github.com/risingwavelabs/risingwave/pull/3674)
+  - `EXPLAIN TRACE`: Traces each optimization stage of the optimizer. [#3945](https://github.com/risingwavelabs/risingwave/pull/3945)
+- Support for lookup joins. Currently, lookup joins can only be performed in local query mode. To use lookup joins, users need to set the configuration parameter `rw_batch_enable_lookup_join` to true. [#3859](https://github.com/risingwavelabs/risingwave/pull/3859) [#3763](https://github.com/risingwavelabs/risingwave/pull/3763)
+- An `ORDER BY` clause in the `CREATE MATERIALIZED VIEW` statement is allowed but not considered as part of the definition of the materialized view. It is only used in the initial creation of the materialized view. It is not used during refreshes. This is a behavior change due to the introduction of parallel table scans. [#3670](https://github.com/risingwavelabs/risingwave/pull/3670)
+- Support for filter clauses on aggregate functions. [#4114](https://github.com/risingwavelabs/risingwave/pull/4114)
 
 #### Connectors
 
-* RisingWave can now sink data to Kafka topics in append-only mode and Debezium mode. [#3923](https://github.com/risingwavelabs/risingwave/pull/3923) [#3682](https://github.com/risingwavelabs/risingwave/pull/3682) [#3674](https://github.com/risingwavelabs/risingwave/pull/3674)
-* Syntax change for `CREATE SOURCE`: A parameter name is no longer wrapped by single quotation marks. [#3997](https://github.com/risingwavelabs/risingwave/pull/3997). See the example:
-    * Old: `CREATE SOURCE s1 WITH ( 'connector' = 'kafka', 'kafka.topic' = 'kafka_1_partition_topic', 'kafka.brokers' = '127.0.0.1:29092' ) ROW FORMAT json;`  
-    * New: `CREATE SOURCE s WITH ( connector = 'kafka', kafka.topic = 'kafka_1_partition_topic', kafka.brokers = '127.0.0.1:29092' ) ROW FORMAT json;`
-
+- RisingWave can now sink data to Kafka topics in append-only mode and Debezium mode. [#3923](https://github.com/risingwavelabs/risingwave/pull/3923) [#3682](https://github.com/risingwavelabs/risingwave/pull/3682) [#3674](https://github.com/risingwavelabs/risingwave/pull/3674)
+- Syntax change for `CREATE SOURCE`: A parameter name is no longer wrapped by single quotation marks. [#3997](https://github.com/risingwavelabs/risingwave/pull/3997). See the example:
+  - Old: `CREATE SOURCE s1 WITH ( 'connector' = 'kafka', 'kafka.topic' = 'kafka_1_partition_topic', 'kafka.brokers' = '127.0.0.1:29092' ) ROW FORMAT json;`
+  - New: `CREATE SOURCE s WITH ( connector = 'kafka', kafka.topic = 'kafka_1_partition_topic', kafka.brokers = '127.0.0.1:29092' ) ROW FORMAT json;`
 
 ### Assets
 
-* Run this version from Docker: <br/>`run -it --pull=always -p 4566:4566 -p 5691:5691 ghcr.io/risingwavelabs/risingwave:v0.1.11 playground`
-* [Prebuilt library for Linux](https://github.com/risingwavelabs/risingwave/releases/download/v0.1.11/risingwave-v0.1.11-x86_64-unknown-linux.tar.gz)
-* [Source code (zip)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.11.zip)
-* [Source code (tar.gz)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.11.tar.gz)
-
-
-
+- Run this version from Docker: <br/>`run -it --pull=always -p 4566:4566 -p 5691:5691 ghcr.io/risingwavelabs/risingwave:v0.1.11 playground`
+- [Prebuilt library for Linux](https://github.com/risingwavelabs/risingwave/releases/download/v0.1.11/risingwave-v0.1.11-x86_64-unknown-linux.tar.gz)
+- [Source code (zip)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.11.zip)
+- [Source code (tar.gz)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.11.tar.gz)
 
 ## v0.1.10
 
@@ -204,48 +190,47 @@ This version was released on July 5, 2022.
 
 ##### SQL operators and functions
 
-* Support string concatenation operator `||`. [#3147](https://github.com/risingwavelabs/risingwave/pull/3147)
-* Support interval comparison. [#3222](https://github.com/risingwavelabs/risingwave/pull/3222)
-* Support dividing intervals by integers, floats, or decimals. [#3441](https://github.com/risingwavelabs/risingwave/pull/3441)
-* Intervals multiplying intervals by floats. [#3641](https://github.com/risingwavelabs/risingwave/pull/3641)
-* Support more temporal operations. [#3472](https://github.com/risingwavelabs/risingwave/pull/3472)
-* Support Common Table Expressions (CTEs) as input of time window functions. [#3188](https://github.com/risingwavelabs/risingwave/pull/3188)
-* Add these new functions:
-    * `concat()` for concatenating strings [#3091](https://github.com/risingwavelabs/risingwave/pull/3091)
-    * `repeat()` for repeating string [#3148](https://github.com/risingwavelabs/risingwave/pull/3148)
-    * `octet_length()` and bit_length() for getting string length [#3526](https://github.com/risingwavelabs/risingwave/pull/3526)
-    * `Row()` for constructing rows [#2914](https://github.com/risingwavelabs/risingwave/pull/2914) [#3152](https://github.com/risingwavelabs/risingwave/pull/3152)
-    * `pg_typeof()` for getting data types of values [#3494](https://github.com/risingwavelabs/risingwave/pull/3494)
-    * `current_database()` for getting the name of the current database in the session [#3650](https://github.com/risingwavelabs/risingwave/pull/3650)
-    * `approx_count_distinct()` for distinct counting [#3121](https://github.com/risingwavelabs/risingwave/pull/3121)
-    * `unnest()` for expanding nested tables to rows [#3017](https://github.com/risingwavelabs/risingwave/pull/3017) 
-* Support `count()`, `min()`, and `max()` functions on these data types: *interval*, *timestamp*, *varchar*, and *date*. [#3069](https://github.com/risingwavelabs/risingwave/pull/3069)
+- Support string concatenation operator `||`. [#3147](https://github.com/risingwavelabs/risingwave/pull/3147)
+- Support interval comparison. [#3222](https://github.com/risingwavelabs/risingwave/pull/3222)
+- Support dividing intervals by integers, floats, or decimals. [#3441](https://github.com/risingwavelabs/risingwave/pull/3441)
+- Intervals multiplying intervals by floats. [#3641](https://github.com/risingwavelabs/risingwave/pull/3641)
+- Support more temporal operations. [#3472](https://github.com/risingwavelabs/risingwave/pull/3472)
+- Support Common Table Expressions (CTEs) as input of time window functions. [#3188](https://github.com/risingwavelabs/risingwave/pull/3188)
+- Add these new functions:
+  - `concat()` for concatenating strings [#3091](https://github.com/risingwavelabs/risingwave/pull/3091)
+  - `repeat()` for repeating string [#3148](https://github.com/risingwavelabs/risingwave/pull/3148)
+  - `octet_length()` and bit_length() for getting string length [#3526](https://github.com/risingwavelabs/risingwave/pull/3526)
+  - `Row()` for constructing rows [#2914](https://github.com/risingwavelabs/risingwave/pull/2914) [#3152](https://github.com/risingwavelabs/risingwave/pull/3152)
+  - `pg_typeof()` for getting data types of values [#3494](https://github.com/risingwavelabs/risingwave/pull/3494)
+  - `current_database()` for getting the name of the current database in the session [#3650](https://github.com/risingwavelabs/risingwave/pull/3650)
+  - `approx_count_distinct()` for distinct counting [#3121](https://github.com/risingwavelabs/risingwave/pull/3121)
+  - `unnest()` for expanding nested tables to rows [#3017](https://github.com/risingwavelabs/risingwave/pull/3017)
+- Support `count()`, `min()`, and `max()` functions on these data types: _interval_, _timestamp_, _varchar_, and _date_. [#3069](https://github.com/risingwavelabs/risingwave/pull/3069)
 
 ##### SQL commands
 
-* Support `EXPLAIN CREATE INDEX`. [#3229](https://github.com/risingwavelabs/risingwave/pull/3229)
-* Add cascade and restrict options in `REVOKE` commands. [#3363](https://github.com/risingwavelabs/risingwave/pull/3363)
-* Expand the `CREATE TABLE` syntax to support creating append-only tables. [#3058](https://github.com/risingwavelabs/risingwave/pull/3058)
-* Support the `CREATE USER` command and user authentication. [#3074](https://github.com/risingwavelabs/risingwave/pull/3074)
+- Support `EXPLAIN CREATE INDEX`. [#3229](https://github.com/risingwavelabs/risingwave/pull/3229)
+- Add cascade and restrict options in `REVOKE` commands. [#3363](https://github.com/risingwavelabs/risingwave/pull/3363)
+- Expand the `CREATE TABLE` syntax to support creating append-only tables. [#3058](https://github.com/risingwavelabs/risingwave/pull/3058)
+- Support the `CREATE USER` command and user authentication. [#3074](https://github.com/risingwavelabs/risingwave/pull/3074)
 
 ##### Data types
 
-* Support implicit casts from single-quoted literals. [#3487](https://github.com/risingwavelabs/risingwave/pull/3487)
-* Add string as an alias for data type varchar.  [#3094](https://github.com/risingwavelabs/risingwave/pull/3094)
-* Support string intervals.  [#3037](https://github.com/risingwavelabs/risingwave/pull/3037)
+- Support implicit casts from single-quoted literals. [#3487](https://github.com/risingwavelabs/risingwave/pull/3487)
+- Add string as an alias for data type varchar. [#3094](https://github.com/risingwavelabs/risingwave/pull/3094)
+- Support string intervals. [#3037](https://github.com/risingwavelabs/risingwave/pull/3037)
 
 ##### Database management
 
-* Add the default super user “postgres”.  [#3127](https://github.com/risingwavelabs/risingwave/pull/3127)
-* The default schema name is changed to “public” from “dev”.  [#3166](https://github.com/risingwavelabs/risingwave/pull/3166)
+- Add the default super user “postgres”. [#3127](https://github.com/risingwavelabs/risingwave/pull/3127)
+- The default schema name is changed to “public” from “dev”. [#3166](https://github.com/risingwavelabs/risingwave/pull/3166)
 
 #### Connectors
 
-* Add random seed for the Datagen Source Connector. [#3124](https://github.com/risingwavelabs/risingwave/pull/3124)
+- Add random seed for the Datagen Source Connector. [#3124](https://github.com/risingwavelabs/risingwave/pull/3124)
 
 ### Assets
 
-* [Prebuilt library for Linux](https://github.com/risingwavelabs/risingwave/releases/download/v0.1.10/risingwave-v0.1.10-x86_64-unknown-linux.tar.gz) 
-* [Source code (zip)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.10.zip)
-* [Source code (tar.gz)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.10.tar.gz)
-
+- [Prebuilt library for Linux](https://github.com/risingwavelabs/risingwave/releases/download/v0.1.10/risingwave-v0.1.10-x86_64-unknown-linux.tar.gz)
+- [Source code (zip)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.10.zip)
+- [Source code (tar.gz)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.10.tar.gz)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,7 @@ This version was released on December 1, 2022.
 
 <defaultNotify note="hello" text="defaultNotify"/>
 <lightNotify note="hello" text="lightNotify" block/>
+<notifyButton note="hello" />
 
 ### Main changes
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,19 +5,16 @@ description: New features and important bug fixes in each release of RisingWave.
 slug: /release-notes
 ---
 
-This page summarizes changes in each version of RisingWave, including new features and important bug fixes.
+This page summarizes changes in each version of RisingWave, including new features and important bug fixes. 
 
 ## v0.1.14
 
-This version was released on December 1, 2022.
-
-<defaultNotify note="hello" text="defaultNotify"/>
-<lightNotify note="hello" text="lightNotify" block/>
-<notifyButton note="hello" />
+This version was released on December 1, 2022. 
 
 ### Main changes
 
 #### SQL features
+
 
 - `PRIMARY KEY` constraint checks can be performed on materialized sources and tables but not on non-materialized sources. For tables or materialized sources that enabled `PRIMARY KEY` constraints, if you insert data to an existing key, the new data will overwrite the old data. [#6320](https://github.com/risingwavelabs/risingwave/pull/6320) [#6435](https://github.com/risingwavelabs/risingwave/pull/6435)
 - Adds support for timestamp with time zone data type. You can use this data type in time window functions, and convert between it and timestamp (without time zone). [#5855](https://github.com/risingwavelabs/risingwave/pull/5855) [#5910](https://github.com/risingwavelabs/risingwave/pull/5910) [#5968](https://github.com/risingwavelabs/risingwave/pull/5968)
@@ -35,6 +32,7 @@ This version was released on December 1, 2022.
 - Adds support for Confluent Schema Registry for Kafka data in Avro and Protobuf formats. [#6289](https://github.com/risingwavelabs/risingwave/pull/6289)
 - Adds two options to the Kinesis connector. Users can specify the startup mode and optionally the sequence number to start with. [#6317](https://github.com/risingwavelabs/risingwave/pull/6317)
 
+
 ## v0.1.13
 
 This version was released on October 17, 2022.
@@ -44,47 +42,57 @@ This version was released on October 17, 2022.
 #### SQL features
 
 - SQL commands:
-
-  - Improves the formatting of response messages of `EXPLAIN` statements. [#5541](https://github.com/risingwavelabs/risingwave/pull/5541)
+    - Improves the formatting of response messages of `EXPLAIN` statements. [#5541](https://github.com/risingwavelabs/risingwave/pull/5541)
 
 - SQL functions:
-  - `to_char()` now supports specifying output format in lowercase. [#5032](https://github.com/risingwavelabs/risingwave/pull/5032)<br/>
-    `to_char(timestamp '2006-01-02 15:04:05', 'yyyy-mm-dd hh24:mi:ss')` → `2006-01-02 15:04:05`
-  - `generate_series` now supports negative steps. [#5231](https://github.com/risingwavelabs/risingwave/pull/5231)<br/>
-    ```sql
-    SELECT * FROM generate_series(5,1,-2);
-    generate_series
-    -----------------
-                   5
-                   3
-                   1
-    (3 rows)
-    ```
-  - Adds support for sum/min/max functions over interval-type data. [#5105](https://github.com/risingwavelabs/risingwave/pull/5105), [#5549](https://github.com/risingwavelabs/risingwave/pull/5549)
-  - Adds support for array concatenation. [#5060](https://github.com/risingwavelabs/risingwave/pull/5060), [#5345](https://github.com/risingwavelabs/risingwave/pull/5345)
-  - Adds support for specifying empty arrays. [#5402](https://github.com/risingwavelabs/risingwave/pull/5402)
-  - Casting from array to varchar is now supported. [#5081](https://github.com/risingwavelabs/risingwave/pull/5081)<br/>
-    `array[1,2]::varchar` → `{1,2}`
-  - Casting from varchar to integer allows leading and trailing spaces. [#5452](https://github.com/risingwavelabs/risingwave/pull/5452)<br/>
-    `' 1 '::int` → `1`
+    - `to_char()` now supports specifying output format in lowercase. [#5032](https://github.com/risingwavelabs/risingwave/pull/5032)<br/>
+        
+        `to_char(timestamp '2006-01-02 15:04:05', 'yyyy-mm-dd hh24:mi:ss')` → `2006-01-02 15:04:05`
+        
+    - `generate_series` now supports negative steps. [#5231](https://github.com/risingwavelabs/risingwave/pull/5231)<br/>
+        
+        ```sql
+        SELECT * FROM generate_series(5,1,-2);
+        generate_series 
+        -----------------
+                       5
+                       3
+                       1
+        (3 rows)
+        ```
+        
+    - Adds support for sum/min/max functions over interval-type data. [#5105](https://github.com/risingwavelabs/risingwave/pull/5105), [#5549](https://github.com/risingwavelabs/risingwave/pull/5549)
+    - Adds support for array concatenation. [#5060](https://github.com/risingwavelabs/risingwave/pull/5060), [#5345](https://github.com/risingwavelabs/risingwave/pull/5345)
+    - Adds support for specifying empty arrays. [#5402](https://github.com/risingwavelabs/risingwave/pull/5402)
+    - Casting from array to varchar is now supported. [#5081](https://github.com/risingwavelabs/risingwave/pull/5081)<br/>
+        
+        `array[1,2]::varchar` → `{1,2}`
+        
+    - Casting from varchar to integer allows leading and trailing spaces. [#5452](https://github.com/risingwavelabs/risingwave/pull/5452)<br/>
+        
+        `' 1 '::int` → `1`
+        
 - Adds new system catalog and psql meta-commands. [#5127](https://github.com/risingwavelabs/risingwave/pull/5127), [#5742](https://github.com/risingwavelabs/risingwave/pull/5742)
-  - `\d`: Lists all relations in the current database. (Materialized) sources are not supported yet.
-  - `\dt`: Lists all tables in the current database.
-  - `\dm`: Lists all materialized views in the current database.
-  - `\di`: Lists all indexes in the current database.
-  - `pg_catalog.pg_index`: Contains information about indexes.
-
+    - `\d`: Lists all relations in the current database. (Materialized) sources are not supported yet.
+    - `\dt`: Lists all tables in the current database.
+    - `\dm`: Lists all materialized views in the current database.
+    - `\di`: Lists all indexes in the current database.
+    - `pg_catalog.pg_index`: Contains information about indexes.
+    
+    
 #### Connectors
 
 - Nested columns are now supported for the datagen connector. [#5550](https://github.com/risingwavelabs/risingwave/pull/5550)
 
+
 ### Assets
 
-- Run this version from Docker:<br/>
-  `docker run -it --pull=always -p 4566:4566 -p 5691:5691 ghcr.io/risingwavelabs/risingwave:v0.1.13 playground`
-- [Prebuilt library for Linux](https://github.com/risingwavelabs/risingwave/releases/download/v0.1.13/risingwave-v0.1.13-x86_64-unknown-linux.tar.gz)
-- [Source code (zip)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.13.zip)
-- [Source code (tar.gz)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.13.tar.gz)
+* Run this version from Docker:<br/>
+    `docker run -it --pull=always -p 4566:4566 -p 5691:5691 ghcr.io/risingwavelabs/risingwave:v0.1.13 playground`
+* [Prebuilt library for Linux](https://github.com/risingwavelabs/risingwave/releases/download/v0.1.13/risingwave-v0.1.13-x86_64-unknown-linux.tar.gz)
+* [Source code (zip)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.13.zip)
+* [Source code (tar.gz)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.13.tar.gz)
+
 
 ## v0.1.12
 
@@ -94,56 +102,57 @@ This version was released on September 7, 2022.
 
 #### SQL features
 
-- SQL commands:
-  - `EXPLAIN` now supports specifying options. Supported options: `trace`, `verbose`, and `type`. Unlike PostgreSQL, each option should be separated by a comma and wrapped by parentheses as a whole. [#4730](https://github.com/risingwavelabs/risingwave/pull/4730)
-  - Adds support for `ALTER USER`. [#4261](https://github.com/risingwavelabs/risingwave/pull/4261)
-  - `CREATE/ALTER USER` now has new options `CREATEUSER` and `NOCREATEUSER`, which specifiy whether or not the user has the privilege to create, alter, or drop other users. [#4447](https://github.com/risingwavelabs/risingwave/pull/4447)
-  - Adds support for EXPLAIN CREATE SINK. [#4430](https://github.com/risingwavelabs/risingwave/pull/4430)
-- SQL functions:
-  - Adds support for new system information functions: `current_schema`, `current_schema()`, and `session_user`. [#4358](https://github.com/risingwavelabs/risingwave/pull/4358)
-- The `pg_namespace` catalog now has a new namespace column `nspacl` for storing access privileges. [#4326](https://github.com/risingwavelabs/risingwave/pull/4326)
+* SQL commands:
+    * `EXPLAIN` now supports specifying options. Supported options: `trace`, `verbose`, and `type`. Unlike PostgreSQL, each option should be separated by a comma and wrapped by parentheses as a whole. [#4730](https://github.com/risingwavelabs/risingwave/pull/4730)
+    * Adds support for `ALTER USER`. [#4261](https://github.com/risingwavelabs/risingwave/pull/4261)
+    * `CREATE/ALTER USER` now has new options `CREATEUSER` and `NOCREATEUSER`, which specifiy whether or not the user has the privilege to create, alter, or drop other users. [#4447](https://github.com/risingwavelabs/risingwave/pull/4447)
+    * Adds support for EXPLAIN CREATE SINK. [#4430](https://github.com/risingwavelabs/risingwave/pull/4430)
+* SQL functions:
+    * Adds support for new system information functions: `current_schema`, `current_schema()`, and `session_user`. [#4358](https://github.com/risingwavelabs/risingwave/pull/4358)
+* The `pg_namespace` catalog now has a new namespace column `nspacl` for storing access privileges. [#4326](https://github.com/risingwavelabs/risingwave/pull/4326)
 
 #### Connectors
 
-- Some connector parameters were renamed. The old parameter names are still functional but may be deprecated in the future. [#4503](https://github.com/risingwavelabs/risingwave/pull/4503)
+* Some connector parameters were renamed. The old parameter names are still functional but may be deprecated in the future. [#4503](https://github.com/risingwavelabs/risingwave/pull/4503)
 
-  - Kafka & Redpanda
+    * Kafka & Redpanda
+        * `kafka.brokers` -> `properties.bootstrap.server`
+        * `kafka.topic` -> `topic`
+        * `kafka.scan.startup.mode` -> `scan.starup.mode`
+        * `kafka.time.offset` -> `scan.startup.timestamp_millis`
+        * `kafka.consumer.group` -> `consumer.group.id`
 
-    - `kafka.brokers` -> `properties.bootstrap.server`
-    - `kafka.topic` -> `topic`
-    - `kafka.scan.startup.mode` -> `scan.starup.mode`
-    - `kafka.time.offset` -> `scan.startup.timestamp_millis`
-    - `kafka.consumer.group` -> `consumer.group.id`
-
-  - Kinesis
-    - `kinesis.stream.name` -> `stream`
-    - `kinesis.stream.region` -> `aws.region`
-    - `kinesis.endpoint` -> `endpoint`
-    - `kinesis.credentials.access` -> `aws.credentials.access_key_id`
-    - `kinesis.credentials.secret` -> `aws.credentials.secret_access_key`
-    - `kinesis.credentials.session_token` -> `aws.credentials.session_token`
-    - `kinesis.assumerole.arn` -> `aws.credentials.role.arn`
-    - `kinesis.assumerole.external_id` -> `aws.credentials.role.external_id`
-  - Pulsar
-    - `pulsar.topic` -> `topic`
-    - `pulsar.admin.url` -> `admin.url`
-    - `pulsar.service.url` -> `service.url`
-    - `pulsar.scan.startup.mode` -> `scan.startup.mode`
-    - `pulsar.time.offset` -> `scan.startup.timestamp_millis`
-
-- The row format name, `debezium json`, for CDC stream sources, has been renamed to `debezium_json`. [#4494](https://github.com/risingwavelabs/risingwave/pull/4494)
+    * Kinesis
+        * `kinesis.stream.name` -> `stream`
+        * `kinesis.stream.region` -> `aws.region`
+        * `kinesis.endpoint` -> `endpoint`
+        * `kinesis.credentials.access` -> `aws.credentials.access_key_id`
+        * `kinesis.credentials.secret` -> `aws.credentials.secret_access_key`
+        * `kinesis.credentials.session_token` -> `aws.credentials.session_token`
+        * `kinesis.assumerole.arn` -> `aws.credentials.role.arn`
+        * `kinesis.assumerole.external_id` -> `aws.credentials.role.external_id`
+    * Pulsar
+        * `pulsar.topic` -> `topic`
+        * `pulsar.admin.url` -> `admin.url`
+        * `pulsar.service.url` -> `service.url`
+        * `pulsar.scan.startup.mode` -> `scan.startup.mode`
+        * `pulsar.time.offset` -> `scan.startup.timestamp_millis`
+* The row format name, `debezium json`, for CDC stream sources, has been renamed to `debezium_json`. [#4494](https://github.com/risingwavelabs/risingwave/pull/4494)
 
 #### Configuration changes
 
-- The default batch query execution mode was changed from distributed to local. [#4789](https://github.com/risingwavelabs/risingwave/pull/4789)
+* The default batch query execution mode was changed from distributed to local. [#4789](https://github.com/risingwavelabs/risingwave/pull/4789)
+
 
 ### Assets
 
-- Run this version from Docker:
-  `docker run -it --pull=always -p 4566:4566 -p 5691:5691 ghcr.io/risingwavelabs/risingwave:v0.1.12 playground`
-- Prebuilt library for Linux is not available in this release.
-- [Source code (zip)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.12.zip)
-- [Source code (tar.gz)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.12.tar.gz)
+* Run this version from Docker:
+    `docker run -it --pull=always -p 4566:4566 -p 5691:5691 ghcr.io/risingwavelabs/risingwave:v0.1.12 playground`
+* Prebuilt library for Linux is not available in this release.
+* [Source code (zip)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.12.zip)
+* [Source code (tar.gz)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.12.tar.gz)
+
+
 
 ## v0.1.11
 
@@ -153,33 +162,37 @@ This version was released on July 29, 2022.
 
 #### SQL features
 
-- New SQL functions:
-  - `overlay()`: Replaces a substring. [#3671](https://github.com/risingwavelabs/risingwave/pull/3671)
-  - `generate_series()`: Generates a series of values from the starting point to the ending point. [#4030](https://github.com/risingwavelabs/risingwave/pull/4030)
-  - `regexp_match()`, `regexp_matches()`: Compares a string against a regular expression pattern and returns matched substrings. [#3702](https://github.com/risingwavelabs/risingwave/pull/3702) [#4062](https://github.com/risingwavelabs/risingwave/pull/4062)
-  - `string_agg ()`: Concatenates the values into a string. [#3952](https://github.com/risingwavelabs/risingwave/pull/3952) [#4183](https://github.com/risingwavelabs/risingwave/pull/4183)
-  - `current_database()`: Returns the current database. [#3650](https://github.com/risingwavelabs/risingwave/pull/3650)
-- New SQL commands:
-  - `SHOW ALL`: Lists all configuration parameters. Use `SHOW parameter` to show the value of a configuration parameter. [#3694](https://github.com/risingwavelabs/risingwave/pull/3694) [#3664](https://github.com/risingwavelabs/risingwave/pull/3664)
-  - `CREATE SINK`: Sinks data to Kafka. [#3923](https://github.com/risingwavelabs/risingwave/pull/3923) [#3682](https://github.com/risingwavelabs/risingwave/pull/3682) [#3674](https://github.com/risingwavelabs/risingwave/pull/3674)
-  - `EXPLAIN TRACE`: Traces each optimization stage of the optimizer. [#3945](https://github.com/risingwavelabs/risingwave/pull/3945)
-- Support for lookup joins. Currently, lookup joins can only be performed in local query mode. To use lookup joins, users need to set the configuration parameter `rw_batch_enable_lookup_join` to true. [#3859](https://github.com/risingwavelabs/risingwave/pull/3859) [#3763](https://github.com/risingwavelabs/risingwave/pull/3763)
-- An `ORDER BY` clause in the `CREATE MATERIALIZED VIEW` statement is allowed but not considered as part of the definition of the materialized view. It is only used in the initial creation of the materialized view. It is not used during refreshes. This is a behavior change due to the introduction of parallel table scans. [#3670](https://github.com/risingwavelabs/risingwave/pull/3670)
-- Support for filter clauses on aggregate functions. [#4114](https://github.com/risingwavelabs/risingwave/pull/4114)
+* New SQL functions:
+    * `overlay()`: Replaces a substring. [#3671](https://github.com/risingwavelabs/risingwave/pull/3671)
+    * `generate_series()`: Generates a series of values from the starting point to the ending point. [#4030](https://github.com/risingwavelabs/risingwave/pull/4030)
+    * `regexp_match()`, `regexp_matches()`: Compares a string against a regular expression pattern and returns matched substrings. [#3702](https://github.com/risingwavelabs/risingwave/pull/3702) [#4062](https://github.com/risingwavelabs/risingwave/pull/4062)
+    * `string_agg ()`: Concatenates the values into a string. [#3952](https://github.com/risingwavelabs/risingwave/pull/3952) [#4183](https://github.com/risingwavelabs/risingwave/pull/4183)
+    * `current_database()`: Returns the current database.  [#3650](https://github.com/risingwavelabs/risingwave/pull/3650)
+* New SQL commands:
+    * `SHOW ALL`: Lists all configuration parameters. Use `SHOW parameter` to show the value of a configuration parameter. [#3694](https://github.com/risingwavelabs/risingwave/pull/3694) [#3664](https://github.com/risingwavelabs/risingwave/pull/3664)
+    * `CREATE SINK`: Sinks data to Kafka. [#3923](https://github.com/risingwavelabs/risingwave/pull/3923) [#3682](https://github.com/risingwavelabs/risingwave/pull/3682) [#3674](https://github.com/risingwavelabs/risingwave/pull/3674)
+    * `EXPLAIN TRACE`: Traces each optimization stage of the optimizer. [#3945](https://github.com/risingwavelabs/risingwave/pull/3945)
+* Support for lookup joins. Currently, lookup joins can only be performed in local query mode. To use lookup joins, users need to set the configuration parameter `rw_batch_enable_lookup_join`  to true.  [#3859](https://github.com/risingwavelabs/risingwave/pull/3859) [#3763](https://github.com/risingwavelabs/risingwave/pull/3763)
+* An `ORDER BY` clause in the `CREATE MATERIALIZED VIEW` statement is allowed but not considered as part of the definition of the materialized view. It is only used in the initial creation of the materialized view. It is not used during refreshes. This is a behavior change due to the introduction of parallel table scans. [#3670](https://github.com/risingwavelabs/risingwave/pull/3670)
+* Support for filter clauses on aggregate functions. [#4114](https://github.com/risingwavelabs/risingwave/pull/4114)
 
 #### Connectors
 
-- RisingWave can now sink data to Kafka topics in append-only mode and Debezium mode. [#3923](https://github.com/risingwavelabs/risingwave/pull/3923) [#3682](https://github.com/risingwavelabs/risingwave/pull/3682) [#3674](https://github.com/risingwavelabs/risingwave/pull/3674)
-- Syntax change for `CREATE SOURCE`: A parameter name is no longer wrapped by single quotation marks. [#3997](https://github.com/risingwavelabs/risingwave/pull/3997). See the example:
-  - Old: `CREATE SOURCE s1 WITH ( 'connector' = 'kafka', 'kafka.topic' = 'kafka_1_partition_topic', 'kafka.brokers' = '127.0.0.1:29092' ) ROW FORMAT json;`
-  - New: `CREATE SOURCE s WITH ( connector = 'kafka', kafka.topic = 'kafka_1_partition_topic', kafka.brokers = '127.0.0.1:29092' ) ROW FORMAT json;`
+* RisingWave can now sink data to Kafka topics in append-only mode and Debezium mode. [#3923](https://github.com/risingwavelabs/risingwave/pull/3923) [#3682](https://github.com/risingwavelabs/risingwave/pull/3682) [#3674](https://github.com/risingwavelabs/risingwave/pull/3674)
+* Syntax change for `CREATE SOURCE`: A parameter name is no longer wrapped by single quotation marks. [#3997](https://github.com/risingwavelabs/risingwave/pull/3997). See the example:
+    * Old: `CREATE SOURCE s1 WITH ( 'connector' = 'kafka', 'kafka.topic' = 'kafka_1_partition_topic', 'kafka.brokers' = '127.0.0.1:29092' ) ROW FORMAT json;`  
+    * New: `CREATE SOURCE s WITH ( connector = 'kafka', kafka.topic = 'kafka_1_partition_topic', kafka.brokers = '127.0.0.1:29092' ) ROW FORMAT json;`
+
 
 ### Assets
 
-- Run this version from Docker: <br/>`run -it --pull=always -p 4566:4566 -p 5691:5691 ghcr.io/risingwavelabs/risingwave:v0.1.11 playground`
-- [Prebuilt library for Linux](https://github.com/risingwavelabs/risingwave/releases/download/v0.1.11/risingwave-v0.1.11-x86_64-unknown-linux.tar.gz)
-- [Source code (zip)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.11.zip)
-- [Source code (tar.gz)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.11.tar.gz)
+* Run this version from Docker: <br/>`run -it --pull=always -p 4566:4566 -p 5691:5691 ghcr.io/risingwavelabs/risingwave:v0.1.11 playground`
+* [Prebuilt library for Linux](https://github.com/risingwavelabs/risingwave/releases/download/v0.1.11/risingwave-v0.1.11-x86_64-unknown-linux.tar.gz)
+* [Source code (zip)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.11.zip)
+* [Source code (tar.gz)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.11.tar.gz)
+
+
+
 
 ## v0.1.10
 
@@ -191,47 +204,47 @@ This version was released on July 5, 2022.
 
 ##### SQL operators and functions
 
-- Support string concatenation operator `||`. [#3147](https://github.com/risingwavelabs/risingwave/pull/3147)
-- Support interval comparison. [#3222](https://github.com/risingwavelabs/risingwave/pull/3222)
-- Support dividing intervals by integers, floats, or decimals. [#3441](https://github.com/risingwavelabs/risingwave/pull/3441)
-- Intervals multiplying intervals by floats. [#3641](https://github.com/risingwavelabs/risingwave/pull/3641)
-- Support more temporal operations. [#3472](https://github.com/risingwavelabs/risingwave/pull/3472)
-- Support Common Table Expressions (CTEs) as input of time window functions. [#3188](https://github.com/risingwavelabs/risingwave/pull/3188)
-- Add these new functions:
-  - `concat()` for concatenating strings [#3091](https://github.com/risingwavelabs/risingwave/pull/3091)
-  - `repeat()` for repeating string [#3148](https://github.com/risingwavelabs/risingwave/pull/3148)
-  - `octet_length()` and bit_length() for getting string length [#3526](https://github.com/risingwavelabs/risingwave/pull/3526)
-  - `Row()` for constructing rows [#2914](https://github.com/risingwavelabs/risingwave/pull/2914) [#3152](https://github.com/risingwavelabs/risingwave/pull/3152)
-  - `pg_typeof()` for getting data types of values [#3494](https://github.com/risingwavelabs/risingwave/pull/3494)
-  - `current_database()` for getting the name of the current database in the session [#3650](https://github.com/risingwavelabs/risingwave/pull/3650)
-  - `approx_count_distinct()` for distinct counting [#3121](https://github.com/risingwavelabs/risingwave/pull/3121)
-  - `unnest()` for expanding nested tables to rows [#3017](https://github.com/risingwavelabs/risingwave/pull/3017)
-- Support `count()`, `min()`, and `max()` functions on these data types: _interval_, _timestamp_, _varchar_, and _date_. [#3069](https://github.com/risingwavelabs/risingwave/pull/3069)
+* Support string concatenation operator `||`. [#3147](https://github.com/risingwavelabs/risingwave/pull/3147)
+* Support interval comparison. [#3222](https://github.com/risingwavelabs/risingwave/pull/3222)
+* Support dividing intervals by integers, floats, or decimals. [#3441](https://github.com/risingwavelabs/risingwave/pull/3441)
+* Intervals multiplying intervals by floats. [#3641](https://github.com/risingwavelabs/risingwave/pull/3641)
+* Support more temporal operations. [#3472](https://github.com/risingwavelabs/risingwave/pull/3472)
+* Support Common Table Expressions (CTEs) as input of time window functions. [#3188](https://github.com/risingwavelabs/risingwave/pull/3188)
+* Add these new functions:
+    * `concat()` for concatenating strings [#3091](https://github.com/risingwavelabs/risingwave/pull/3091)
+    * `repeat()` for repeating string [#3148](https://github.com/risingwavelabs/risingwave/pull/3148)
+    * `octet_length()` and bit_length() for getting string length [#3526](https://github.com/risingwavelabs/risingwave/pull/3526)
+    * `Row()` for constructing rows [#2914](https://github.com/risingwavelabs/risingwave/pull/2914) [#3152](https://github.com/risingwavelabs/risingwave/pull/3152)
+    * `pg_typeof()` for getting data types of values [#3494](https://github.com/risingwavelabs/risingwave/pull/3494)
+    * `current_database()` for getting the name of the current database in the session [#3650](https://github.com/risingwavelabs/risingwave/pull/3650)
+    * `approx_count_distinct()` for distinct counting [#3121](https://github.com/risingwavelabs/risingwave/pull/3121)
+    * `unnest()` for expanding nested tables to rows [#3017](https://github.com/risingwavelabs/risingwave/pull/3017) 
+* Support `count()`, `min()`, and `max()` functions on these data types: *interval*, *timestamp*, *varchar*, and *date*. [#3069](https://github.com/risingwavelabs/risingwave/pull/3069)
 
 ##### SQL commands
 
-- Support `EXPLAIN CREATE INDEX`. [#3229](https://github.com/risingwavelabs/risingwave/pull/3229)
-- Add cascade and restrict options in `REVOKE` commands. [#3363](https://github.com/risingwavelabs/risingwave/pull/3363)
-- Expand the `CREATE TABLE` syntax to support creating append-only tables. [#3058](https://github.com/risingwavelabs/risingwave/pull/3058)
-- Support the `CREATE USER` command and user authentication. [#3074](https://github.com/risingwavelabs/risingwave/pull/3074)
+* Support `EXPLAIN CREATE INDEX`. [#3229](https://github.com/risingwavelabs/risingwave/pull/3229)
+* Add cascade and restrict options in `REVOKE` commands. [#3363](https://github.com/risingwavelabs/risingwave/pull/3363)
+* Expand the `CREATE TABLE` syntax to support creating append-only tables. [#3058](https://github.com/risingwavelabs/risingwave/pull/3058)
+* Support the `CREATE USER` command and user authentication. [#3074](https://github.com/risingwavelabs/risingwave/pull/3074)
 
 ##### Data types
 
-- Support implicit casts from single-quoted literals. [#3487](https://github.com/risingwavelabs/risingwave/pull/3487)
-- Add string as an alias for data type varchar. [#3094](https://github.com/risingwavelabs/risingwave/pull/3094)
-- Support string intervals. [#3037](https://github.com/risingwavelabs/risingwave/pull/3037)
+* Support implicit casts from single-quoted literals. [#3487](https://github.com/risingwavelabs/risingwave/pull/3487)
+* Add string as an alias for data type varchar.  [#3094](https://github.com/risingwavelabs/risingwave/pull/3094)
+* Support string intervals.  [#3037](https://github.com/risingwavelabs/risingwave/pull/3037)
 
 ##### Database management
 
-- Add the default super user “postgres”. [#3127](https://github.com/risingwavelabs/risingwave/pull/3127)
-- The default schema name is changed to “public” from “dev”. [#3166](https://github.com/risingwavelabs/risingwave/pull/3166)
+* Add the default super user “postgres”.  [#3127](https://github.com/risingwavelabs/risingwave/pull/3127)
+* The default schema name is changed to “public” from “dev”.  [#3166](https://github.com/risingwavelabs/risingwave/pull/3166)
 
 #### Connectors
 
-- Add random seed for the Datagen Source Connector. [#3124](https://github.com/risingwavelabs/risingwave/pull/3124)
+* Add random seed for the Datagen Source Connector. [#3124](https://github.com/risingwavelabs/risingwave/pull/3124)
 
 ### Assets
 
-- [Prebuilt library for Linux](https://github.com/risingwavelabs/risingwave/releases/download/v0.1.10/risingwave-v0.1.10-x86_64-unknown-linux.tar.gz)
-- [Source code (zip)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.10.zip)
-- [Source code (tar.gz)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.10.tar.gz)
+* [Prebuilt library for Linux](https://github.com/risingwavelabs/risingwave/releases/download/v0.1.10/risingwave-v0.1.10-x86_64-unknown-linux.tar.gz) 
+* [Source code (zip)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.10.zip)
+* [Source code (tar.gz)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.1.10.tar.gz)

--- a/src/theme/DefaultNotify/index.tsx
+++ b/src/theme/DefaultNotify/index.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from "react";
+import { Popover } from "react-tiny-popover";
+import "./style.css";
+import { useColorMode } from "@docusaurus/theme-common";
+import { toast } from "react-toastify";
+import { postNotification } from "../../api/feedback";
+
+type Props = {
+  note: string;
+  text: string;
+  block?: boolean;
+};
+
+function DefaultNotify({ note, text, block }: Props) {
+  const [shown, setShown] = useState(false);
+  const { isDarkTheme } = useColorMode();
+  const [dark, setDark] = useState(false);
+  const [email, setEmail] = useState("");
+
+  useEffect(() => {
+    setDark(isDarkTheme);
+  }, [isDarkTheme]);
+
+  const getNotify = () => {
+    const emailValid = email.match(/^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/i);
+    if (!emailValid) {
+      toast.error("Email address is invalid!");
+      return;
+    }
+
+    postNotification(email, note)
+      .then(() => {
+        toast.success("Congratulation! You have subscribed this feature.");
+        setShown(false);
+      })
+      .catch((err) => {
+        if (err.response) toast.info(err.response.data.msg ?? "Something went wrong :(");
+        else if (err.request) toast.error("Something went wrong :(");
+      })
+      .finally(() => setEmail(""));
+  };
+
+  return (
+    <Popover
+      isOpen={shown}
+      positions={["bottom"]}
+      align="start"
+      onClickOutside={() => setShown(false)}
+      content={
+        <div className="mt-2 -ml-2">
+          <form className="searchbox-wrap">
+            <input
+              type="email"
+              placeholder="Email address"
+              value={email}
+              required
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <button
+              type="submit"
+              onClick={(e) => {
+                e.preventDefault();
+                getNotify();
+              }}
+            >
+              <span>Notify me</span>
+            </button>
+          </form>
+        </div>
+      }
+    >
+      <button className={block ? "default block" : "default"} onClick={() => setShown(!shown)}>
+        {text}
+      </button>
+    </Popover>
+  );
+}
+
+export default DefaultNotify;

--- a/src/theme/DefaultNotify/index.tsx
+++ b/src/theme/DefaultNotify/index.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Popover } from "react-tiny-popover";
 import "./style.css";
-import { useColorMode } from "@docusaurus/theme-common";
 import { toast } from "react-toastify";
 import { postNotification } from "../../api/feedback";
 

--- a/src/theme/DefaultNotify/index.tsx
+++ b/src/theme/DefaultNotify/index.tsx
@@ -13,13 +13,8 @@ type Props = {
 
 function DefaultNotify({ note, text, block }: Props) {
   const [shown, setShown] = useState(false);
-  const { isDarkTheme } = useColorMode();
-  const [dark, setDark] = useState(false);
   const [email, setEmail] = useState("");
-
-  useEffect(() => {
-    setDark(isDarkTheme);
-  }, [isDarkTheme]);
+  const [valid, setValid] = useState(false);
 
   const getNotify = () => {
     const emailValid = email.match(/^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/i);
@@ -47,26 +42,21 @@ function DefaultNotify({ note, text, block }: Props) {
       align="start"
       onClickOutside={() => setShown(false)}
       content={
-        <div className="mt-2 -ml-2">
-          <form className="searchbox-wrap">
-            <input
-              type="email"
-              placeholder="Email address"
-              value={email}
-              required
-              onChange={(e) => setEmail(e.target.value)}
-            />
-            <button
-              type="submit"
-              onClick={(e) => {
-                e.preventDefault();
-                getNotify();
-              }}
-            >
-              <span>Notify me</span>
-            </button>
-          </form>
-        </div>
+        <form className={valid ? "newsletter-form valid mt-2" : "newsletter-form mt-2"}>
+          <input
+            type="email"
+            placeholder="Email address"
+            value={email}
+            required
+            onChange={(e) => {
+              setEmail(e.target.value);
+              setValid(!!e.target.value.match(/^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/i));
+            }}
+          />
+          <button type="submit" disabled={!valid} onClick={getNotify}>
+            <span className=""> Notify Me </span>
+          </button>
+        </form>
       }
     >
       <button className={block ? "default block" : "default"} onClick={() => setShown(!shown)}>

--- a/src/theme/DefaultNotify/style.css
+++ b/src/theme/DefaultNotify/style.css
@@ -1,0 +1,7 @@
+.mt-2 {
+  margin-top: 4px;
+}
+
+.-ml-2 {
+  margin-left: -4px;
+}

--- a/src/theme/LightNotify/index.tsx
+++ b/src/theme/LightNotify/index.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Popover } from "react-tiny-popover";
 import "./style.css";
-import { useColorMode } from "@docusaurus/theme-common";
 import { toast } from "react-toastify";
 import { postNotification } from "../../api/feedback";
 

--- a/src/theme/LightNotify/index.tsx
+++ b/src/theme/LightNotify/index.tsx
@@ -13,13 +13,8 @@ type Props = {
 
 function LightNotify({ note, text, block }: Props) {
   const [shown, setShown] = useState(false);
-  const { isDarkTheme } = useColorMode();
-  const [dark, setDark] = useState(false);
   const [email, setEmail] = useState("");
-
-  useEffect(() => {
-    setDark(isDarkTheme);
-  }, [isDarkTheme]);
+  const [valid, setValid] = useState(false);
 
   const getNotify = () => {
     const emailValid = email.match(/^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/i);
@@ -47,26 +42,21 @@ function LightNotify({ note, text, block }: Props) {
       align="start"
       onClickOutside={() => setShown(false)}
       content={
-        <div className="mt-2 -ml-2">
-          <form className="searchbox-wrap light-shadow">
-            <input
-              type="email"
-              placeholder="Email address"
-              value={email}
-              required
-              onChange={(e) => setEmail(e.target.value)}
-            />
-            <button
-              type="submit"
-              onClick={(e) => {
-                e.preventDefault();
-                getNotify();
-              }}
-            >
-              <span>Notify me</span>
-            </button>
-          </form>
-        </div>
+        <form className={valid ? "newsletter-form valid mt-2" : "newsletter-form mt-2"}>
+          <input
+            type="email"
+            placeholder="Email address"
+            value={email}
+            required
+            onChange={(e) => {
+              setEmail(e.target.value);
+              setValid(!!e.target.value.match(/^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/i));
+            }}
+          />
+          <button type="submit" disabled={!valid} onClick={getNotify}>
+            <span className=""> Notify Me </span>
+          </button>
+        </form>
       }
     >
       <button className={block ? "light block" : "light"} onClick={() => setShown(!shown)}>

--- a/src/theme/LightNotify/index.tsx
+++ b/src/theme/LightNotify/index.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from "react";
+import { Popover } from "react-tiny-popover";
+import "./style.css";
+import { useColorMode } from "@docusaurus/theme-common";
+import { toast } from "react-toastify";
+import { postNotification } from "../../api/feedback";
+
+type Props = {
+  note: string;
+  text: string;
+  block?: boolean;
+};
+
+function LightNotify({ note, text, block }: Props) {
+  const [shown, setShown] = useState(false);
+  const { isDarkTheme } = useColorMode();
+  const [dark, setDark] = useState(false);
+  const [email, setEmail] = useState("");
+
+  useEffect(() => {
+    setDark(isDarkTheme);
+  }, [isDarkTheme]);
+
+  const getNotify = () => {
+    const emailValid = email.match(/^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/i);
+    if (!emailValid) {
+      toast.error("Email address is invalid!");
+      return;
+    }
+
+    postNotification(email, note)
+      .then(() => {
+        toast.success("Congratulation! You have subscribed this feature.");
+        setShown(false);
+      })
+      .catch((err) => {
+        if (err.response) toast.info(err.response.data.msg ?? "Something went wrong :(");
+        else if (err.request) toast.error("Something went wrong :(");
+      })
+      .finally(() => setEmail(""));
+  };
+
+  return (
+    <Popover
+      isOpen={shown}
+      positions={["bottom"]}
+      align="start"
+      onClickOutside={() => setShown(false)}
+      content={
+        <div className="mt-2 -ml-2">
+          <form className="searchbox-wrap light-shadow">
+            <input
+              type="email"
+              placeholder="Email address"
+              value={email}
+              required
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <button
+              type="submit"
+              onClick={(e) => {
+                e.preventDefault();
+                getNotify();
+              }}
+            >
+              <span>Notify me</span>
+            </button>
+          </form>
+        </div>
+      }
+    >
+      <button className={block ? "light block" : "light"} onClick={() => setShown(!shown)}>
+        {text}
+      </button>
+    </Popover>
+  );
+}
+
+export default LightNotify;

--- a/src/theme/LightNotify/style.css
+++ b/src/theme/LightNotify/style.css
@@ -1,0 +1,3 @@
+.light-shadow {
+  box-shadow: rgb(0 0 0 / 19%) 0px 0px 4px 1px, rgb(0 0 0 / 19%) 1px 1px 5px -1px;
+}

--- a/src/theme/MDXComponents/index.js
+++ b/src/theme/MDXComponents/index.js
@@ -16,6 +16,8 @@ import RollButton from "@theme/RollButton";
 import DefaultButton from "@theme/DefaultButton";
 import LightButton from "@theme/LightButton";
 import NotifyButton from "@theme/NotifyButton";
+import DefaultNotify from "@theme/DefaultNotify";
+import LightNotify from "@theme/LightNotify";
 
 function unwrapMDXElement(element) {
   if (element?.props?.mdxType && element?.props?.originalType) {
@@ -72,5 +74,7 @@ const MDXComponents = {
   notifyButton: NotifyButton,
   defaultButton: DefaultButton,
   lightButton: LightButton,
+  defaultNotify: DefaultNotify,
+  lightNotify: LightNotify,
 };
 export default MDXComponents;

--- a/src/theme/NotifyButton/index.tsx
+++ b/src/theme/NotifyButton/index.tsx
@@ -11,13 +11,8 @@ type Props = {
 
 function NotifyButton({ note }: Props) {
   const [shown, setShown] = useState(false);
-  const { isDarkTheme } = useColorMode();
-  const [dark, setDark] = useState(false);
+  const [valid, setValid] = useState(false);
   const [email, setEmail] = useState("");
-
-  useEffect(() => {
-    setDark(isDarkTheme);
-  }, [isDarkTheme]);
 
   const getNotify = () => {
     const emailValid = email.match(/^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/i);
@@ -45,26 +40,21 @@ function NotifyButton({ note }: Props) {
       align="start"
       onClickOutside={() => setShown(false)}
       content={
-        <div className="">
-          <form className="searchbox-wrap">
-            <input
-              type="email"
-              placeholder="Email address"
-              value={email}
-              required
-              onChange={(e) => setEmail(e.target.value)}
-            />
-            <button
-              type="submit"
-              onClick={(e) => {
-                e.preventDefault();
-                getNotify();
-              }}
-            >
-              <span>Notify me</span>
-            </button>
-          </form>
-        </div>
+        <form className={valid ? "newsletter-form valid" : "newsletter-form"}>
+          <input
+            type="email"
+            placeholder="Email address"
+            value={email}
+            required
+            onChange={(e) => {
+              setEmail(e.target.value);
+              setValid(!!e.target.value.match(/^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/i));
+            }}
+          />
+          <button type="submit" disabled={!valid} onClick={getNotify}>
+            <span className=""> Notify Me </span>
+          </button>
+        </form>
       }
     >
       <div className="notify-button" onClick={() => setShown(!shown)}>

--- a/src/theme/NotifyButton/style.css
+++ b/src/theme/NotifyButton/style.css
@@ -99,12 +99,21 @@
 
 .searchbox-wrap input:focus {
   outline: none;
+  border: none;
+  margin: 0;
+  background-color: field;
+}
+
+[data-theme="dark"] .searchbox-wrap button {
+  outline: none;
+  border: none;
+  margin: 0;
   background-color: field;
 }
 
 .searchbox-wrap button {
   margin: 0;
-  padding-right: 6px;
+  padding-right: 4px;
   background-color: #fff;
   -webkit-border-top-right-radius: 18px;
   -webkit-border-bottom-right-radius: 18px;
@@ -115,10 +124,6 @@
   border: none;
   cursor: pointer;
   cursor: hand;
-}
-
-[data-theme="dark"] .searchbox-wrap button {
-  background-color: field;
 }
 
 .searchbox-wrap button span {
@@ -136,4 +141,152 @@
 .searchbox-wrap button span:hover {
   background-color: #6c7ff2;
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.19);
+}
+
+.newsletter-form {
+  --primary: #6386e6;
+  --primary-dark: #2055ee;
+  --primary-darkest: #133fc0;
+  --input-placeholder: #a6accd;
+  --input-text: #646b8c;
+  --border-default: #e1e6f9;
+  --border-active: #275efe;
+  --background: #fff;
+  --button-text: #ffffff;
+  --success: #275efe;
+  --trails: rgba(39, 94, 254, 0.15);
+  display: flex;
+  align-items: center;
+  max-width: 300px;
+  width: 100%;
+  background: var(--background);
+  box-shadow: inset 0 0 0 var(--border-width, 1px) var(--border, var(--border-default));
+  border-radius: 9px;
+  padding-right: 4px;
+  transition: box-shadow 0.25s;
+}
+
+[data-theme="dark"] .newsletter-form {
+  background-color: #181a1b;
+}
+
+.newsletter-form input:-webkit-autofill {
+  -webkit-text-fill-color: var(--input-text) !important;
+  transition: background-color 5000s ease-in-out 0s;
+}
+
+.newsletter-form input,
+.newsletter-form button {
+  -webkit-appearance: none;
+  background: none;
+  outline: none;
+  display: block;
+  border: none;
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 24px;
+  margin: 0;
+}
+
+.newsletter-form input {
+  width: 100%;
+  flex-grow: 1;
+  padding: 12px 12px 12px 16px;
+  color: var(--input-text);
+  font-weight: 400;
+}
+
+.newsletter-form input::-moz-placeholder {
+  color: var(--input-placeholder);
+}
+
+.newsletter-form input:-ms-input-placeholder {
+  color: var(--input-placeholder);
+}
+
+.newsletter-form input::placeholder {
+  color: var(--input-placeholder);
+}
+
+.newsletter-form button {
+  --text-opacity: 1;
+  --success-x: -12px;
+  --success-stroke: 14px;
+  --success-opacity: 0;
+  --border-radius: 7px;
+  --overflow: hidden;
+  --x: 0px;
+  --y: 0px;
+  --rotate: 0deg;
+  --plane-x: 0px;
+  --plane-y: 0px;
+  --plane-opacity: 1;
+  --trails-stroke: 57px;
+  --left-wing-background: var(--primary);
+  --left-wing-first-x: 0%;
+  --left-wing-first-y: 0%;
+  --left-wing-second-x: 50%;
+  --left-wing-second-y: 0%;
+  --left-wing-third-x: 0%;
+  --left-wing-third-y: 100%;
+  --left-body-background: var(--primary);
+  --left-body-first-x: 50%;
+  --left-body-first-y: 0%;
+  --left-body-second-x: 50%;
+  --left-body-second-y: 100%;
+  --left-body-third-x: 0%;
+  --left-body-third-y: 100%;
+  --right-wing-background: var(--primary);
+  --right-wing-first-x: 50%;
+  --right-wing-first-y: 0%;
+  --right-wing-second-x: 100%;
+  --right-wing-second-y: 0%;
+  --right-wing-third-x: 100%;
+  --right-wing-third-y: 100%;
+  --right-body-background: var(--primary);
+  --right-body-first-x: 50%;
+  --right-body-first-y: 0%;
+  --right-body-second-x: 50%;
+  --right-body-second-y: 100%;
+  --right-body-third-x: 100%;
+  --right-body-third-y: 100%;
+  position: relative;
+  padding: 8px 0;
+  min-width: 100px;
+  text-align: center;
+  font-weight: 500;
+  cursor: var(--button-cursor, not-allowed);
+  filter: var(--button-filter, grayscale(65%));
+  color: var(--button-text);
+  border-radius: var(--border-radius);
+  transform: translateZ(0);
+  transition: opacity 0.25s, filter 0.25s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.newsletter-form button {
+  background-color: var(--primary);
+}
+
+.newsletter-form.valid button:hover {
+  background-color: #3d67d7;
+}
+
+.newsletter-form button .plane,
+.newsletter-form button .trails {
+  pointer-events: none;
+  position: absolute;
+}
+
+.newsletter-form button span {
+  display: block;
+  position: relative;
+  z-index: 4;
+  opacity: var(--text-opacity);
+}
+
+.newsletter-form.valid {
+  --button-opacity: 1;
+  --button-cursor: pointer;
+  --button-filter: grayscale(0%);
 }

--- a/src/theme/NotifyButton/style.css
+++ b/src/theme/NotifyButton/style.css
@@ -168,6 +168,7 @@
 
 [data-theme="dark"] .newsletter-form {
   background-color: #181a1b;
+  box-shadow: inset 0 0 0 var(--border-width, 1px) #747986;
 }
 
 .newsletter-form input:-webkit-autofill {

--- a/src/theme/NotifyButton/style.css
+++ b/src/theme/NotifyButton/style.css
@@ -104,7 +104,7 @@
 
 .searchbox-wrap button {
   margin: 0;
-  padding-right: 10px;
+  padding-right: 6px;
   background-color: #fff;
   -webkit-border-top-right-radius: 18px;
   -webkit-border-bottom-right-radius: 18px;


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
- added two buttons: light notify button and default notify button

- **Related code PR**: 

- **Related doc issue**: 
Resolves /

- **Notes**: 
- 
Usage:

```
<defaultNotify note="hello" text="defaultNotify"/>
<lightNotify note="hello" text="lightNotify" block/>
```


<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
