### PR TITLE
Add interval microsecond precision

### DIFF
--- a/docs/sql/sql-data-types.md
+++ b/docs/sql/sql-data-types.md
@@ -21,7 +21,7 @@ RisingWave supports the following data types:
 |time without time zone|time|Time of day (no time zone) | Example: `time '18:20:49'` |
 |timestamp without time zone|timestamp|Date and time (no time zone) | Example: `'2022-03-13 01:00:00'::timestamp` |
 |timestamp with time zone |timestamptz|Timestamp with time zone. <br/>The 'Z' stands for UTC (Coordinated Universal Time). | Example: `'2022-03-13 01:00:00Z'::timestamptz` |
-|interval| |Time span. <br/>Input in string format. Units include: microsecond/microseconds/usecs, second/seconds/s, minute/minutes/min/m, hour/hours/hr/h, day/days/d, month/months/mon, and year/years/yr/y. | Examples: `interval '4 hour'` → `04:00:00.000000` <br /> `interval '3 day'` → `3 days 00:00:00.000000` |
+|interval| |Time span. <br/>Input in string format. Units include: second/seconds/s, minute/minutes/min/m, hour/hours/hr/h, day/days/d, month/months/mon, and year/years/yr/y. Units smaller than seconds can be specified in the input. | Examples: `interval '4 hour'` → `04:00:00` <br /> `interval '3 day'` → `3 days 00:00:00` <br /> `interval '04:00:00.1234'` → `04:00:00.1234` |
 |struct| |A struct is a column that contains nested data. For syntax and examples, see [Struct](./data-types/data-type-struct.md). | |
 |array| | An array is an ordered list of zero or more elements that share the same data type including the array type. For syntax and examples, see [Array](./data-types/data-type-array.md).|
 

--- a/docs/sql/sql-data-types.md
+++ b/docs/sql/sql-data-types.md
@@ -21,7 +21,7 @@ RisingWave supports the following data types:
 |time without time zone|time|Time of day (no time zone) | Example: `time '18:20:49'` |
 |timestamp without time zone|timestamp|Date and time (no time zone) | Example: `'2022-03-13 01:00:00'::timestamp` |
 |timestamp with time zone |timestamptz|Timestamp with time zone. <br/>The 'Z' stands for UTC (Coordinated Universal Time). | Example: `'2022-03-13 01:00:00Z'::timestamptz` |
-|interval| |Time span. <br/>Input in string format. Units include: second/seconds/s, minute/minutes/min/m, hour/hours/hr/h, day/days/d, month/months/mon, and year/years/yr/y. Units smaller than second can be specified in the input. | Examples: `interval '4 hour'` → `04:00:00` <br /> `interval '3 day'` → `3 days 00:00:00` <br /> `interval '04:00:00.1234'` → `04:00:00.1234` |
+|interval| |Time span. <br/>Input in string format. Units include: second/seconds/s, minute/minutes/min/m, hour/hours/hr/h, day/days/d, month/months/mon, and year/years/yr/y. Units smaller than second can only be specified in a numerical format. | Examples: `interval '4 hour'` → `04:00:00` <br /> `interval '3 day'` → `3 days 00:00:00` <br /> `interval '04:00:00.1234'` → `04:00:00.1234` |
 |struct| |A struct is a column that contains nested data. For syntax and examples, see [Struct](./data-types/data-type-struct.md). | |
 |array| | An array is an ordered list of zero or more elements that share the same data type including the array type. For syntax and examples, see [Array](./data-types/data-type-array.md).|
 

--- a/docs/sql/sql-data-types.md
+++ b/docs/sql/sql-data-types.md
@@ -21,7 +21,7 @@ RisingWave supports the following data types:
 |time without time zone|time|Time of day (no time zone) | Example: `time '18:20:49'` |
 |timestamp without time zone|timestamp|Date and time (no time zone) | Example: `'2022-03-13 01:00:00'::timestamp` |
 |timestamp with time zone |timestamptz|Timestamp with time zone. <br/>The 'Z' stands for UTC (Coordinated Universal Time). | Example: `'2022-03-13 01:00:00Z'::timestamptz` |
-|interval| |Time span. <br/>Input in string format. Units include: second/seconds/s, minute/minutes/min/m, hour/hours/hr/h, day/days/d, month/months/mon, and year/years/yr/y. | Examples: `interval '4 hour'` → `04:00:00` <br /> `interval '3 day'` → `3 days 00:00:00` |
+|interval| |Time span. <br/>Input in string format. Units include: microsecond/microseconds/usecs, second/seconds/s, minute/minutes/min/m, hour/hours/hr/h, day/days/d, month/months/mon, and year/years/yr/y. | Examples: `interval '4 hour'` → `04:00:00.000000` <br /> `interval '3 day'` → `3 days 00:00:00.000000` |
 |struct| |A struct is a column that contains nested data. For syntax and examples, see [Struct](./data-types/data-type-struct.md). | |
 |array| | An array is an ordered list of zero or more elements that share the same data type including the array type. For syntax and examples, see [Array](./data-types/data-type-array.md).|
 

--- a/docs/sql/sql-data-types.md
+++ b/docs/sql/sql-data-types.md
@@ -21,7 +21,7 @@ RisingWave supports the following data types:
 |time without time zone|time|Time of day (no time zone) | Example: `time '18:20:49'` |
 |timestamp without time zone|timestamp|Date and time (no time zone) | Example: `'2022-03-13 01:00:00'::timestamp` |
 |timestamp with time zone |timestamptz|Timestamp with time zone. <br/>The 'Z' stands for UTC (Coordinated Universal Time). | Example: `'2022-03-13 01:00:00Z'::timestamptz` |
-|interval| |Time span. <br/>Input in string format. Units include: second/seconds/s, minute/minutes/min/m, hour/hours/hr/h, day/days/d, month/months/mon, and year/years/yr/y. Units smaller than seconds can be specified in the input. | Examples: `interval '4 hour'` → `04:00:00` <br /> `interval '3 day'` → `3 days 00:00:00` <br /> `interval '04:00:00.1234'` → `04:00:00.1234` |
+|interval| |Time span. <br/>Input in string format. Units include: second/seconds/s, minute/minutes/min/m, hour/hours/hr/h, day/days/d, month/months/mon, and year/years/yr/y. Units smaller than second can be specified in the input. | Examples: `interval '4 hour'` → `04:00:00` <br /> `interval '3 day'` → `3 days 00:00:00` <br /> `interval '04:00:00.1234'` → `04:00:00.1234` |
 |struct| |A struct is a column that contains nested data. For syntax and examples, see [Struct](./data-types/data-type-struct.md). | |
 |array| | An array is an ordered list of zero or more elements that share the same data type including the array type. For syntax and examples, see [Array](./data-types/data-type-array.md).|
 


### PR DESCRIPTION
Add interval microsecond precision.

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Add interval microsecond precision.

- **Preview**: 
https://pr-684.d2fbku9n2b6wde.amplifyapp.com/docs/upcoming/sql-data-types/

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/8501

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/663

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
