### PR TITLE
Add array_to_string and array_join functions

### DIFF
--- a/docs/sql/functions-operators/sql-function-array.md
+++ b/docs/sql/functions-operators/sql-function-array.md
@@ -6,4 +6,5 @@ title: Array functions
 
 |Function|Description|Example|
 |---|---|---|
+| array_to_string(*any_array*, *delimiter_string*, *null_string*) → *output_string* <br /><br /> array_join(*any_array*, *delimiter_string*, *null_string*) → *output_string* |Converts an array to a string. The optional *delimiter_string* separates the array's elements in the resulting string, and the optional *null_string* represents `NULL` elements in the array. `array_join` can also be used instead of `array_to_string`.|`array_to_string(array[1, 2, 3, NULL, 5], ',', '*')` → `1,2,3,*,5` <br /> `array_join(array[1, 2, 3, NULL, 5], ',', '*')` → `1,2,3,*,5`|
 | unnest(*any_array*) → *set_of_any_element* |Expands an array, or combination of arrays, into a set of rows. The array's elements are output in the order they are stored.|`unnest(Array[1,2,3])` → <br />`1`<br />`2`<br />`3` <br /> `unnest(Array[Array[1,3,4,5],Array[2,3]])` → <br />`1`<br />`3`<br />`4`<br />`5`<br />`2`<br />`3`|


### PR DESCRIPTION
Add array_to_string() and array_join() functions.

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Add array_to_string() and array_join() functions.

- **Preview**: 
https://pr-656.d2fbku9n2b6wde.amplifyapp.com/docs/upcoming/sql-function-array/

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/8027
https://github.com/risingwavelabs/risingwave/pull/8069

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/636

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
