### PR TITLE
Update Run RisingWave locally docs

### DIFF
--- a/versioned_docs/version-0.1.17/deploy/risingwave-local.md
+++ b/versioned_docs/version-0.1.17/deploy/risingwave-local.md
@@ -74,7 +74,7 @@ import TabItem from '@theme/TabItem';
     ```
 
     :::note
-    If you are using a Mac with Apple silicon (such as the M1 / M2 chip), you need to install `LLVM` by running `brew llvm`.
+    If you are using a Mac with Apple silicon (such as the M1 / M2 chip), you need to install `LLVM` by running `brew install llvm`.
     :::
 
     </TabItem>


### PR DESCRIPTION
Fix LLVM install note command for Apple silicon

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Fix LLVM install note for ARM Macs
Changed the LLVM install command from
from :
```bash
brew llvm
```
to
```bash
brew install llvm
```
- **Preview**: 
[Preview](https://pr-639.d2fbku9n2b6wde.amplifyapp.com/docs/current/risingwave-local/)

- **Related code PR**: 
None
- **Related doc issue**: 
None

- **Notes**: 
None

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [x] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [x] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
