### PR TITLE
Correcting a mistake in Ingest data from PostgreSQL CDC

### DIFF
--- a/docs/guides/ingest-from-postgres-cdc.md
+++ b/docs/guides/ingest-from-postgres-cdc.md
@@ -31,16 +31,16 @@ import TabItem from '@theme/TabItem';
 <Tabs>
 <TabItem value="pg_self_hosted" label="Self-hosted" default>
 
-Ensure that the `wal_value` of your PostgreSQL is `logical`. Check by using the following query.
+Ensure that the `wal_level` of your PostgreSQL is `logical`. Check by using the following query.
 
 ```sql
 SHOW wal_level;
 ```
 
-By default, it will be `replica`. For CDC, you will need to set it to logical in the database configuration file (`postgresql.conf`) or via a `psql` command. The following command will change the `wal_value`.
+By default, it will be `replica`. For CDC, you will need to set it to logical in the database configuration file (`postgresql.conf`) or via a `psql` command. The following command will change the `wal_level`.
 
 ```sql
-ALTER SYSTEM SET wal_value = logical;
+ALTER SYSTEM SET wal_level = logical;
 ```
 
 Keep in mind that changing the `wal_level` requires a restart of the PostgreSQL instance and can affect database performance.

--- a/versioned_docs/version-0.1.16/guides/ingest-from-postgres-cdc.md
+++ b/versioned_docs/version-0.1.16/guides/ingest-from-postgres-cdc.md
@@ -31,16 +31,16 @@ import TabItem from '@theme/TabItem';
 <Tabs>
 <TabItem value="pg_self_hosted" label="Self-hosted" default>
 
-Ensure that the `wal_value` of your PostgreSQL is `logical`. Check by using the following query.
+Ensure that the `wal_level` of your PostgreSQL is `logical`. Check by using the following query.
 
 ```sql
 SHOW wal_level;
 ```
 
-By default, it will be `replica`. For CDC, you will need to set it to logical in the database configuration file (`postgresql.conf`) or via a `psql` command. The following command will change the `wal_value`.
+By default, it will be `replica`. For CDC, you will need to set it to logical in the database configuration file (`postgresql.conf`) or via a `psql` command. The following command will change the `wal_level`.
 
 ```sql
-ALTER SYSTEM SET wal_value = logical;
+ALTER SYSTEM SET wal_level = logical;
 ```
 
 Keep in mind that changing the `wal_level` requires a restart of the PostgreSQL instance and can affect database performance.


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Replacing `was_value` with `was_level`.


<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
