### PR TITLE
fix: remove group id in kafka source

### DIFF
--- a/docs/create-source/create-source-kafka.md
+++ b/docs/create-source/create-source-kafka.md
@@ -124,7 +124,6 @@ For materialized sources with primary key constraints, if a new data record with
 |---|---|
 |topic| Required. Address of the Kafka topic. One source can only correspond to one topic.|
 |properties.bootstrap.server| Required. Address of the Kafka broker. Format: `'ip:port,ip:port'`.	|
-|properties.group.id	|Required. Name of the Kafka consumer group	|
 |scan.startup.mode|Optional. The offset mode that RisingWave will use to consume data. The two supported modes are `earliest` (earliest offset) and `latest` (latest offset). If not specified, the default value `earliest` will be used.|
 |scan.startup.timestamp_millis|Optional. RisingWave will start to consume data from the specified UNIX timestamp (milliseconds). If this field is specified, the value for `scan.startup.mode` will be ignored.|
 
@@ -154,8 +153,7 @@ WITH (
    topic='demo_topic',
    properties.bootstrap.server='172.10.1.1:9090,172.10.1.2:9090',
    scan.startup.mode='latest',
-   scan.startup.timestamp_millis='140000000',
-   properties.group.id='demo_consumer_name'
+   scan.startup.timestamp_millis='140000000'
 )
 ROW FORMAT AVRO MESSAGE 'main_message'
 ROW SCHEMA LOCATION CONFLUENT SCHEMA REGISTRY 'http://127.0.0.1:8081';
@@ -173,8 +171,7 @@ WITH (
    topic='demo_topic',
    properties.bootstrap.server='172.10.1.1:9090,172.10.1.2:9090',
    scan.startup.mode='latest',
-   scan.startup.timestamp_millis='140000000',
-   properties.group.id='demo_consumer_name'
+   scan.startup.timestamp_millis='140000000'
 )
 ROW FORMAT JSON;
 ```
@@ -188,8 +185,7 @@ WITH (
    topic='demo_topic',
    properties.bootstrap.server='172.10.1.1:9090,172.10.1.2:9090',
    scan.startup.mode='latest',
-   scan.startup.timestamp_millis='140000000',
-   properties.group.id='demo_consumer_name'
+   scan.startup.timestamp_millis='140000000'
 )
 ROW FORMAT PROTOBUF MESSAGE 'main_message'
 ROW SCHEMA LOCATION 'https://demo_bucket_name.s3-us-west-2.amazonaws.com/demo.proto';

--- a/versioned_docs/version-0.1.17/create-source/create-source-kafka.md
+++ b/versioned_docs/version-0.1.17/create-source/create-source-kafka.md
@@ -124,7 +124,6 @@ For materialized sources with primary key constraints, if a new data record with
 |---|---|
 |topic| Required. Address of the Kafka topic. One source can only correspond to one topic.|
 |properties.bootstrap.server| Required. Address of the Kafka broker. Format: `'ip:port,ip:port'`.	|
-|properties.group.id	|Required. Name of the Kafka consumer group	|
 |scan.startup.mode|Optional. The offset mode that RisingWave will use to consume data. The two supported modes are `earliest` (earliest offset) and `latest` (latest offset). If not specified, the default value `earliest` will be used.|
 |scan.startup.timestamp_millis|Optional. RisingWave will start to consume data from the specified UNIX timestamp (milliseconds). If this field is specified, the value for `scan.startup.mode` will be ignored.|
 

--- a/versioned_docs/version-0.1.17/create-source/create-source-kafka.md
+++ b/versioned_docs/version-0.1.17/create-source/create-source-kafka.md
@@ -153,8 +153,7 @@ WITH (
    topic='demo_topic',
    properties.bootstrap.server='172.10.1.1:9090,172.10.1.2:9090',
    scan.startup.mode='latest',
-   scan.startup.timestamp_millis='140000000',
-   properties.group.id='demo_consumer_name'
+   scan.startup.timestamp_millis='140000000'
 )
 ROW FORMAT AVRO MESSAGE 'main_message'
 ROW SCHEMA LOCATION CONFLUENT SCHEMA REGISTRY 'http://127.0.0.1:8081';
@@ -172,8 +171,7 @@ WITH (
    topic='demo_topic',
    properties.bootstrap.server='172.10.1.1:9090,172.10.1.2:9090',
    scan.startup.mode='latest',
-   scan.startup.timestamp_millis='140000000',
-   properties.group.id='demo_consumer_name'
+   scan.startup.timestamp_millis='140000000'
 )
 ROW FORMAT JSON;
 ```
@@ -187,8 +185,7 @@ WITH (
    topic='demo_topic',
    properties.bootstrap.server='172.10.1.1:9090,172.10.1.2:9090',
    scan.startup.mode='latest',
-   scan.startup.timestamp_millis='140000000',
-   properties.group.id='demo_consumer_name'
+   scan.startup.timestamp_millis='140000000'
 )
 ROW FORMAT PROTOBUF MESSAGE 'main_message'
 ROW SCHEMA LOCATION 'https://demo_bucket_name.s3-us-west-2.amazonaws.com/demo.proto';


### PR DESCRIPTION
as group id is for the consumer group concept in kafka and we are not using this feature, using it can lead to some unexpected behavior.

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
[ What's changed? ]

as group id is for the consumer group concept in kafka and we are not using this feature, using it can lead to some unexpected behavior.

- **Preview**: 
[ Paste the preview link to the edited page here. ]

- **Related code PR**: 
[ Provide the link to the code PR here. For example, https://github.com/risingwavelabs/risingwave/pull/4085. Delete this part if there's no code PR related. ]

- **Related doc issue**: 
Resolves [ Provide the link to the doc issue here. ]

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
