### PR TITLE
Add match_pattern parameter to S3 source

### DIFF
--- a/docs/create-source/create-source-s3.md
+++ b/docs/create-source/create-source-s3.md
@@ -34,6 +34,7 @@ ROW FORMAT csv [WITHOUT HEADER] DELIMITED BY ',';
 |s3.bucket_name	|Required. The name of the bucket the data source is stored in.	|
 |s3.credentials.access| Conditional. This field indicates the access key ID of AWS. It must be used with `s3.credentials.secret`. If not specified, RisingWave will automatically try to use `~/.aws/credentials`.|
 |s3.credentials.secret| Conditional. This field indicates the secret access key of AWS. It must be used wtih `s3.credentials.access`. If not specified, RisingWave will automatically try to use `~/.aws/credentials`.|
+|match_pattern| Conditional. This field is used to find object keys in `s3.bucket_name` that match the given pattern. Standard Unix-style glob syntax is supported. |
 
 
 ## Example
@@ -51,5 +52,5 @@ CREATE TABLE s(
     s3.bucket_name = 'example-s3-source',
     s3.credentials.access = 'xxxxx',
     s3.credentials.secret = 'xxxxx'
-) ROW FORMAT csv [WITHOUT HEADER] DELIMITED BY ',';
+) ROW FORMAT csv WITHOUT HEADER DELIMITED BY ',';
 ```


### PR DESCRIPTION

## Info
- **Description**: 
Add match_pattern parameter to S3 create source

- **Preview**: 
[ Paste the preview link to the edited page here. ]

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/7565

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/551

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
