### PR TITLE
fix: switch path to latest

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,7 +36,7 @@ const config = {
             },
             "0.1.14": {
               label: "0.1.14 (current)",
-              path: "/current",
+              path: "/latest",
               badge: false,
               banner: "none",
             },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 export default function Home() {
   useEffect(() => {
-    window.location.href = window.location.href + "docs/current/intro";
+    window.location.href = window.location.href + "docs/latest/intro";
     // window.location.href = window.location.href + "landing";
   }, []);
 

--- a/src/pages/landing/index.js
+++ b/src/pages/landing/index.js
@@ -57,7 +57,7 @@ function HomepageHeader() {
         <SVGText width="250" height="100" fill={dark ? "#fff" : "#000"} />
       </div>
       <ButtonGroup windoWidth={windowSize.width}>
-        <Link to={`/docs/current/intro`}>
+        <Link to={`/docs/latest/intro`}>
           <Button variant="contained" sx={{ width: 200, margin: "5px", textTransform: "none" }}>
             <Translate>Docs</Translate>
           </Button>

--- a/src/theme/DocVersionBanner/index.js
+++ b/src/theme/DocVersionBanner/index.js
@@ -6,7 +6,7 @@ export default function DocVersionBannerWrapper(props) {
   const [shown, setShown] = useState(false);
 
   useEffect(() => {
-    if (!location.pathname.includes("current")) {
+    if (!location.pathname.includes("latest")) {
       setShown(true);
     }
   }, [location.pathname]);
@@ -20,9 +20,9 @@ export default function DocVersionBannerWrapper(props) {
         >
           <div>You are viewing the documentation of an unreleased version of RisingWave.</div>
           <b>
-            <a href={`/docs/current/${location.pathname.split("/").at(-2)}`}>
+            <a href={`/docs/latest/${location.pathname.split("/").at(-2)}`}>
               {" "}
-              Switch to the current public release →
+              Switch to the latest public release →
             </a>
           </b>
         </div>


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Switch `current` version's path to `/latest`

- **Related code PR**: 

- **Related doc issue**: 
Resolves 

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
