### PR TITLE
Add support for pow function using double precision parameters

### DIFF
--- a/docs/sql/functions-operators/sql-function-mathematical.md
+++ b/docs/sql/functions-operators/sql-function-mathematical.md
@@ -23,8 +23,11 @@ title: Mathematical functions and operators
 | Function | Description | Example |
 | ----------- | ----------- | ----------- | 
 | abs ( *input_value* ) → *absolute_value* | Returns the absolute value of *input_value*. The *input_value* can be type int or decimal. The return type is the same as the *input_value* type. | abs(-3) → 3 |
+| ceil ( *numeric_input* ) → *integer_output* <br /> ceil ( *double_precision_input* ) → *integer_output* | Returns the nearest integer greater than or equal to the argument. | ceil(1.23559) → 2 <br /> ceil(-1.23559) → -1 |
+| floor ( *numeric_input* ) → *integer_output* <br /> floor ( *double_precision_input* ) → *integer_output* | Returns the nearest integer less than or equal to the argument. | floor(1.23559) → 1 <br /> floor(-1.23559) → -2 |
+| pow ( *x_double_precision*, *y_double_precision* ) → *double_precision_output* | Returns *x_double_precision* raised to the power of *y_double_precision*. | pow(2.0, 3.0) → 8 |
 | round ( *x_numeric*, *y_int* ) → *output_value* | Rounds *x_numeric* to *y_int* decimal places. *y* cannot be negative. | round(1.23559, 2) → 1.24 |
 | round ( *numeric_input* ) → *integer_output* <br /> round ( *double_precision_input* ) → *integer_output* | Rounds to the nearest integer. | round(1.23559) → 1 |
-| floor ( *numeric_input* ) → *integer_output* <br /> floor ( *double_precision_input* ) → *integer_output* | Returns the nearest integer less than or equal to the argument. | floor(1.23559) → 1 <br /> floor(-1.23559) → -2 |
-| ceil ( *numeric_input* ) → *integer_output* <br /> ceil ( *double_precision_input* ) → *integer_output* | Returns the nearest integer greater than or equal to the argument. | ceil(1.23559) → 2 <br /> ceil(-1.23559) → -1 |
+
+
 


### PR DESCRIPTION
Add support for pow function using double precision parameters.

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Add support for pow function using double precision parameters.

- **Preview**: 
[ Paste the preview link to the edited page here. ]

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/7789

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/554

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
