### PR TITLE
fix: import @theme/Admonition components

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -16,7 +16,7 @@ const config = {
   favicon: "img/favicon.ico",
   presets: [
     [
-      "classic",
+      "@docusaurus/preset-classic",
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         gtag: {
@@ -24,6 +24,10 @@ const config = {
           anonymizeIP: true,
         },
         docs: {
+          admonitions: {
+            tag: ":::",
+            keywords: ["note", "tip", "info", "caution", "danger"],
+          },
           sidebarPath: require.resolve("./sidebars.js"),
           showLastUpdateAuthor: false,
           showLastUpdateTime: true,

--- a/src/theme/MDXComponents/index.js
+++ b/src/theme/MDXComponents/index.js
@@ -18,6 +18,7 @@ import LightButton from "@theme/LightButton";
 import NotifyButton from "@theme/NotifyButton";
 import DefaultNotify from "@theme/DefaultNotify";
 import LightNotify from "@theme/LightNotify";
+import Admonition from "@theme/Admonition";
 
 function unwrapMDXElement(element) {
   if (element?.props?.mdxType && element?.props?.originalType) {
@@ -76,5 +77,6 @@ const MDXComponents = {
   lightButton: LightButton,
   defaultNotify: DefaultNotify,
   lightNotify: LightNotify,
+  admonition: Admonition,
 };
 export default MDXComponents;


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
when upgrading to docusaurus 2.2.0, I missed to reimport some components in MDXComponents

- **Related code PR**: 
/

- **Related doc issue**: 
Resolves #443 

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
