### PR TITLE
Fix the broken manifest links

### DIFF
--- a/docs/deploy/risingwave-kubernetes.md
+++ b/docs/deploy/risingwave-kubernetes.md
@@ -89,7 +89,7 @@ RisingWave supports using MinIO as the object storage.
 Run the following command to deploy a RisingWave instance with MinIO as the object storage.
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/examples/risingwave/risingwave-etcd-minio.yaml
+kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/docs/manifests/risingwave/risingwave-etcd-minio.yaml
 ```
 
 </TabItem>
@@ -110,7 +110,7 @@ RisingWave supports using Amazon S3 as the object storage.
 1. Deploy a RisingWave instance with S3 as the object storage.
 
     ```shell
-    kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/examples/risingwave/risingwave-etcd-s3.yaml
+    kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/docs/manifests/risingwave/risingwave-etcd-s3.yaml
     ```
 
 </TabItem>
@@ -158,7 +158,7 @@ By default, the Operator creates a service for the frontend component, through w
 1. Create a Pod.
 
     ```shell
-    kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/examples/psql/psql-console.yaml
+    kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/docs/manifests/psql/psql-console.yaml
     ```
 
 1. Attach to the Pod so that you can execute commands inside the container.

--- a/versioned_docs/version-0.1.14/deploy/risingwave-kubernetes.md
+++ b/versioned_docs/version-0.1.14/deploy/risingwave-kubernetes.md
@@ -89,7 +89,7 @@ RisingWave supports using MinIO as the object storage.
 Run the following command to deploy a RisingWave instance with MinIO as the object storage.
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/examples/risingwave/risingwave-etcd-minio.yaml
+kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/docs/manifests/risingwave/risingwave-etcd-minio.yaml
 ```
 
 </TabItem>
@@ -110,7 +110,7 @@ RisingWave supports using Amazon S3 as the object storage.
 1. Deploy a RisingWave instance with S3 as the object storage.
 
     ```shell
-    kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/examples/risingwave/risingwave-etcd-s3.yaml
+    kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/docs/manifests/risingwave/risingwave-etcd-s3.yaml
     ```
 
 </TabItem>
@@ -158,7 +158,7 @@ By default, the Operator creates a service for the frontend component, through w
 1. Create a Pod.
 
     ```shell
-    kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/examples/psql/psql-console.yaml
+    kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/docs/manifests/psql/psql-console.yaml
     ```
 
 1. Attach to the Pod so that you can execute commands inside the container.

--- a/versioned_docs/version-0.1.15/deploy/risingwave-kubernetes.md
+++ b/versioned_docs/version-0.1.15/deploy/risingwave-kubernetes.md
@@ -89,7 +89,7 @@ RisingWave supports using MinIO as the object storage.
 Run the following command to deploy a RisingWave instance with MinIO as the object storage.
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/examples/risingwave/risingwave-etcd-minio.yaml
+kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/docs/manifests/risingwave/risingwave-etcd-minio.yaml
 ```
 
 </TabItem>
@@ -110,7 +110,7 @@ RisingWave supports using Amazon S3 as the object storage.
 1. Deploy a RisingWave instance with S3 as the object storage.
 
     ```shell
-    kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/examples/risingwave/risingwave-etcd-s3.yaml
+    kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/docs/manifests/risingwave/risingwave-etcd-s3.yaml
     ```
 
 </TabItem>
@@ -158,7 +158,7 @@ By default, the Operator creates a service for the frontend component, through w
 1. Create a Pod.
 
     ```shell
-    kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/examples/psql/psql-console.yaml
+    kubectl apply -f https://raw.githubusercontent.com/risingwavelabs/risingwave-operator/main/docs/manifests/psql/psql-console.yaml
     ```
 
 1. Attach to the Pod so that you can execute commands inside the container.


### PR DESCRIPTION
Signed-off-by: arkbriar <arkbriar@gmail.com>

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 

Fix the broken manifest links since the files are moved to the `docs/manifests` dir.

- **Preview**: 
[ Paste the preview link to the edited page here. ]

- **Related code PR**: 
[ Provide the link to the code PR here. For example, https://github.com/risingwavelabs/risingwave/pull/4085. Delete this part if there's no code PR related. ]

- **Related doc issue**: 
Resolves [ Provide the link to the doc issue here. ]

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
