### PR TITLE
fix: incorrect kubectl flags in kubernetes page

### DIFF
--- a/docs/deploy/risingwave-kubernetes.md
+++ b/docs/deploy/risingwave-kubernetes.md
@@ -102,7 +102,7 @@ RisingWave supports using Amazon S3 as the object storage.
 1. Create a Secret with the name ‘s3-credentials’.
 
     ```shell
-    kubectl create secret generic s3-credentials —from-literal AccessKeyID=${ACCESS_KEY} —from-literal SecretAccessKey=${SECRET_ACCESS_KEY} —from-literal Region=${AWS_REGION}
+    kubectl create secret generic s3-credentials --from-literal AccessKeyID=${ACCESS_KEY} --from-literal SecretAccessKey=${SECRET_ACCESS_KEY} --from-literal Region=${AWS_REGION}
     ```
 
 1. On the S3 console, [create a bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html) with the name ‘hummock001’.


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
`etcd + s3` section in https://www.risingwave.dev/docs/latest/risingwave-kubernetes/#deploy-a-risingwave-instance
change kubectl command flags from `—from-literal` to `--from-literal`
check: https://kubernetes.io/docs/concepts/configuration/secret/#use-case-pods-with-prod-test-credentials

- **Related code PR**: 
[ Provide the link to the code PR here. For example, https://github.com/risingwavelabs/risingwave/pull/4085. Delete this part if there's no code PR related. ]

- **Related doc issue**: 
Resolves [ Provide the link to the doc issue here. ]

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>


## Published doc pages
https://pr-429.d2fbku9n2b6wde.amplifyapp.com/docs/latest/risingwave-kubernetes/
