### PR TITLE
Rename field_name to connector parameters 

### DIFF
--- a/docs/create-source/create-source-cdc.md
+++ b/docs/create-source/create-source-cdc.md
@@ -31,12 +31,12 @@ CREATE TABLE [ IF NOT EXISTS ] source_name (
 ) 
 WITH (
    connector='kafka',
-   field_name='value', ...
+   connector_parameter='value', ...
 ) 
 ROW FORMAT { DEBEZIUM_JSON | MAXWELL };
 ```
 
-### `WITH` parameters
+### Connector Parameters
 
 |Field|Notes|
 |---|---|

--- a/docs/create-source/create-source-kafka.md
+++ b/docs/create-source/create-source-kafka.md
@@ -18,7 +18,7 @@ CREATE {TABLE | SOURCE} [ IF NOT EXISTS ] source_name
 [schema_definition]
 WITH (
    connector='kafka',
-   field_name='value', ...
+   connector_parameter='value', ...
 )
 ROW FORMAT data_format 
 [ MESSAGE 'message' ]
@@ -47,7 +47,7 @@ For materialized sources with primary key constraints, if a new data record with
 
 :::
 
-### `WITH` Parameters
+### Connector Parameters
 
 |Field|Notes|
 |---|---|

--- a/docs/create-source/create-source-kafka.md
+++ b/docs/create-source/create-source-kafka.md
@@ -47,7 +47,7 @@ For materialized sources with primary key constraints, if a new data record with
 
 :::
 
-### Connector Parameters
+### Connector parameters
 
 |Field|Notes|
 |---|---|
@@ -57,7 +57,7 @@ For materialized sources with primary key constraints, if a new data record with
 |scan.startup.mode|Optional. The offset mode that RisingWave will use to consume data. The two supported modes are `earliest` (earliest offset) and `latest` (latest offset). If not specified, the default value `earliest` will be used.|
 |scan.startup.timestamp_millis|Optional. RisingWave will start to consume data from the specified UNIX timestamp (milliseconds). If this field is specified, the value for `scan.startup.mode` will be ignored.|
 
-### Other Parameters
+### Other parameters
 
 |Field|Notes|
 |---|---|

--- a/docs/create-source/create-source-kafka.md
+++ b/docs/create-source/create-source-kafka.md
@@ -47,7 +47,7 @@ For materialized sources with primary key constraints, if a new data record with
 
 :::
 
-### Parameters
+### `WITH` Parameters
 
 |Field|Notes|
 |---|---|

--- a/docs/create-source/create-source-kafka.md
+++ b/docs/create-source/create-source-kafka.md
@@ -56,11 +56,15 @@ For materialized sources with primary key constraints, if a new data record with
 |properties.group.id	|Required. Name of the Kafka consumer group	|
 |scan.startup.mode|Optional. The offset mode that RisingWave will use to consume data. The two supported modes are `earliest` (earliest offset) and `latest` (latest offset). If not specified, the default value `earliest` will be used.|
 |scan.startup.timestamp_millis|Optional. RisingWave will start to consume data from the specified UNIX timestamp (milliseconds). If this field is specified, the value for `scan.startup.mode` will be ignored.|
+
+### Other Parameters
+
+|Field|Notes|
+|---|---|
 |*data_format*| Data format. Supported formats: `JSON`, `AVRO`, `PROTOBUF`|
 |*message* | Message for the format. Required for Avro and Protobuf.|
 |*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. For Avro and Protobuf data, you must specify either a schema location or a schema registry but not both.|
 |*schema_registry_url*| Confluent Schema Registry URL. Example: `http://127.0.0.1:8081`. For Avro or Protobuf data, you must specify either a schema location or a Confluent Schema Registry but not both.|
-
 
 ## Example
 

--- a/docs/create-source/create-source-kinesis.md
+++ b/docs/create-source/create-source-kinesis.md
@@ -44,7 +44,7 @@ RisingWave performs primary key constraint checks on materialized sources but no
 For materialized sources with primary key constraints, if a new data record with an existing key comes in, the new record will overwrite the existing record. 
 :::
 
-### Parameters
+### `WITH` Parameters
 
 |Field|	Notes|
 |---|---|

--- a/docs/create-source/create-source-kinesis.md
+++ b/docs/create-source/create-source-kinesis.md
@@ -61,6 +61,8 @@ For materialized sources with primary key constraints, if a new data record with
 
 ### Other Parameters
 
+|Field|	Notes|
+|---|---|
 |*data_format*| Supported formats: `JSON`, `AVRO`, `PROTOBUF`.|
 |*message* |Message for the format. Required when *data_format* is `AVRO` or `PROTOBUF`.|
 |*location*| Web location of the schema file in  `http://...`, `https://...`, or `S3://...` format. Required when *data_format* is `AVRO` or `PROTOBUF`. Examples:<br/>`https://<example_host>/risingwave/proto-simple-schema.proto`<br/>`s3://risingwave-demo/schema-location` |

