### PR TITLE
Add array_agg() support

### DIFF
--- a/docs/sql/functions-operators/sql-function-aggregate.md
+++ b/docs/sql/functions-operators/sql-function-aggregate.md
@@ -11,6 +11,7 @@ The DISTINCT option, ORDER BY clauses, and FILTER clauses can be used in aggrega
 
 |Function|Description|
 |---|---|
+|array_agg( *expression* ) → *output_array*| Returns an array from input values in which each value in the set is assigned to an array element. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.|
 |avg( *expression* ) → see description| Returns the average (arithmetic mean) of the selected values. Input types include smallint, int, bigint, numeric, real, and double precision. Return type is numeric for integer inputs and double precision for float point inputs.|
 |count( *expression* ) → bigint|Returns the number of non-null rows. Input types include bool, smallint, int, bigint, numeric, real, double precision, and string.|
 |max( *expression* ) → same as input type|Returns the maximum value in a set of values. Input types include smallint, int, bigint, numeric, real, double precision, and string.|

--- a/docs/sql/functions-operators/sql-function-aggregate.md
+++ b/docs/sql/functions-operators/sql-function-aggregate.md
@@ -11,7 +11,7 @@ The DISTINCT option, ORDER BY clauses, and FILTER clauses can be used in aggrega
 
 |Function|Description|
 |---|---|
-|array_agg( *expression* [ ORDER BY [ *sort_expression* {ASC \| DESC} ] ] ) → *output_array*| Returns an array from input values in which each value in the set is assigned to an array element. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.|
+|array_agg( *expression* [ ORDER BY [ sort_expression {ASC \| DESC} ] ] ) → *output_array*| Returns an array from input values in which each value in the set is assigned to an array element. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.|
 |avg( *expression* ) → see description| Returns the average (arithmetic mean) of the selected values. Input types include smallint, int, bigint, numeric, real, and double precision. Return type is numeric for integer inputs and double precision for float point inputs.|
 |count( *expression* ) → bigint|Returns the number of non-null rows. Input types include bool, smallint, int, bigint, numeric, real, double precision, and string.|
 |max( *expression* ) → same as input type|Returns the maximum value in a set of values. Input types include smallint, int, bigint, numeric, real, double precision, and string.|

--- a/docs/sql/functions-operators/sql-function-aggregate.md
+++ b/docs/sql/functions-operators/sql-function-aggregate.md
@@ -11,7 +11,7 @@ The DISTINCT option, ORDER BY clauses, and FILTER clauses can be used in aggrega
 
 |Function|Description|
 |---|---|
-|array_agg( *expression* ) → *output_array*| Returns an array from input values in which each value in the set is assigned to an array element. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.|
+|array_agg( *expression* [ ORDER BY [ *sort_expression* {ASC \| DESC} ] ] ) → *output_array*| Returns an array from input values in which each value in the set is assigned to an array element. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.|
 |avg( *expression* ) → see description| Returns the average (arithmetic mean) of the selected values. Input types include smallint, int, bigint, numeric, real, and double precision. Return type is numeric for integer inputs and double precision for float point inputs.|
 |count( *expression* ) → bigint|Returns the number of non-null rows. Input types include bool, smallint, int, bigint, numeric, real, double precision, and string.|
 |max( *expression* ) → same as input type|Returns the maximum value in a set of values. Input types include smallint, int, bigint, numeric, real, double precision, and string.|


### PR DESCRIPTION
Add array_agg() support.

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Add array_agg() support.

- **Preview**: 
[ Paste the preview link to the edited page here. ]

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/4862
https://github.com/risingwavelabs/risingwave/pull/4895

- **Related doc issue**: 
https://github.com/risingwavelabs/risingwave-docs/issues/497

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
