### PR TITLE
fix start command

### DIFF
--- a/docs/deploy/risingwave-local.md
+++ b/docs/deploy/risingwave-local.md
@@ -38,7 +38,7 @@ import TabItem from '@theme/TabItem';
 3. Start RisingWave in playground mode.
 
     ```shell
-    ./risedev playground    #Or ./risedev p
+    ./risingwave playground
     ```
 
 </TabItem>
@@ -90,10 +90,10 @@ import TabItem from '@theme/TabItem';
 
 3. Start RisingWave.
 
-    To start RisingWave, in the terminal, navigate to the directory where RisingWave is downloaded, and run the following command.
+    To start RisingWave, in the terminal, navigate to the directory where RisingWave is cloned, and run the following command.
   
     ```shell
-    ./risingwave playground
+    ./risedev playground
     ```
 
 

--- a/docs/deploy/risingwave-local.md
+++ b/docs/deploy/risingwave-local.md
@@ -19,9 +19,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs>
-<TabItem value="library" label="Pre-built library (Linux)">
+<TabItem value="library" label="Pre-built package (Linux)">
 
-1. Download the pre-built library.
+1. Download the pre-built binary.
 
     ```shell
     wget https://github.com/risingwavelabs/risingwave/releases/download/v0.1.14/risingwave-v0.1.14-x86_64-unknown-linux.tar.gz
@@ -29,7 +29,7 @@ import TabItem from '@theme/TabItem';
 
     > You can find previous binary releases in [Release notes](/release-notes.md).
 
-2. Unzip the library.
+2. Unzip the binary.
 
     ```shell
     tar xvf risingwave-v0.1.14-x86_64-unknown-linux.tar.gz
@@ -90,10 +90,10 @@ import TabItem from '@theme/TabItem';
 
 3. Start RisingWave.
 
-    To compile and start RisingWave, you can use RiseDev, the developer tool for RisingWave.
+    To compile and start RisingWave, you can use [RiseDev](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#set-up-the-development-environment), the developer's tool for RisingWave.
   
     ```shell
-    ./risedev playground
+    ./risedev playground    #Or ./risedev p
     ```
 
 

--- a/docs/deploy/risingwave-local.md
+++ b/docs/deploy/risingwave-local.md
@@ -44,10 +44,10 @@ import TabItem from '@theme/TabItem';
 </TabItem>
 <TabItem value="source" label="Build from source (Linux & macOS)">
 
-1. Clone the [risingwave](https://github.com/risingwavelabs/risingwave) repository.
+1. Clone the [risingwave](https://github.com/risingwavelabs/risingwave) repository and enter the directory.
 
     ```shell
-    git clone https://github.com/risingwavelabs/risingwave.git
+    git clone https://github.com/risingwavelabs/risingwave.git && cd risingwave
     ```
 
 2. Install dependencies.
@@ -90,7 +90,7 @@ import TabItem from '@theme/TabItem';
 
 3. Start RisingWave.
 
-    To start RisingWave, in the terminal, navigate to the directory where RisingWave is cloned, and run the following command.
+    To compile and start RisingWave, you can use RiseDev, the developer tool for RisingWave.
   
     ```shell
     ./risedev playground

--- a/versioned_docs/version-0.1.14/deploy/risingwave-local.md
+++ b/versioned_docs/version-0.1.14/deploy/risingwave-local.md
@@ -38,7 +38,7 @@ import TabItem from '@theme/TabItem';
 3. Start RisingWave in playground mode.
 
     ```shell
-    ./risedev playground    #Or ./risedev p
+    ./risingwave playground
     ```
 
 </TabItem>
@@ -90,10 +90,10 @@ import TabItem from '@theme/TabItem';
 
 3. Start RisingWave.
 
-    To start RisingWave, in the terminal, navigate to the directory where RisingWave is downloaded, and run the following command.
+    To start RisingWave, in the terminal, navigate to the directory where RisingWave is cloned, and run the following command.
   
     ```shell
-    ./risingwave playground
+    ./risedev playground
     ```
 
 

--- a/versioned_docs/version-0.1.14/deploy/risingwave-local.md
+++ b/versioned_docs/version-0.1.14/deploy/risingwave-local.md
@@ -19,9 +19,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs>
-<TabItem value="library" label="Pre-built library (Linux)">
+<TabItem value="library" label="Pre-built package (Linux)">
 
-1. Download the pre-built library.
+1. Download the pre-built binary.
 
     ```shell
     wget https://github.com/risingwavelabs/risingwave/releases/download/v0.1.14/risingwave-v0.1.14-x86_64-unknown-linux.tar.gz
@@ -29,7 +29,7 @@ import TabItem from '@theme/TabItem';
 
     > You can find previous binary releases in [Release notes](/release-notes.md).
 
-2. Unzip the library.
+2. Unzip the binary.
 
     ```shell
     tar xvf risingwave-v0.1.14-x86_64-unknown-linux.tar.gz
@@ -90,10 +90,10 @@ import TabItem from '@theme/TabItem';
 
 3. Start RisingWave.
 
-    To compile and start RisingWave, you can use RiseDev, the developer tool for RisingWave.
+    To compile and start RisingWave, you can use [RiseDev](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#set-up-the-development-environment), the developer's tool for RisingWave.
   
     ```shell
-    ./risedev playground
+    ./risedev playground    #Or ./risedev p
     ```
 
 

--- a/versioned_docs/version-0.1.14/deploy/risingwave-local.md
+++ b/versioned_docs/version-0.1.14/deploy/risingwave-local.md
@@ -44,10 +44,10 @@ import TabItem from '@theme/TabItem';
 </TabItem>
 <TabItem value="source" label="Build from source (Linux & macOS)">
 
-1. Clone the [risingwave](https://github.com/risingwavelabs/risingwave) repository.
+1. Clone the [risingwave](https://github.com/risingwavelabs/risingwave) repository and enter the directory.
 
     ```shell
-    git clone https://github.com/risingwavelabs/risingwave.git
+    git clone https://github.com/risingwavelabs/risingwave.git && cd risingwave
     ```
 
 2. Install dependencies.
@@ -90,7 +90,7 @@ import TabItem from '@theme/TabItem';
 
 3. Start RisingWave.
 
-    To start RisingWave, in the terminal, navigate to the directory where RisingWave is cloned, and run the following command.
+    To compile and start RisingWave, you can use RiseDev, the developer tool for RisingWave.
   
     ```shell
     ./risedev playground


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 

The command is wrong (reversed). Refer to RisingWave README:

![image](https://user-images.githubusercontent.com/37948597/207948712-9410da2f-002a-43ad-9787-0043019b80fe.png)

BTW, the quick start guild seems different from RisingWave's README. I don't know whether it's intended, so I just make minimum changes to fix the commands without changing style/wording too much.

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