--- a/docs/create-source/create-source-kinesis.md
+++ b/docs/create-source/create-source-kinesis.md
@@ -16,7 +16,7 @@ CREATE {TABLE | SOURCE} [ IF NOT EXISTS ] source_name
 [schema_definition]
 WITH (
    connector='kinesis',
-   field_name='value', ...
+   connector_parameter='value', ...
 ) 
 ROW FORMAT data_format
 [ MESSAGE 'message' ]
@@ -44,7 +44,7 @@ RisingWave performs primary key constraint checks on materialized sources but no
 For materialized sources with primary key constraints, if a new data record with an existing key comes in, the new record will overwrite the existing record. 
 :::
 
-### `WITH` Parameters
+### Connector Parameters
 
 |Field|	Notes|
 |---|---|

--- a/docs/create-source/create-source-kinesis.md
+++ b/docs/create-source/create-source-kinesis.md
@@ -44,7 +44,7 @@ RisingWave performs primary key constraint checks on materialized sources but no
 For materialized sources with primary key constraints, if a new data record with an existing key comes in, the new record will overwrite the existing record. 
 :::
 
-### Connector Parameters
+### Connector parameters
 
 |Field|	Notes|
 |---|---|
@@ -59,7 +59,7 @@ For materialized sources with primary key constraints, if a new data record with
 |scan.startup.mode |Optional. The startup mode for Kinesis consumer. Supported modes: `earliest` (starts from the earliest offset), `latest` (starts from the latest offset), and `sequence_number` (starts from specific sequence number, specified by `scan.startup.sequence_number`). The default mode is `earliest`.|
 |scan.startup.sequence_number |Optional. This field specifies the sequence number to start consuming from. True if `scan.startup.mode` = `sequence_number`, otherwise False.| 
 
-### Other Parameters
+### Other parameters
 
 |Field|	Notes|
 |---|---|

