### PR TITLE
Add diagram to SHOW SINKS

### DIFF
--- a/docs/sql/commands/sql-show-sinks.md
+++ b/docs/sql/commands/sql-show-sinks.md
@@ -14,6 +14,19 @@ SHOW SINKS;
 ```
 
 
+import rr from '@theme/RailroadDiagram'
+
+export const svg = rr.Diagram(
+    rr.Sequence(
+        rr.Terminal('SHOW SINKS'),
+        rr.Terminal(';'),
+    )
+);
+
+<drawer SVG={svg} />
+
+
+
 ## Example
 
 ```sql


### PR DESCRIPTION
Add diagram to SHOW SINKS.

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Add diagram to SHOW SINKS.

- **Preview**: 
https://pr-674.d2fbku9n2b6wde.amplifyapp.com/docs/upcoming/sql-show-sinks/

- **Related code PR**: 
N/A

- **Related doc issue**: 
Resolves no doc issue.

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
