### PR TITLE
Remove MESSAGE clause from AVRO examples

### DIFF
--- a/docs/create-source/create-source-kafka.md
+++ b/docs/create-source/create-source-kafka.md
@@ -132,7 +132,7 @@ For materialized sources with primary key constraints, if a new data record with
 |Field|Notes|
 |---|---|
 |*data_format*| Data format. Supported formats: `JSON`, `AVRO`, `PROTOBUF`|
-|*message* | Message for the format. Required for Avro and Protobuf.|
+|*message* | Message for the format. Required for Protobuf.|
 |*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. For Avro and Protobuf data, you must specify either a schema location or a schema registry but not both.|
 |*schema_registry_url*| Confluent Schema Registry URL. Example: `http://127.0.0.1:8081`. For Avro or Protobuf data, you must specify either a schema location or a Confluent Schema Registry but not both.|
 
@@ -155,7 +155,7 @@ WITH (
    scan.startup.mode='latest',
    scan.startup.timestamp_millis='140000000'
 )
-ROW FORMAT AVRO MESSAGE 'main_message'
+ROW FORMAT AVRO
 ROW SCHEMA LOCATION CONFLUENT SCHEMA REGISTRY 'http://127.0.0.1:8081';
 ```
 </TabItem>

--- a/docs/create-source/create-source-kafka.md
+++ b/docs/create-source/create-source-kafka.md
@@ -132,7 +132,7 @@ For materialized sources with primary key constraints, if a new data record with
 |Field|Notes|
 |---|---|
 |*data_format*| Data format. Supported formats: `JSON`, `AVRO`, `PROTOBUF`|
-|*message* | Message for the format. Required for Protobuf.|
+|*message* | Message name of the main Message in schema definition. Required for Protobuf.|
 |*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. For Avro and Protobuf data, you must specify either a schema location or a schema registry but not both.|
 |*schema_registry_url*| Confluent Schema Registry URL. Example: `http://127.0.0.1:8081`. For Avro or Protobuf data, you must specify either a schema location or a Confluent Schema Registry but not both.|
 

--- a/docs/create-source/create-source-kinesis.md
+++ b/docs/create-source/create-source-kinesis.md
@@ -129,7 +129,7 @@ For materialized sources with primary key constraints, if a new data record with
 |Field|	Notes|
 |---|---|
 |*data_format*| Supported formats: `JSON`, `AVRO`, `PROTOBUF`.|
-|*message* |Message for the format. Required when *data_format* is `PROTOBUF`.|
+|*message* |Message name of the main Message in schema definition. Required when *data_format* is `PROTOBUF`.|
 |*location*| Web location of the schema file in  `http://...`, `https://...`, or `S3://...` format. Required when *data_format* is `AVRO` or `PROTOBUF`. Examples:<br/>`https://<example_host>/risingwave/proto-simple-schema.proto`<br/>`s3://risingwave-demo/schema-location` |
 
 ## Example

--- a/docs/create-source/create-source-kinesis.md
+++ b/docs/create-source/create-source-kinesis.md
@@ -129,7 +129,7 @@ For materialized sources with primary key constraints, if a new data record with
 |Field|	Notes|
 |---|---|
 |*data_format*| Supported formats: `JSON`, `AVRO`, `PROTOBUF`.|
-|*message* |Message for the format. Required when *data_format* is `AVRO` or `PROTOBUF`.|
+|*message* |Message for the format. Required when *data_format* is `PROTOBUF`.|
 |*location*| Web location of the schema file in  `http://...`, `https://...`, or `S3://...` format. Required when *data_format* is `AVRO` or `PROTOBUF`. Examples:<br/>`https://<example_host>/risingwave/proto-simple-schema.proto`<br/>`s3://risingwave-demo/schema-location` |
 
 ## Example
@@ -152,7 +152,7 @@ WITH (
    aws.credentials.role.arn='arn:aws-cn:iam::602389639824:role/demo_role',
    aws.credentials.role.external_id='demo_external_id'
 ) 
-ROW FORMAT AVRO MESSAGE 'main_message'
+ROW FORMAT AVRO
 ROW SCHEMA LOCATION 'https://demo_bucket_name.s3-us-west-2.amazonaws.com/demo.avsc';
 ```
 </TabItem>

--- a/docs/create-source/create-source-pulsar.md
+++ b/docs/create-source/create-source-pulsar.md
@@ -124,7 +124,7 @@ For materialized sources with primary key constraints, if a new data record with
 |scan.startup.mode|Optional. The offset mode that RisingWave will use to consume data. The two supported modes are `earliest` (earliest offset) and `latest` (latest offset). If not specified, the default value `earliest` will be used.|
 |scan.startup.timestamp_millis.| Optional. RisingWave will start to consume data from the specified UNIX timestamp (milliseconds).|
 |*data_format*| Supported formats: `JSON`, `AVRO`, `PROTOBUF`.|
-|*message* |Message for the format. Required when *data_format* is `AVRO` or `PROTOBUF`.|
+|*message* |Message for the format. Required when *data_format* is `PROTOBUF`.|
 |*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. Required when *data_format* is `AVRO` or `PROTOBUF`. Examples:<br/>`https://<example_host>/risingwave/proto-simple-schema.proto`<br/>`s3://risingwave-demo/schema-location` |
 
 ## Example
@@ -146,7 +146,7 @@ WITH (
    scan.startup.mode='latest',
    scan.startup.timestamp_millis='140000000'
 )
-ROW FORMAT AVRO MESSAGE 'FooMessage'
+ROW FORMAT AVRO
 ROW SCHEMA LOCATION 'https://demo_bucket_name.s3-us-west-2.amazonaws.com/demo.avsc';
 ```
 </TabItem>

--- a/docs/create-source/create-source-pulsar.md
+++ b/docs/create-source/create-source-pulsar.md
@@ -124,7 +124,7 @@ For materialized sources with primary key constraints, if a new data record with
 |scan.startup.mode|Optional. The offset mode that RisingWave will use to consume data. The two supported modes are `earliest` (earliest offset) and `latest` (latest offset). If not specified, the default value `earliest` will be used.|
 |scan.startup.timestamp_millis.| Optional. RisingWave will start to consume data from the specified UNIX timestamp (milliseconds).|
 |*data_format*| Supported formats: `JSON`, `AVRO`, `PROTOBUF`.|
-|*message* |Message for the format. Required when *data_format* is `PROTOBUF`.|
+|*message* |Message name of the main Message in schema definition. Required when *data_format* is `PROTOBUF`.|
 |*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. Required when *data_format* is `AVRO` or `PROTOBUF`. Examples:<br/>`https://<example_host>/risingwave/proto-simple-schema.proto`<br/>`s3://risingwave-demo/schema-location` |
 
 ## Example


### PR DESCRIPTION
## Info
- **Description**: 
Remove MESSAGE clause from AVRO examples

- **Preview**: 
[ Paste the preview link to the edited page here. ]

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/8124

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/640

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
