### PR TITLE
Add syntax generator diagram to ALTER USER

### DIFF
--- a/docs/sql/commands/sql-alter-user.md
+++ b/docs/sql/commands/sql-alter-user.md
@@ -39,8 +39,6 @@ ALTER USER user_name
     [ [ WITH ] option [ ... ] ]
 ```
 
-import rr from '@theme/RailroadDiagram'
-
 export const svgtwo = rr.Diagram(
 rr.Stack(
    rr.Sequence(

--- a/docs/sql/commands/sql-alter-user.md
+++ b/docs/sql/commands/sql-alter-user.md
@@ -45,14 +45,10 @@ rr.Stack(
       rr.Terminal('ALTER USER'),
       rr.NonTerminal('user_name', 'skip'),
    ),
-   rr.Optional(
-      rr.Stack(
-         rr.Sequence(
-            rr.Terminal('WITH'),
-         ),
-         rr.Sequence(
-            rr.NonTerminal('option'),
-      ),
+   rr.Sequence(
+      rr.Optional(rr.Terminal('WITH')),
+      rr.OneOrMore(rr.Sequence(
+      rr.NonTerminal('option', 'skip')))
    ),
 )
 );

--- a/docs/sql/commands/sql-alter-user.md
+++ b/docs/sql/commands/sql-alter-user.md
@@ -14,10 +14,53 @@ ALTER USER user_name
     RENAME TO new_user_name
 ```
 
+
+import rr from '@theme/RailroadDiagram'
+
+export const svg = rr.Diagram(
+rr.Stack(
+   rr.Sequence(
+      rr.Terminal("ALTER USER"),
+      rr.NonTerminal("user_name", "skip"),
+   ),
+   rr.Sequence(
+      rr.Terminal("RENAME TO"),
+      rr.NonTerminal("new_user_name", "skip"),
+   ),
+)
+);
+
+<drawer SVG={svg} />
+
+
+
 ```sql title="Alter user properties."
 ALTER USER user_name 
     [ [ WITH ] option [ ... ] ]
 ```
+
+export const svg = rr.Diagram(
+rr.Stack(
+   rr.Sequence(
+      rr.Terminal('ALTER USER'),
+      rr.NonTerminal('user_name', 'skip'),
+   ),
+   rr.Optional(
+      rr.Stack(
+         rr.Sequence(
+            rr.Terminal('WITH'),
+         ),
+         rr.OneOrMore (
+            rr.Sequence(
+               rr.NonTerminal('option'),
+            ),rr.Comment('Option can be a property of the user, such as password, role, etc.'),
+         ),
+      ),
+   ),
+)
+);
+
+<drawer SVG={svg} />
 
 
 ## Parameters

--- a/docs/sql/commands/sql-alter-user.md
+++ b/docs/sql/commands/sql-alter-user.md
@@ -50,11 +50,8 @@ rr.Stack(
          rr.Sequence(
             rr.Terminal('WITH'),
          ),
-         rr.OneOrMore (
-            rr.Sequence(
-               rr.NonTerminal('option'),
-            ),rr.Comment('Option can be a property of the user, such as password, role, etc.'),
-         ),
+         rr.Sequence(
+            rr.NonTerminal('option'),
       ),
    ),
 )

--- a/docs/sql/commands/sql-alter-user.md
+++ b/docs/sql/commands/sql-alter-user.md
@@ -39,6 +39,8 @@ ALTER USER user_name
     [ [ WITH ] option [ ... ] ]
 ```
 
+import rr from '@theme/RailroadDiagram'
+
 export const svg = rr.Diagram(
 rr.Stack(
    rr.Sequence(

--- a/docs/sql/commands/sql-alter-user.md
+++ b/docs/sql/commands/sql-alter-user.md
@@ -41,7 +41,7 @@ ALTER USER user_name
 
 import rr from '@theme/RailroadDiagram'
 
-export const svg = rr.Diagram(
+export const svgtwo = rr.Diagram(
 rr.Stack(
    rr.Sequence(
       rr.Terminal('ALTER USER'),
@@ -62,7 +62,7 @@ rr.Stack(
 )
 );
 
-<drawer SVG={svg} />
+<drawer SVG={svgtwo} />
 
 
 ## Parameters


### PR DESCRIPTION
Add syntax generator diagram to ALTER USER.

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Add syntax generator diagram to ALTER USER

- **Preview**: 
https://pr-559.d2fbku9n2b6wde.amplifyapp.com/docs/upcoming/sql-alter-user/

- **Related code PR**: 
N/A

- **Related doc issue**: 
Resolves no doc issue.

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