--- a/docs/create-source/create-source-kinesis.md
+++ b/docs/create-source/create-source-kinesis.md
@@ -58,6 +58,9 @@ For materialized sources with primary key constraints, if a new data record with
 |aws.credentials.role.external_id|Optional. The [external id](https://aws.amazon.com/blogs/security/how-to-use-external-id-when-granting-access-to-your-aws-resources/) used to authorize access to third-party resources.	|
 |scan.startup.mode |Optional. The startup mode for Kinesis consumer. Supported modes: `earliest` (starts from the earliest offset), `latest` (starts from the latest offset), and `sequence_number` (starts from specific sequence number, specified by `scan.startup.sequence_number`). The default mode is `earliest`.|
 |scan.startup.sequence_number |Optional. This field specifies the sequence number to start consuming from. True if `scan.startup.mode` = `sequence_number`, otherwise False.| 
+
+### Other Parameters
+
 |*data_format*| Supported formats: `JSON`, `AVRO`, `PROTOBUF`.|
 |*message* |Message for the format. Required when *data_format* is `AVRO` or `PROTOBUF`.|
 |*location*| Web location of the schema file in  `http://...`, `https://...`, or `S3://...` format. Required when *data_format* is `AVRO` or `PROTOBUF`. Examples:<br/>`https://<example_host>/risingwave/proto-simple-schema.proto`<br/>`s3://risingwave-demo/schema-location` |

--- a/docs/create-source/create-source-pulsar.md
+++ b/docs/create-source/create-source-pulsar.md
@@ -18,7 +18,7 @@ CREATE {TABLE | SOURCE} [ IF NOT EXISTS ] source_name
 [schema_definition]
 WITH (
    connector='pulsar',
-   field_name='value', ...
+   connector_parameter='value', ...
 )
 ROW FORMAT data_format 
 [MESSAGE 'message']

--- a/docs/create-source/create-source-s3.md
+++ b/docs/create-source/create-source-s3.md
@@ -13,7 +13,7 @@ CREATE SOURCE [ IF NOT EXISTS ] source_name
 schema_definition
 WITH (
    connector='s3',
-   field_name='value', ...
+   connector_parameter='value', ...
 )
 ROW FORMAT csv [WITHOUT HEADER] DELIMITED BY ','; 
 ```

--- a/docs/ingestion-overview.md
+++ b/docs/ingestion-overview.md
@@ -1,0 +1,36 @@
+---
+id: ingestion-overview
+title: Overview of data ingestion
+slug: /ingestion-overview
+---
+
+You can ingest data into RisingWave in two ways:
+
+- Connect to and ingest data from external sources such as databases and message brokers.
+- Insert data to tables directly.
+
+## Ingest data from external data sources
+
+### Materialized and non-materialized source
+
+A source is a resource that RisingWave can get data from. You can create a source in RisingWave using the `CREATE SOURCE` command. When creating a source, you can choose to persist the data from the source in RisingWave by adding `MATERIALIZED` in between `CREATE` and `SOURCE` (that is, `CREATE MATERIALIZED SOURCE`). 
+
+Regardless whether the data is persisted in RisingWave or not, you can create materialized views or sinks to perform analysis and transformations.
+
+RisingWave supports ingesting data from these external sources:
+
+- [PostgreSQL CDC](./create-source/create-source-cdc.md)
+- [MySQL CDC](./create-source/create-source-cdc.md)
+- [Kafka](./create-source/create-source-kafka.md)
+- [Redpanda](./create-source/create-source-redpanda.md)
+- [Kinesis](./create-source/create-source-kinesis.md)
+- [Pulsar](./create-source/create-source-pulsar.md)
+
+
+### Supported data formats
+
+To learn about the supported data formats, see [Data formats](./sql/commands/sql-create-source.md#supported-formats).
+
+## Insert data into tables
+
+As a database, RisingWave supports creating tables ([`CREATE TABLE`](./sql/commands/sql-create-table.md)) and inserting data to tables ([`INSERT`](./sql/commands/sql-insert.md)).

--- a/docs/sql/commands/sql-create-source.md
+++ b/docs/sql/commands/sql-create-source.md
@@ -17,7 +17,7 @@ CREATE SOURCE [ IF NOT EXISTS ] source_name
 [schema_definition]
 WITH (
    connector='connector_name',
-   field_name='value', ...
+   connector_parameter='value', ...
 )
 ROW FORMAT data_format 
 [MESSAGE 'message']

--- a/docs/sql/commands/sql-create-table.md
+++ b/docs/sql/commands/sql-create-table.md
@@ -21,7 +21,7 @@ CREATE TABLE [ IF NOT EXISTS ] table_name (
 )
 [ WITH (
    connector='connector_name',
-   field_name='value', ...
+   connector_parameter='value', ...
 )
 ROW FORMAT data_format 
 [MESSAGE 'message']

--- a/versioned_docs/version-0.1.14/sql/create-source/create-source-cdc.md
+++ b/versioned_docs/version-0.1.14/sql/create-source/create-source-cdc.md
@@ -24,12 +24,12 @@ CREATE MATERIALIZED SOURCE [ IF NOT EXISTS ] source_name (
 ) 
 WITH (
    connector='kafka',
-   field_name='value', ...
+   connector_parameter='value', ...
 ) 
 ROW FORMAT { DEBEZIUM_JSON | MAXWELL };
 ```
 
-### `WITH` parameters
+### Connector Parameters
 
 
 |Field|	Default|	Type|	Description|	Required?|

--- a/versioned_docs/version-0.1.14/sql/create-source/create-source-cdc.md
+++ b/versioned_docs/version-0.1.14/sql/create-source/create-source-cdc.md
@@ -29,7 +29,7 @@ WITH (
 ROW FORMAT { DEBEZIUM_JSON | MAXWELL };
 ```
 
-### Connector Parameters
+### Connector parameters
 
 
 |Field|	Default|	Type|	Description|	Required?|

--- a/versioned_docs/version-0.1.14/sql/create-source/create-source-kafka-redpanda.md
+++ b/versioned_docs/version-0.1.14/sql/create-source/create-source-kafka-redpanda.md
@@ -33,7 +33,7 @@ RisingWave performs primary key constraint checks on materialized sources but no
 For materialized sources with primary key constraints, if a new data record with an existing key comes in, the new record will overwrite the existing record. 
 :::
 
-### Connector Parameters
+### Connector parameters
 
 |Field|	Required?| 	Notes|
 |---|---|---|

--- a/versioned_docs/version-0.1.14/sql/create-source/create-source-kafka-redpanda.md
+++ b/versioned_docs/version-0.1.14/sql/create-source/create-source-kafka-redpanda.md
@@ -20,7 +20,7 @@ CREATE [ MATERIALIZED ] SOURCE [ IF NOT EXISTS ] source_name (
 WITH (
    connector='kafka',
    topic='value',
-   field_name='value', ...
+   connector_parameter='value', ...
 )
 ROW FORMAT data_format 
 [ MESSAGE 'message' ]
@@ -33,7 +33,7 @@ RisingWave performs primary key constraint checks on materialized sources but no
 For materialized sources with primary key constraints, if a new data record with an existing key comes in, the new record will overwrite the existing record. 
 :::
 
-### `WITH` parameters
+### Connector Parameters
 
 |Field|	Required?| 	Notes|
 |---|---|---|

--- a/versioned_docs/version-0.1.14/sql/create-source/create-source-kinesis.md
+++ b/versioned_docs/version-0.1.14/sql/create-source/create-source-kinesis.md
@@ -29,7 +29,7 @@ RisingWave performs primary key constraint checks on materialized sources but no
 For materialized sources with primary key constraints, if a new data record with an existing key comes in, the new record will overwrite the existing record. 
 :::
 
-### Connector Parameters
+### Connector parameters
 
 |Field|	Default|	Type|	Description|	Required?|
 |---|---|---|---|---|
@@ -44,7 +44,7 @@ For materialized sources with primary key constraints, if a new data record with
 |scan.startup.mode |earliest  |String| The startup mode for Kinesis consumer. Supported modes: 'earliest' (starts from the earliest offset), 'latest' (starts from the latest offset), and 'sequence_number' (starts from specific sequence number, specified by 'scan.startup.sequence_number').|False|
 |scan.startup.sequence_number |None | String| Specify the sequence number to start consuming from. | True if `scan.startup.mode` = 'sequence_number', otherwise False| 
 
-### Row format parameters
+### Other parameters
 
 Specify the format of the stream in the `ROW FORMAT` section of your statement.
 

--- a/versioned_docs/version-0.1.14/sql/create-source/create-source-kinesis.md
+++ b/versioned_docs/version-0.1.14/sql/create-source/create-source-kinesis.md
@@ -16,7 +16,7 @@ CREATE [ MATERIALIZED ] SOURCE [ IF NOT EXISTS ] source_name (
 ) 
 WITH (
    connector='kinesis',
-   field_name='value', ...
+   connector_parameter='value', ...
 ) 
 ROW FORMAT data_format
 [ MESSAGE 'message' ]
@@ -29,7 +29,7 @@ RisingWave performs primary key constraint checks on materialized sources but no
 For materialized sources with primary key constraints, if a new data record with an existing key comes in, the new record will overwrite the existing record. 
 :::
 
-### `WITH` parameters
+### Connector Parameters
 
 |Field|	Default|	Type|	Description|	Required?|
 |---|---|---|---|---|

--- a/versioned_docs/version-0.1.14/sql/create-source/create-source-pulsar.md
+++ b/versioned_docs/version-0.1.14/sql/create-source/create-source-pulsar.md
@@ -30,7 +30,7 @@ RisingWave performs primary key constraint checks on materialized sources but no
 For materialized sources with primary key constraints, if a new data record with an existing key comes in, the new record will overwrite the existing record. 
 :::
 
-### Connector Parameters
+### Connector parameters
 
 |Field|	Default|	Type|	Description|	Required?|
 |---|---|---|---|---|
@@ -40,7 +40,7 @@ For materialized sources with primary key constraints, if a new data record with
 |scan.startup.mode	|earliest	|String	|The Pulsar consumer starts consuming data from the commit offset. This includes two values: `'earliest'` and `'latest'`.	|False|
 |scan.startup.timestamp_millis	|None	|Int64	|Specify the offset in milliseconds from a certain point of time.	|False|
 
-### Row format parameters
+### Other parameters
 
 Specify the format of the stream in the `ROW FORMAT` section of your statement.
 

--- a/versioned_docs/version-0.1.14/sql/create-source/create-source-pulsar.md
+++ b/versioned_docs/version-0.1.14/sql/create-source/create-source-pulsar.md
@@ -17,7 +17,7 @@ CREATE [ MATERIALIZED ] SOURCE [ IF NOT EXISTS ] source_name (
 )
 WITH (
    connector='pulsar',
-   field_name='value', ...
+   connector_parameter='value', ...
 )
 ROW FORMAT data_format 
 [MESSAGE 'message']
@@ -30,7 +30,7 @@ RisingWave performs primary key constraint checks on materialized sources but no
 For materialized sources with primary key constraints, if a new data record with an existing key comes in, the new record will overwrite the existing record. 
 :::
 
-### `WITH` parameters
+### Connector Parameters
 
 |Field|	Default|	Type|	Description|	Required?|
 |---|---|---|---|---|

--- a/versioned_docs/version-0.1.15/create-source/create-source-cdc.md
+++ b/versioned_docs/version-0.1.15/create-source/create-source-cdc.md
@@ -28,12 +28,12 @@ CREATE MATERIALIZED SOURCE [ IF NOT EXISTS ] source_name (
 ) 
 WITH (
    connector='kafka',
-   field_name='value', ...
+   connector_parameter='value', ...
 ) 
 ROW FORMAT { DEBEZIUM_JSON | MAXWELL };
 ```
 
-### `WITH` parameters
+### Connector Parameters
 
 |Field|Notes|
 |---|---|

--- a/versioned_docs/version-0.1.15/create-source/create-source-cdc.md
+++ b/versioned_docs/version-0.1.15/create-source/create-source-cdc.md
@@ -33,7 +33,7 @@ WITH (
 ROW FORMAT { DEBEZIUM_JSON | MAXWELL };
 ```
 
-### Connector Parameters
+### Connector parameters
 
 |Field|Notes|
 |---|---|

--- a/versioned_docs/version-0.1.15/create-source/create-source-kafka.md
+++ b/versioned_docs/version-0.1.15/create-source/create-source-kafka.md
@@ -47,7 +47,7 @@ For materialized sources with primary key constraints, if a new data record with
 
 :::
 
-### Parameters
+### `WITH` Parameters
 
 |Field|Notes|
 |---|---|

--- a/versioned_docs/version-0.1.15/create-source/create-source-kafka.md
+++ b/versioned_docs/version-0.1.15/create-source/create-source-kafka.md
@@ -18,7 +18,7 @@ CREATE [ MATERIALIZED ] SOURCE [ IF NOT EXISTS ] source_name
 [schema_definition]
 WITH (
    connector='kafka',
-   field_name='value', ...
+   connector_parameter='value', ...
 )
 ROW FORMAT data_format 
 [ MESSAGE 'message' ]
@@ -47,7 +47,7 @@ For materialized sources with primary key constraints, if a new data record with
 
 :::
 
-### `WITH` Parameters
+### Connector Parameters
 
 |Field|Notes|
 |---|---|

--- a/versioned_docs/version-0.1.15/create-source/create-source-kafka.md
+++ b/versioned_docs/version-0.1.15/create-source/create-source-kafka.md
@@ -57,11 +57,15 @@ For materialized sources with primary key constraints, if a new data record with
 |properties.group.id	|Required. Name of the Kafka consumer group	|
 |scan.startup.mode|Optional. The offset mode that RisingWave will use to consume data. The two supported modes are `earliest` (earliest offset) and `latest` (latest offset). If not specified, the default value `earliest` will be used.|
 |scan.startup.timestamp_millis|Optional. RisingWave will start to consume data from the specified UNIX timestamp (milliseconds). If this field is specified, the value for `scan.startup.mode` will be ignored.|
+
+### Other Parameters
+
+|Field|	Notes|
+|---|---|
 |*data_format*| Data format. Supported formats: `JSON`, `AVRO`, `PROTOBUF`|
 |*message* | Message for the format. Required for Avro and Protobuf.|
 |*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. For Avro and Protobuf data, you must specify either a schema location or a schema registry but not both.|
 |*schema_registry_url*| Confluent Schema Registry URL. Example: `http://127.0.0.1:8081`. For Avro or Protobuf data, you must specify either a schema location or a Confluent Schema Registry but not both.|
-
 
 ## Example
 

--- a/versioned_docs/version-0.1.15/create-source/create-source-kafka.md
+++ b/versioned_docs/version-0.1.15/create-source/create-source-kafka.md
@@ -47,7 +47,7 @@ For materialized sources with primary key constraints, if a new data record with
 
 :::
 
-### Connector Parameters
+### Connector parameters
 
 |Field|Notes|
 |---|---|
@@ -58,7 +58,7 @@ For materialized sources with primary key constraints, if a new data record with
 |scan.startup.mode|Optional. The offset mode that RisingWave will use to consume data. The two supported modes are `earliest` (earliest offset) and `latest` (latest offset). If not specified, the default value `earliest` will be used.|
 |scan.startup.timestamp_millis|Optional. RisingWave will start to consume data from the specified UNIX timestamp (milliseconds). If this field is specified, the value for `scan.startup.mode` will be ignored.|
 
-### Other Parameters
+### Other parameters
 
 |Field|	Notes|
 |---|---|

--- a/versioned_docs/version-0.1.15/create-source/create-source-kinesis.md
+++ b/versioned_docs/version-0.1.15/create-source/create-source-kinesis.md
@@ -42,7 +42,7 @@ RisingWave performs primary key constraint checks on materialized sources but no
 For materialized sources with primary key constraints, if a new data record with an existing key comes in, the new record will overwrite the existing record. 
 :::
 
-### Connector Parameters
+### Connector parameters
 
 |Field|	Notes|
 |---|---|
@@ -58,7 +58,7 @@ For materialized sources with primary key constraints, if a new data record with
 |scan.startup.mode |Optional. The startup mode for Kinesis consumer. Supported modes: 'earliest' (starts from the earliest offset), 'latest' (starts from the latest offset), and 'sequence_number' (starts from specific sequence number, specified by 'scan.startup.sequence_number'). The default mode is `earliest`.|
 |scan.startup.sequence_number |Optional. This field specifies the sequence number to start consuming from. True if `scan.startup.mode` = `sequence_number`, otherwise False.| 
 
-### Other Parameters
+### Other parameters
 
 |Field|	Notes|
 |---|---|

--- a/versioned_docs/version-0.1.15/create-source/create-source-kinesis.md
+++ b/versioned_docs/version-0.1.15/create-source/create-source-kinesis.md
@@ -42,7 +42,7 @@ RisingWave performs primary key constraint checks on materialized sources but no
 For materialized sources with primary key constraints, if a new data record with an existing key comes in, the new record will overwrite the existing record. 
 :::
 
-### Parameters
+### `WITH` Parameters
 
 |Field|	Notes|
 |---|---|

--- a/versioned_docs/version-0.1.15/create-source/create-source-kinesis.md
+++ b/versioned_docs/version-0.1.15/create-source/create-source-kinesis.md
@@ -57,10 +57,14 @@ For materialized sources with primary key constraints, if a new data record with
 |aws.credentials.role.external_id|Optional. The [external id](https://aws.amazon.com/blogs/security/how-to-use-external-id-when-granting-access-to-your-aws-resources/) used to authorize access to third-party resources.	|
 |scan.startup.mode |Optional. The startup mode for Kinesis consumer. Supported modes: 'earliest' (starts from the earliest offset), 'latest' (starts from the latest offset), and 'sequence_number' (starts from specific sequence number, specified by 'scan.startup.sequence_number'). The default mode is `earliest`.|
 |scan.startup.sequence_number |Optional. This field specifies the sequence number to start consuming from. True if `scan.startup.mode` = `sequence_number`, otherwise False.| 
+
+### Other Parameters
+
+|Field|	Notes|
+|---|---|
 |*data_format*| Supported formats: `JSON`, `AVRO`, `PROTOBUF`.|
 |*message* |Message for the format. Required when *data_format* is `AVRO` or `PROTOBUF`.|
 |*location*| Web location of the schema file in  `http://...`, `https://...`, or `S3://...` format. Required when *data_format* is `AVRO` or `PROTOBUF`. Examples:<br/>`https://<example_host>/risingwave/proto-simple-schema.proto`<br/>`s3://risingwave-demo/schema-location` |
-
 ## Example
 Here is an example of connecting RisingWave to Kinesis Data Streams to read data from individual streams.
 

--- a/versioned_docs/version-0.1.15/create-source/create-source-kinesis.md
+++ b/versioned_docs/version-0.1.15/create-source/create-source-kinesis.md
@@ -14,7 +14,7 @@ CREATE [ MATERIALIZED ] SOURCE [ IF NOT EXISTS ] source_name
 [schema_definition]
 WITH (
    connector='kinesis',
-   field_name='value', ...
+   connector_parameter='value', ...
 ) 
 ROW FORMAT data_format
 [ MESSAGE 'message' ]
@@ -42,7 +42,7 @@ RisingWave performs primary key constraint checks on materialized sources but no
 For materialized sources with primary key constraints, if a new data record with an existing key comes in, the new record will overwrite the existing record. 
 :::
 
-### `WITH` Parameters
+### Connector Parameters
 
 |Field|	Notes|
 |---|---|

--- a/versioned_docs/version-0.1.15/create-source/create-source-pulsar.md
+++ b/versioned_docs/version-0.1.15/create-source/create-source-pulsar.md
@@ -45,7 +45,7 @@ For materialized sources with primary key constraints, if a new data record with
 :::
 
 
-### Connector Parameters
+### Connector parameters
 
 |Field|Notes|
 |---|---|
@@ -56,7 +56,7 @@ For materialized sources with primary key constraints, if a new data record with
 |scan.startup.mode|Optional. The offset mode that RisingWave will use to consume data. The two supported modes are `earliest` (earliest offset) and `latest` (latest offset). If not specified, the default value `earliest` will be used.|
 |scan.startup.timestamp_millis.| Optional. RisingWave will start to consume data from the specified UNIX timestamp (milliseconds).|
 
-### Other Parameters
+### Other parameters
 
 |Field|	Notes|
 |---|---|

--- a/versioned_docs/version-0.1.15/create-source/create-source-pulsar.md
+++ b/versioned_docs/version-0.1.15/create-source/create-source-pulsar.md
@@ -15,7 +15,7 @@ CREATE [ MATERIALIZED ] SOURCE [ IF NOT EXISTS ] source_name
 [schema_definition]
 WITH (
    connector='pulsar',
-   field_name='value', ...
+   connector_parameter='value', ...
 )
 ROW FORMAT data_format 
 [MESSAGE 'message']
@@ -45,7 +45,7 @@ For materialized sources with primary key constraints, if a new data record with
 :::
 
 
-### `WITH` Parameters
+### Connector Parameters
 
 |Field|Notes|
 |---|---|

--- a/versioned_docs/version-0.1.15/create-source/create-source-pulsar.md
+++ b/versioned_docs/version-0.1.15/create-source/create-source-pulsar.md
@@ -45,7 +45,7 @@ For materialized sources with primary key constraints, if a new data record with
 :::
 
 
-### Parameters
+### `WITH` Parameters
 
 |Field|Notes|
 |---|---|

--- a/versioned_docs/version-0.1.15/create-source/create-source-pulsar.md
+++ b/versioned_docs/version-0.1.15/create-source/create-source-pulsar.md
@@ -55,6 +55,11 @@ For materialized sources with primary key constraints, if a new data record with
 |admin.url	|Required. Address of the Pulsar admin.|
 |scan.startup.mode|Optional. The offset mode that RisingWave will use to consume data. The two supported modes are `earliest` (earliest offset) and `latest` (latest offset). If not specified, the default value `earliest` will be used.|
 |scan.startup.timestamp_millis.| Optional. RisingWave will start to consume data from the specified UNIX timestamp (milliseconds).|
+
+### Other Parameters
+
+|Field|	Notes|
+|---|---|
 |*data_format*| Supported formats: `JSON`, `AVRO`, `PROTOBUF`.|
 |*message* |Message for the format. Required when *data_format* is `AVRO` or `PROTOBUF`.|
 |*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. Required when *data_format* is `AVRO` or `PROTOBUF`. Examples:<br/>`https://<example_host>/risingwave/proto-simple-schema.proto`<br/>`s3://risingwave-demo/schema-location` |

--- a/versioned_docs/version-0.1.15/sql/commands/sql-create-source.md
+++ b/versioned_docs/version-0.1.15/sql/commands/sql-create-source.md
@@ -16,7 +16,7 @@ CREATE [ MATERIALIZED ] SOURCE [ IF NOT EXISTS ] source_name
 [schema_definition]
 WITH (
    connector='connector_name',
-   field_name='value', ...
+   connector_parameter='value', ...
 )
 ROW FORMAT data_format 
 [MESSAGE 'message']

--- a/versioned_docs/version-0.1.16/create-source/create-source-cdc.md
+++ b/versioned_docs/version-0.1.16/create-source/create-source-cdc.md
@@ -31,12 +31,12 @@ CREATE TABLE [ IF NOT EXISTS ] source_name (
 ) 
 WITH (
    connector='kafka',
-   field_name='value', ...
+   connector_parameter='value', ...
 ) 
 ROW FORMAT { DEBEZIUM_JSON | MAXWELL };
 ```
 
-### `WITH` parameters
+### Connector Parameters
 
 |Field|Notes|
 |---|---|

--- a/versioned_docs/version-0.1.16/create-source/create-source-cdc.md
+++ b/versioned_docs/version-0.1.16/create-source/create-source-cdc.md
@@ -36,7 +36,7 @@ WITH (
 ROW FORMAT { DEBEZIUM_JSON | MAXWELL };
 ```
 
-### Connector Parameters
+### Connector parameters
 
 |Field|Notes|
 |---|---|

--- a/versioned_docs/version-0.1.16/create-source/create-source-kafka.md
+++ b/versioned_docs/version-0.1.16/create-source/create-source-kafka.md
@@ -56,6 +56,11 @@ For materialized sources with primary key constraints, if a new data record with
 |properties.group.id	|Required. Name of the Kafka consumer group	|
 |scan.startup.mode|Optional. The offset mode that RisingWave will use to consume data. The two supported modes are `earliest` (earliest offset) and `latest` (latest offset). If not specified, the default value `earliest` will be used.|
 |scan.startup.timestamp_millis|Optional. RisingWave will start to consume data from the specified UNIX timestamp (milliseconds). If this field is specified, the value for `scan.startup.mode` will be ignored.|
+
+### Other Parameters
+
+|Field|	Notes|
+|---|---|
 |*data_format*| Data format. Supported formats: `JSON`, `AVRO`, `PROTOBUF`|
 |*message* | Message for the format. Required for Avro and Protobuf.|
 |*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. For Avro and Protobuf data, you must specify either a schema location or a schema registry but not both.|

--- a/versioned_docs/version-0.1.16/create-source/create-source-kafka.md
+++ b/versioned_docs/version-0.1.16/create-source/create-source-kafka.md
@@ -18,7 +18,7 @@ CREATE {TABLE | SOURCE} [ IF NOT EXISTS ] source_name
 [schema_definition]
 WITH (
    connector='kafka',
-   field_name='value', ...
+   connector_parameter='value', ...
 )
 ROW FORMAT data_format 
 [ MESSAGE 'message' ]
@@ -47,7 +47,7 @@ For materialized sources with primary key constraints, if a new data record with
 
 :::
 
-### `WITH` Parameters
+### Connector Parameters
 
 |Field|Notes|
 |---|---|

--- a/versioned_docs/version-0.1.16/create-source/create-source-kafka.md
+++ b/versioned_docs/version-0.1.16/create-source/create-source-kafka.md
@@ -47,7 +47,7 @@ For materialized sources with primary key constraints, if a new data record with
 
 :::
 
-### Connector Parameters
+### Connector parameters
 
 |Field|Notes|
 |---|---|
@@ -57,7 +57,7 @@ For materialized sources with primary key constraints, if a new data record with
 |scan.startup.mode|Optional. The offset mode that RisingWave will use to consume data. The two supported modes are `earliest` (earliest offset) and `latest` (latest offset). If not specified, the default value `earliest` will be used.|
 |scan.startup.timestamp_millis|Optional. RisingWave will start to consume data from the specified UNIX timestamp (milliseconds). If this field is specified, the value for `scan.startup.mode` will be ignored.|
 
-### Other Parameters
+### Other parameters
 
 |Field|	Notes|
 |---|---|

--- a/versioned_docs/version-0.1.16/create-source/create-source-kafka.md
+++ b/versioned_docs/version-0.1.16/create-source/create-source-kafka.md
@@ -47,7 +47,7 @@ For materialized sources with primary key constraints, if a new data record with
 
 :::
 
-### Parameters
+### `WITH` Parameters
 
 |Field|Notes|
 |---|---|

--- a/versioned_docs/version-0.1.16/create-source/create-source-kinesis.md
+++ b/versioned_docs/version-0.1.16/create-source/create-source-kinesis.md
@@ -44,7 +44,7 @@ RisingWave performs primary key constraint checks on materialized sources but no
 For materialized sources with primary key constraints, if a new data record with an existing key comes in, the new record will overwrite the existing record. 
 :::
 
-### Parameters
+### `WITH` Parameters
 
 |Field|	Notes|
 |---|---|

--- a/versioned_docs/version-0.1.16/create-source/create-source-kinesis.md
+++ b/versioned_docs/version-0.1.16/create-source/create-source-kinesis.md
@@ -16,7 +16,7 @@ CREATE {TABLE | SOURCE} [ IF NOT EXISTS ] source_name
 [schema_definition]
 WITH (
    connector='kinesis',
-   field_name='value', ...
+   connector_parameter='value', ...
 ) 
 ROW FORMAT data_format
 [ MESSAGE 'message' ]
@@ -44,7 +44,7 @@ RisingWave performs primary key constraint checks on materialized sources but no
 For materialized sources with primary key constraints, if a new data record with an existing key comes in, the new record will overwrite the existing record. 
 :::
 
-### `WITH` Parameters
+### Connector Parameters
 
 |Field|	Notes|
 |---|---|

--- a/versioned_docs/version-0.1.16/create-source/create-source-kinesis.md
+++ b/versioned_docs/version-0.1.16/create-source/create-source-kinesis.md
@@ -44,7 +44,7 @@ RisingWave performs primary key constraint checks on materialized sources but no
 For materialized sources with primary key constraints, if a new data record with an existing key comes in, the new record will overwrite the existing record. 
 :::
 
-### Connector Parameters
+### Connector parameters
 
 |Field|	Notes|
 |---|---|
@@ -59,7 +59,7 @@ For materialized sources with primary key constraints, if a new data record with
 |scan.startup.mode |Optional. The startup mode for Kinesis consumer. Supported modes: `earliest` (starts from the earliest offset), `latest` (starts from the latest offset), and `sequence_number` (starts from specific sequence number, specified by `scan.startup.sequence_number`). The default mode is `earliest`.|
 |scan.startup.sequence_number |Optional. This field specifies the sequence number to start consuming from. True if `scan.startup.mode` = `sequence_number`, otherwise False.| 
 
-### Other Parameters
+### Other parameters
 
 |Field|	Notes|
 |---|---|

--- a/versioned_docs/version-0.1.16/create-source/create-source-kinesis.md
+++ b/versioned_docs/version-0.1.16/create-source/create-source-kinesis.md
@@ -58,6 +58,11 @@ For materialized sources with primary key constraints, if a new data record with
 |aws.credentials.role.external_id|Optional. The [external id](https://aws.amazon.com/blogs/security/how-to-use-external-id-when-granting-access-to-your-aws-resources/) used to authorize access to third-party resources.	|
 |scan.startup.mode |Optional. The startup mode for Kinesis consumer. Supported modes: `earliest` (starts from the earliest offset), `latest` (starts from the latest offset), and `sequence_number` (starts from specific sequence number, specified by `scan.startup.sequence_number`). The default mode is `earliest`.|
 |scan.startup.sequence_number |Optional. This field specifies the sequence number to start consuming from. True if `scan.startup.mode` = `sequence_number`, otherwise False.| 
+
+### Other Parameters
+
+|Field|	Notes|
+|---|---|
 |*data_format*| Supported formats: `JSON`, `AVRO`, `PROTOBUF`.|
 |*message* |Message for the format. Required when *data_format* is `AVRO` or `PROTOBUF`.|
 |*location*| Web location of the schema file in  `http://...`, `https://...`, or `S3://...` format. Required when *data_format* is `AVRO` or `PROTOBUF`. Examples:<br/>`https://<example_host>/risingwave/proto-simple-schema.proto`<br/>`s3://risingwave-demo/schema-location` |

--- a/versioned_docs/version-0.1.16/create-source/create-source-pulsar.md
+++ b/versioned_docs/version-0.1.16/create-source/create-source-pulsar.md
@@ -18,7 +18,7 @@ CREATE {TABLE | SOURCE} [ IF NOT EXISTS ] source_name
 [schema_definition]
 WITH (
    connector='pulsar',
-   field_name='value', ...
+   connector_parameter='value', ...
 )
 ROW FORMAT data_format 
 [MESSAGE 'message']

--- a/versioned_docs/version-0.1.16/create-source/create-source-s3.md
+++ b/versioned_docs/version-0.1.16/create-source/create-source-s3.md
@@ -13,7 +13,7 @@ CREATE SOURCE [ IF NOT EXISTS ] source_name
 schema_definition
 WITH (
    connector='s3',
-   field_name='value', ...
+   connector_parameter='value', ...
 )
 ROW FORMAT csv [WITHOUT HEADER] DELIMITED BY ','; 
 ```

--- a/versioned_docs/version-0.1.16/sql/commands/sql-create-source.md
+++ b/versioned_docs/version-0.1.16/sql/commands/sql-create-source.md
@@ -17,7 +17,7 @@ CREATE SOURCE [ IF NOT EXISTS ] source_name
 [schema_definition]
 WITH (
    connector='connector_name',
-   field_name='value', ...
+   connector_parameter='value', ...
 )
 ROW FORMAT data_format 
 [MESSAGE 'message']

--- a/versioned_docs/version-0.1.16/sql/commands/sql-create-table.md
+++ b/versioned_docs/version-0.1.16/sql/commands/sql-create-table.md
@@ -21,7 +21,7 @@ CREATE TABLE [ IF NOT EXISTS ] table_name (
 )
 [ WITH (
    connector='connector_name',
-   field_name='value', ...
+   connector_parameter='value', ...
 )
 ROW FORMAT data_format 
 [MESSAGE 'message']


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
[ What's changed? ]

When I see `field_name` I feel a little bit confused about what it is. And there's nothing else called `field_name` in the doc. I cannot relate it to the `Parameter` section. 

Some pages call it `WITH Parameter` (inconsistency!). That's better. But what about `connector_parameter` which seems more clear?

- **Preview**: 
[ Paste the preview link to the edited page here. ]

- **Related code PR**: 


- **Related doc issue**: 
Resolves [ Provide the link to the doc issue here. ]

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
