### PR TITLE
fix: redirect latest to current

### DIFF
--- a/src/theme/DocVersionBanner/index.js
+++ b/src/theme/DocVersionBanner/index.js
@@ -6,7 +6,8 @@ export default function DocVersionBannerWrapper(props) {
   const [shown, setShown] = useState(false);
 
   useEffect(() => {
-    if (!location.pathname.includes("current")) {
+    const version = location.pathname.split("/")[2];
+    if (version !== "current") {
       setShown(true);
     }
   }, [location.pathname]);

--- a/src/theme/Navbar/index.tsx
+++ b/src/theme/Navbar/index.tsx
@@ -25,7 +25,6 @@ import Logo from "@theme/Logo";
 import IconMenu from "@theme/IconMenu";
 import IconClose from "@theme/IconClose";
 import styles from "./styles.module.css";
-import { useHistory } from "@docusaurus/router";
 
 // retrocompatible with v1
 const DefaultNavItemPosition = "right";
@@ -196,8 +195,6 @@ export default function Navbar(): JSX.Element {
     navbar: { hideOnScroll, style },
   } = useThemeConfig();
 
-  const history = useHistory();
-
   const mobileSidebar = useMobileSidebar();
   const colorModeToggle = useColorModeToggle();
   const activeDocPlugin = useActivePlugin();
@@ -206,16 +203,6 @@ export default function Navbar(): JSX.Element {
   const items = useNavbarItems();
   const hasSearchNavbarItem = items.some((item) => item.type === "search");
   const { leftItems, rightItems } = splitNavItemsByPosition(items);
-
-  useEffect(() => {
-    const paths = location.pathname.split("/");
-    const version = paths[2];
-
-    if (version === "latest") {
-      const res = window.location.href.replace(version, "current");
-      window.location.replace(res);
-    }
-  }, []);
 
   return (
     <nav

--- a/src/theme/Navbar/index.tsx
+++ b/src/theme/Navbar/index.tsx
@@ -25,6 +25,7 @@ import Logo from "@theme/Logo";
 import IconMenu from "@theme/IconMenu";
 import IconClose from "@theme/IconClose";
 import styles from "./styles.module.css";
+import { useHistory } from "@docusaurus/router";
 
 // retrocompatible with v1
 const DefaultNavItemPosition = "right";
@@ -195,6 +196,8 @@ export default function Navbar(): JSX.Element {
     navbar: { hideOnScroll, style },
   } = useThemeConfig();
 
+  const history = useHistory();
+
   const mobileSidebar = useMobileSidebar();
   const colorModeToggle = useColorModeToggle();
   const activeDocPlugin = useActivePlugin();
@@ -203,6 +206,16 @@ export default function Navbar(): JSX.Element {
   const items = useNavbarItems();
   const hasSearchNavbarItem = items.some((item) => item.type === "search");
   const { leftItems, rightItems } = splitNavItemsByPosition(items);
+
+  useEffect(() => {
+    const paths = location.pathname.split("/");
+    const version = paths[2];
+
+    if (version === "latest") {
+      const res = window.location.href.replace(version, "current");
+      window.location.replace(res);
+    }
+  }, []);
 
   return (
     <nav

--- a/src/theme/NotFound.js
+++ b/src/theme/NotFound.js
@@ -1,0 +1,27 @@
+import React, { useEffect } from "react";
+import NotFound from "@theme-original/NotFound";
+import { useHistory, useLocation } from "@docusaurus/router";
+
+export default function NotFoundWrapper(props) {
+  const location = useLocation();
+  const history = useHistory();
+
+  useEffect(() => {
+    const paths = location.pathname.split("/");
+    const version = paths[2];
+    const slug = paths[3];
+
+    if (version === "latest") {
+      const res = window.location.href.replace(version, "current");
+      window.location.replace(res);
+    } else if (version === "current") {
+      history.push(`/docs/current/intro`);
+    }
+  }, []);
+
+  return (
+    <>
+      <NotFound {...props} />
+    </>
+  );
+}


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 


- **Related code PR**: 


- **Related doc issue**: 

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
