### PR TITLE
feat: swizzle the docs version banner

### DIFF
--- a/src/theme/DocVersionBanner/index.js
+++ b/src/theme/DocVersionBanner/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import DocVersionBanner from '@theme-original/DocVersionBanner';
+
+export default function DocVersionBannerWrapper(props) {
+  return (
+    <>
+      <DocVersionBanner {...props} />
+      {/* TODO: custom styles of the docs verions banner */}
+    </>
+  );
+}


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
- swizzle the docs version banner to allow banner customization

- **Related code PR**: 

- **Related doc issue**: 

- **Notes**: 


<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
