### PR TITLE
Correct v0.1.15 release date from 2022 to 2023

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,7 +9,7 @@ This page summarizes changes in each version of RisingWave, including new featur
 
 ## v0.1.15
 
-This version was released on January 3, 2022. 
+This version was released on January 3, 2023. 
 
 ### Main changes
 


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Correct release date typo.

- **Related doc issue**: 
Resolves  #490 

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>


## Published doc pages
  [ After merging this PR, edit the description to include the links to the updated doc pages here. For example, https://www.risingwave.dev/docs/latest/intro/. ]
