### PR TITLE
Update rw-integration-summary.md

### DIFF
--- a/versioned_docs/version-0.1.17/rw-integration-summary.md
+++ b/versioned_docs/version-0.1.17/rw-integration-summary.md
@@ -92,7 +92,7 @@ For tools or integrations that you would like to use but are not listed in the t
 
 |System ||Availability |
 |---|-|--|
-|Apache Superset| |Available. See [Visualize RisingWave data in Superset](/guides/grafana-integration.md) for details. |
+|Apache Superset| |Available. See [Visualize RisingWave data in Superset](/guides/superset-integration.md) for details. |
 |Cube.js| | Researching <voteNotify note="cubejs" />|
 |DBeaver| |In progress <voteNotify note="dbeaver" />|
 |Grafana| |Available. See [Visualize RisingWave data in Grafana](/guides/grafana-integration.md) for details.|


### PR DESCRIPTION
FIx superset integration guide path.

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Fix the path for the Superset example from  

*grafana-integration.md* to *superset-integration.md*

- **Preview**: 
https://pr-677.d2fbku9n2b6wde.amplifyapp.com/docs/current/rw-integration-summary/
- **Related code PR**: 
None
- **Related doc issue**: 
Resolves [ Provide the link to the doc issue here. ]
None
- **Notes**: 
None
<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
