### PR TITLE
Depreciated old CREATE MATERIALIZED SOURCE syntax

### DIFF
--- a/docs/create-source/create-source-cdc.md
+++ b/docs/create-source/create-source-cdc.md
@@ -11,7 +11,7 @@ CDC tools and platforms can record row-level changes (INSERT, UPDATE, and DELETE
 
 To ingest CDC data from MySQL or PostgreSQL into RisingWave, you can use a CDC tool to convert data change streams in databases to Kafka topics, and then use the native Kafka connector in RisingWave to consume data from the Kafka topics.
 
-For RisingWave to ingest CDC data, you must create a materialized source (`CREATE MATERIALIZED SOURCE`) and specify primary keys. Materializing a source means that you want to persist the data from the source in RisingWave. For CDC data, the source must be materalized.
+For RisingWave to ingest CDC data, you must create a materialized source (`CREATE TABLE`) and specify primary keys. Materializing a source means that you want to persist the data from the source in RisingWave. For CDC data, the source must be materalized.
 
 The supported CDC data formats are [Debezium](https://debezium.io) JSON (for both MySQL and PostgreSQL) and [Maxwell](https://maxwells-daemon.io) JSON (for MySQL only).
 
@@ -22,7 +22,7 @@ The supported CDC data formats are [Debezium](https://debezium.io) JSON (for bot
 ## Syntax
 
 ```sql
-CREATE MATERIALIZED SOURCE [ IF NOT EXISTS ] source_name (
+CREATE TABLE [ IF NOT EXISTS ] source_name (
    column_name data_type [ PRIMARY KEY ], ...
    PRIMARY KEY ( column_name, ... )
 ) 
@@ -49,7 +49,7 @@ ROW FORMAT { DEBEZIUM_JSON | MAXWELL };
 Here is an example of creating a materialized source using the Kafka connector to consume data from Kafka topics.
 
 ```sql
-CREATE MATERIALIZED SOURCE [IF NOT EXISTS] source_name (
+CREATE TABLE [IF NOT EXISTS] source_name (
    column1 varchar,
    column2 integer,
    PRIMARY KEY (column1)

--- a/docs/create-source/create-source-datagen.md
+++ b/docs/create-source/create-source-datagen.md
@@ -22,7 +22,7 @@ import rr from '@theme/RailroadDiagram'
 export const svg = rr.Diagram(
 rr.Stack(
    rr.Sequence(
-      rr.Terminal('CREATE MATERIALIZED SOURCE'),
+      rr.Terminal('CREATE TABLE'),
       rr.NonTerminal('source_name', 'skip'),
       rr.Terminal('('),
       rr.OneOrMore (rr.Sequence ( rr.Terminal ('column_name'), rr.Terminal ('data_type')), ','),
@@ -78,7 +78,7 @@ rr.Stack(
 <TabItem value="code" label="Code">
 
 ```sql
-CREATE MATERIALIZED SOURCE source_name ( column_name data_type, ... ) 
+CREATE TABLE source_name ( column_name data_type, ... ) 
 WITH (
    connector = ' datagen ',
    fields.column_name.column_parameter = ' value ', ...  -- Configure the generator for each column. See detailed information below.
@@ -185,7 +185,7 @@ The following statement creates a source `s1` with four columns:
 
 
 ```sql
-CREATE MATERIALIZED SOURCE s1 (i1 int, v1 struct<v2 int, v3 double>, t1 timestamp, c1 varchar) 
+CREATE TABLE s1 (i1 int, v1 struct<v2 int, v3 double>, t1 timestamp, c1 varchar) 
 WITH (
      connector = 'datagen',
      fields.i1.kind = 'sequence',

--- a/docs/create-source/create-source-kafka.md
+++ b/docs/create-source/create-source-kafka.md
@@ -7,14 +7,14 @@ slug: /create-source-kafka
 
 This topic describes how to connect RisingWave to a Kafka broker that you want to receive data from, and how to specify data formats, schemas, and security (encryption and authentication) settings.
 
-A source is a resource that RisingWave can read data from. You can create a source in RisingWave using the `CREATE SOURCE` command. When creating a source, you can choose to persist the data from the source in RisingWave by adding `MATERIALIZED` in between `CREATE` and `SOURCE` (that is, `CREATE MATERIALIZED SOURCE`). 
+A source is a resource that RisingWave can read data from. You can create a source in RisingWave using the `CREATE SOURCE` command. When creating a source, you can choose to persist the data from the source in RisingWave by using the `CREATE TABLE` command and specifying the connection settings and data format.
 
 Regardless of whether the data is persisted in RisingWave, you can create materialized views to perform analysis or sinks for data transformations.
 
 ## Syntax
 
 ```sql
-CREATE [ MATERIALIZED ] SOURCE [ IF NOT EXISTS ] source_name 
+CREATE {TABLE | SOURCE} [ IF NOT EXISTS ] source_name 
 [schema_definition]
 WITH (
    connector='kafka',
@@ -51,7 +51,6 @@ For materialized sources with primary key constraints, if a new data record with
 
 |Field|Notes|
 |---|---|
-|`MATERIALIZED`| When you materialize a source, you choose to persist the data from the source in RisingWave.|
 |topic| Required. Address of the Kafka topic. One source can only correspond to one topic.|
 |properties.bootstrap.server| Required. Address of the Kafka broker. Format: `'ip:port,ip:port'`.	|
 |properties.group.id	|Required. Name of the Kafka consumer group	|
@@ -74,7 +73,7 @@ import TabItem from '@theme/TabItem';
 <TabItem value="avro" label="Avro" default>
 
 ```sql
-CREATE MATERIALIZED SOURCE IF NOT EXISTS source_abc 
+CREATE SOURCE IF NOT EXISTS source_abc 
 WITH (
    connector='kafka',
    topic='demo_topic',
@@ -90,7 +89,7 @@ ROW SCHEMA LOCATION CONFLUENT SCHEMA REGISTRY 'http://127.0.0.1:8081';
 <TabItem value="json" label="JSON" default>
 
 ```sql
-CREATE MATERIALIZED SOURCE IF NOT EXISTS source_abc (
+CREATE TABLE IF NOT EXISTS source_abc (
    column1 varchar,
    column2 integer,
 )
@@ -108,7 +107,7 @@ ROW FORMAT JSON;
 <TabItem value="pb" label="Protobuf" default>
 
 ```sql
-CREATE MATERIALIZED SOURCE IF NOT EXISTS source_abc 
+CREATE SOURCE IF NOT EXISTS source_abc 
 WITH (
    connector='kafka',
    topic='demo_topic',
@@ -198,10 +197,10 @@ For the definitions of the parameters, see the [librdkafka properties list](http
 
 :::
 
-Here is an example of creating a source encrypted with SSL without using SASL authentication.
+Here is an example of creating a materialized source encrypted with SSL without using SASL authentication.
 
 ```sql
-CREATE MATERIALIZED SOURCE IF NOT EXISTS source_1 (
+CREATE TABLE IF NOT EXISTS source_1 (
    column1 varchar,
    column2 integer,
 )                  
@@ -244,7 +243,7 @@ For SASL/PLAIN with SSL, you need to include these SSL parameters:
 Here is an example of creating a source authenticated with SASL/PLAIN without SSL encryption.
 
 ```sql
-CREATE MATERIALIZED SOURCE IF NOT EXISTS source_2 (
+CREATE SOURCE IF NOT EXISTS source_2 (
    column1 varchar,
    column2 integer,
 )                  
@@ -263,7 +262,7 @@ ROW FORMAT JSON;
 This is an example of creating a source authenticated with SASL/PLAIN with SSL encryption.
 
 ```sql
-CREATE MATERIALIZED SOURCE IF NOT EXISTS source_3 (
+CREATE SOURCE IF NOT EXISTS source_3 (
    column1 varchar,
    column2 integer,
 )                  
@@ -306,10 +305,10 @@ For SASL/SCRAM with SSL, you also need to include these SSL parameters:
 - properties.ssl.key.location
 - properties.ssl.key.password
 
-Here is an example of creating a source authenticated with SASL/SCRAM without SSL encryption.
+Here is an example of creating a materialized source authenticated with SASL/SCRAM without SSL encryption.
 
 ```sql
-CREATE MATERIALIZED SOURCE IF NOT EXISTS source_4 (
+CREATE TABLE IF NOT EXISTS source_4 (
    column1 varchar,
    column2 integer,
 )                  
@@ -347,7 +346,7 @@ For the definitions of the parameters, see the [librdkafka properties list](http
 Here is an example of creating a source authenticated with SASL/GSSAPI without SSL encryption.
 
 ```sql
-CREATE MATERIALIZED SOURCE IF NOT EXISTS source_5 (
+CREATE SOURCE IF NOT EXISTS source_5 (
    column1 varchar,
    column2 integer,
 )                  
@@ -394,10 +393,10 @@ For SASL/OAUTHBEARER with SSL, you also need to include these SSL parameters:
 - properties.ssl.key.location
 - properties.ssl.key.password
 
-This is an example of creating a source authenticated with SASL/OAUTHBEARER without SSL encryption.
+This is an example of creating a materialized source authenticated with SASL/OAUTHBEARER without SSL encryption.
 
 ```sql
-CREATE MATERIALIZED SOURCE IF NOT EXISTS source_6 (
+CREATE TABLE IF NOT EXISTS source_6 (
    column1 varchar,
    column2 integer,
 )                  

--- a/docs/create-source/create-source-kinesis.md
+++ b/docs/create-source/create-source-kinesis.md
@@ -7,10 +7,12 @@ slug: /create-source-kinesis
 
 Use the SQL statement below to connect RisingWave to Kinesis Data Streams.
 
+When creating a source, you can choose to persist the data from the source in RisingWave by using `CREATE TABLE` instead of `CREATE SOURCE` and specifying the connection settings and data format.
+
 ## Syntax
 
 ```sql
-CREATE [ MATERIALIZED ] SOURCE [ IF NOT EXISTS ] source_name 
+CREATE {TABLE | SOURCE} [ IF NOT EXISTS ] source_name 
 [schema_definition]
 WITH (
    connector='kinesis',
@@ -18,7 +20,7 @@ WITH (
 ) 
 ROW FORMAT data_format
 [ MESSAGE 'message' ]
-[ ROW SCHEMA LOCATION 'location' ]
+[ ROW SCHEMA LOCATION 'location' ];
 ```
 
 **schema_definition**:
@@ -31,7 +33,7 @@ ROW FORMAT data_format
 
 :::info
 
-For Avro and Protobuf data, do not specify `schema_definition` in the `CREATE SOURCE` or `CREATE MATERIALIZED SOURCE` statement. The schema should be provided in a Web location in the `ROW SCHEMA LOCATION` section.
+For Avro and Protobuf data, do not specify `schema_definition` in the `CREATE SOURCE` or `CREATE TABLE` statement. The schema should be provided in a Web location in the `ROW SCHEMA LOCATION` section.
 
 :::
 
@@ -46,7 +48,6 @@ For materialized sources with primary key constraints, if a new data record with
 
 |Field|	Notes|
 |---|---|
-|`MATERIALIZED`| When you materialize a source, you choose to persist the data from the source in RisingWave.|
 |stream	|Required. Name of the stream.|
 |aws.region	|Required. AWS service region. For example, US East (N. Virginia).|
 |endpoint	|Optional. URL of the entry point for the AWS Kinesis service.|
@@ -71,7 +72,7 @@ import TabItem from '@theme/TabItem';
 <TabItem value="avro" label="Avro" default>
 
 ```sql
-CREATE [MATERIALIZED] SOURCE [IF NOT EXISTS] source_name
+CREATE {TABLE | SOURCE} [IF NOT EXISTS] source_name
 WITH (
    connector='kinesis',
    stream='kafka',
@@ -88,7 +89,7 @@ ROW SCHEMA LOCATION 'https://demo_bucket_name.s3-us-west-2.amazonaws.com/demo.av
 <TabItem value="json" label="JSON" default>
 
 ```sql
-CREATE [MATERIALIZED] SOURCE [IF NOT EXISTS] source_name (
+CREATE {TABLE | SOURCE} [IF NOT EXISTS] source_name (
    column1 varchar,
    column2 integer,
 ) 
@@ -107,7 +108,7 @@ ROW FORMAT JSON;
 <TabItem value="pb" label="Protobuf" default>
 
 ```sql
-CREATE [MATERIALIZED] SOURCE [IF NOT EXISTS] source_name
+CREATE {TABLE | SOURCE} [IF NOT EXISTS] source_name
 WITH (
    connector='kinesis',
    stream='kafka',

--- a/docs/create-source/create-source-pulsar.md
+++ b/docs/create-source/create-source-pulsar.md
@@ -8,10 +8,12 @@ slug: /create-source-pulsar
 
 Use the SQL statement below to connect RisingWave to a Pulsar broker.
 
+When creating a source, you can choose to persist the data from the source in RisingWave by using `CREATE TABLE` instead of `CREATE SOURCE` and specifying the connection settings and data format.
+
 ## Syntax
 
 ```sql
-CREATE [ MATERIALIZED ] SOURCE [ IF NOT EXISTS ] source_name 
+CREATE {TABLE | SOURCE} [ IF NOT EXISTS ] source_name 
 [schema_definition]
 WITH (
    connector='pulsar',
@@ -32,7 +34,7 @@ ROW FORMAT data_format
 
 :::info
 
-For Avro and Protobuf data, do not specify `schema_definition` in the `CREATE SOURCE` or `CREATE MATERIALIZED SOURCE` statement. The schema should be provided in a Web location in the `ROW SCHEMA LOCATION` section.
+For Avro and Protobuf data, do not specify `schema_definition` in the `CREATE SOURCE` or `CREATE TABLE` statement. The schema should be provided in a Web location in the `ROW SCHEMA LOCATION` section.
 
 :::
 
@@ -55,7 +57,6 @@ For materialized sources with primary key constraints, if a new data record with
 
 |Field|Notes|
 |---|---|
-|`MATERIALIZED`| When you materialize a source, you choose to persist the data from the source in RisingWave.|
 |topic	|Required. Address of the Pulsar topic. One source can only correspond to one topic.|
 |service.url| Required. Address of the Pulsar service.	|
 |admin.url	|Required. Address of the Pulsar admin.|
@@ -75,7 +76,7 @@ import TabItem from '@theme/TabItem';
 <TabItem value="avro" label="Avro" default>
 
 ```sql
-CREATE MATERIALIZED SOURCE IF NOT EXISTS source_abc 
+CREATE {TABLE | SOURCE} IF NOT EXISTS source_abc 
 WITH (
    connector='pulsar',
    topic='demo_topic',
@@ -91,7 +92,7 @@ ROW SCHEMA LOCATION 'https://demo_bucket_name.s3-us-west-2.amazonaws.com/demo.av
 <TabItem value="json" label="JSON" default>
 
 ```sql
-CREATE MATERIALIZED SOURCE IF NOT EXISTS source_abc (
+CREATE {TABLE | SOURCE} IF NOT EXISTS source_abc (
    column1 string,
    column2 integer,
 )
@@ -109,7 +110,7 @@ ROW FORMAT JSON;
 <TabItem value="pb" label="Protobuf" default>
 
 ```sql
-CREATE MATERIALIZED SOURCE IF NOT EXISTS source_abc (
+CREATE {TABLE | SOURCE} IF NOT EXISTS source_abc (
    column1 string,
    column2 integer,
 )

--- a/docs/data-ingestion.md
+++ b/docs/data-ingestion.md
@@ -13,7 +13,7 @@ You can ingest data into RisingWave in two ways:
 
 ### Materialized and non-materialized source
 
-A source is a resource that RisingWave can read data from. You can create a source in RisingWave using the `CREATE SOURCE` command. When creating a source, you can choose to persist the data from the source in RisingWave by adding `MATERIALIZED` in between `CREATE` and `SOURCE` (that is, `CREATE MATERIALIZED SOURCE`). 
+A source is a resource that RisingWave can read data from. You can create a source in RisingWave using the `CREATE SOURCE` command. When creating a source, you can choose to persist the data from the source in RisingWave by using the `CREATE TABLE` command.
 
 Regardless of whether the data is persisted in RisingWave, you can create materialized views to perform analysis or sinks for data transformations.
 

--- a/docs/key-concepts.md
+++ b/docs/key-concepts.md
@@ -10,13 +10,13 @@ This page explains key concepts and terms that are used throughout the documenta
 
 ### Sources
 
-A source is a resource that RisingWave can read data from. Common sources include message brokers such as Apache Kafka and Apache Pulsar and databases such as MySQL and PostgreSQL. You can create a source in RisingWave using the `CREATE SOURCE` command. When creating a source, you can choose to persist the data from the source by adding `MATERIALIZED` in between `CREATE` and `SOURCE` (that is, `CREATE MATERIALIZED SOURCE`). 
+A source is a resource that RisingWave can read data from. Common sources include message brokers such as Apache Kafka and Apache Pulsar and databases such as MySQL and PostgreSQL. You can create a source in RisingWave using the `CREATE SOURCE` command. When creating a source, you can choose to persist the data from the source by using the `CREATE TABLE` command. 
 
 Regardless of whether the data is persisted in RisingWave, you can create materialized views to perform analysis or sinks for data transformations.
 
 ### Materialized sources
 
-To materialize a source is to persist the data from the source into RisingWave. As the data grows, a materialized source can consume a large amount of storage space. You must use the `CREATE MATERIALIZED SOURCE` statement to create a materialized source. For details, see [CREATE SOURCE](/sql/commands/sql-create-source.md).
+To materialize a source is to persist the data from the source into RisingWave. As the data grows, a materialized source can consume a large amount of storage space. You must use the `CREATE TABLE` statement to create a materialized source. For details, see [`CREATE TABLE`](/sql/commands/sql-create-table.md).
 
 ### Sinks
 

--- a/docs/sql/commands/sql-create-source.md
+++ b/docs/sql/commands/sql-create-source.md
@@ -5,14 +5,15 @@ description: Supported data sources and how to connect RisingWave to the sources
 slug: /sql-create-source
 ---
 
-A source is a resource that RisingWave can read data from. You can create a source in RisingWave using the `CREATE SOURCE` command. When creating a source, you can choose to persist the data from the source in RisingWave by adding `MATERIALIZED` in between `CREATE` and `SOURCE` (that is, `CREATE MATERIALIZED SOURCE`). 
+A source is a resource that RisingWave can read data from. You can create a source in RisingWave using the `CREATE SOURCE` command. 
+If you  choose to persist the data from the source in RisingWave, use the `CREATE TABLE` command with connector settings. See [CREATE TABLE](sql-create-table.md) for more details.
 
 Regardless of whether the data is persisted in RisingWave, you can create materialized views to perform analysis or sinks for data transformations.
 
 ## Syntax
 
 ```sql
-CREATE [ MATERIALIZED ] SOURCE [ IF NOT EXISTS ] source_name 
+CREATE SOURCE [ IF NOT EXISTS ] source_name 
 [schema_definition]
 WITH (
    connector='connector_name',
@@ -50,7 +51,7 @@ When a source is created, RisingWave does not ingest data immediately. RisingWav
 
 ## Supported formats
 
-When creating a source, specify the format in the `ROW FORMAT` section of the `CREATE SOURCE` or `CREATE MATERIALIZED SOURCE` statement.
+When creating a source, specify the format in the `ROW FORMAT` section of the `CREATE SOURCE` or `CREATE TABLE` statement.
 
 ### Avro
 
@@ -58,7 +59,7 @@ For data in Avro format, you must specify a message and a schema file location. 
 
 :::info
 
-For Avro data, you cannot specify the schema in the `schema_definition` section of a `CREATE SOURCE` or `CREATE MATERIALIZED SOURCE` statement.
+For Avro data, you cannot specify the schema in the `schema_definition` section of a `CREATE SOURCE` or `CREATE TABLE` statement.
 
 :::
 
@@ -86,7 +87,7 @@ For data in Protobuf format, you must specify a message and a schema location. T
 
 :::info
 
-For protobuf data, you cannot specify the schema in the `schema_definition` section of a `CREATE SOURCE` or `CREATE MATERIALIZED SOURCE`statement.
+For protobuf data, you cannot specify the schema in the `schema_definition` section of a `CREATE SOURCE` or `CREATE TABLE` statement.
 
 :::
 

--- a/docs/sql/commands/sql-create-table.md
+++ b/docs/sql/commands/sql-create-table.md
@@ -47,8 +47,8 @@ If creating a materialized source, remember to include the connector settings wi
 |*table_name*    |The name of the table. If a schema name is given (for example, `CREATE TABLE <schema>.<table> ...`), then the table is created in the specified schema. Otherwise it is created in the current schema.|
 |*col_name*      |The name of a column.|
 |*data_type*|The data type of a column. With the `struct` data type, you can create a nested table. Elements in a nested table need to be enclosed with angle brackets ("<\>"). |
-|**WITH** clause |The connector settings if trying to create a materialized source. See the [Data ingestion](../../data-ingestion.md) page for the full list of supported source as well as links to the specific page specifying the syntax for each source. |
-|**ROW FORMAT** clause |The data format of the source data. To learn about the supported data formats, see [Data formats](sql-create-source.md#supported-formats). |
+|**WITH** clause |Specify the connector settings here if trying to create a materialized source. See the [Data ingestion](../../data-ingestion.md) page for the full list of supported source as well as links to specific connector pages detailing the syntax for each source. |
+|**ROW FORMAT** clause |Specify the data format of the source data here if trying to create a materialized source. To learn about the supported data formats, see [Data formats](sql-create-source.md#supported-formats). |
 
 ## Examples
 

--- a/docs/sql/commands/sql-create-table.md
+++ b/docs/sql/commands/sql-create-table.md
@@ -5,10 +5,10 @@ description: Create a table.
 slug: /sql-create-table
 ---
 
-Use the `CREATE TABLE` command to create a new table. Tables consist of fixed columns and insertable rows. Rows can be added using the [`INSERT`](sql-insert.md) command.
+Use the `CREATE TABLE` command to create a new table or a materialized source. Tables consist of fixed columns and insertable rows. Rows can be added using the [`INSERT`](sql-insert.md) command. If creating a materialized source, be sure to include the connector settings and data format.
 
 :::info
-To ingest data streams, you should [create sources](sql-create-source.md) instead.
+If you choose to not persist the data from the source in RisingWave, you should use [`CREATE SOURCE`](sql-create-source.md).
 :::
 
 ## Syntax
@@ -18,7 +18,14 @@ CREATE TABLE [ IF NOT EXISTS ] table_name (
     col_name data_type [ PRIMARY KEY ],
     ...
     [ PRIMARY KEY (col_name, ... ) ]
-);
+)
+[ WITH (
+   connector='connector_name',
+   field_name='value', ...
+)
+ROW FORMAT data_format 
+[MESSAGE 'message']
+[ROW SCHEMA LOCATION 'location'] ];
 ```
 
 :::note
@@ -26,9 +33,11 @@ For tables with primary key constraints, if you insert a new data record with an
 :::
 
 :::note
-
 Names and unquoted identifiers are case-insensitive. Therefore, you must double-quote any of these fields for them to be case-sensitive.
+:::
 
+:::note
+If creating a materialized source, remember to include the connector settings with the `WITH` clause and to specify the data format with the `ROW FORMAT` clause. See [`CREATE SOURCE`](sql-create-source.md) for a full list of supported connectors and data formats.
 :::
 
 ## Parameters
@@ -38,6 +47,8 @@ Names and unquoted identifiers are case-insensitive. Therefore, you must double-
 |*table_name*    |The name of the table. If a schema name is given (for example, `CREATE TABLE <schema>.<table> ...`), then the table is created in the specified schema. Otherwise it is created in the current schema.|
 |*col_name*      |The name of a column.|
 |*data_type*|The data type of a column. With the `struct` data type, you can create a nested table. Elements in a nested table need to be enclosed with angle brackets ("<\>"). |
+|**WITH** clause |The connector settings if trying to create a materialized source. See the [Data ingestion](../../data-ingestion.md) page for the full list of supported source as well as links to the specific page specifying the syntax for each source. |
+|**ROW FORMAT** clause |The data format of the source data. To learn about the supported data formats, see [Data formats](sql-create-source.md#supported-formats). |
 
 ## Examples
 
@@ -65,4 +76,20 @@ CREATE TABLE IF NOT EXISTS taxi_trips(
       tolls DOUBLE PRECISION>);
 ```
 
+The statement below creates a materialized source with a Kafka broker as the source.
 
+```sql
+CREATE TABLE IF NOT EXISTS source_abc (
+   column1 varchar,
+   column2 integer,
+)
+WITH (
+   connector='kafka',
+   topic='demo_topic',
+   properties.bootstrap.server='172.10.1.1:9090,172.10.1.2:9090',
+   scan.startup.mode='latest',
+   scan.startup.timestamp_millis='140000000',
+   properties.group.id='demo_consumer_name'
+)
+ROW FORMAT JSON;
+```

--- a/docs/sql/commands/sql-show-sources.md
+++ b/docs/sql/commands/sql-show-sources.md
@@ -10,7 +10,7 @@ Use the `SHOW SOURCES` command to show existing sources.
 ## Syntax
 
 ```sql
-SHOW [ MATERIALIZED ] SOURCES [ FROM schema_name ];
+SHOW SOURCES [ FROM schema_name ];
 ```
 ## Parameters
 |Parameter or clause        | Description           |


### PR DESCRIPTION
Depreciated old CREATE MATERIALIZED SOURCE syntax to CREATE TABLE where necessary.

## Info
- **Description**: 
Changed instances of CREATE MATERIALIZED SOURCE to CREATE TABLE. Updated CREATE SOURCE and CREATE TABLE pages to reflect the syntax change. Updated individual connector pages to reflect the syntax change.

- **Preview**: 
[ Paste the preview link to the edited page here. ]

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/7281
https://github.com/risingwavelabs/risingwave/pull/7110

- **Related doc issue**: 
https://github.com/risingwavelabs/risingwave-docs/issues/517

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
