### PR TITLE
Add offset to tumble and hop time window functions

### DIFF
--- a/docs/sql/functions-operators/sql-function-time-window.md
+++ b/docs/sql/functions-operators/sql-function-time-window.md
@@ -25,12 +25,21 @@ The syntax of the `tumble()` window function is as follows:
 
 ```sql
 SELECT [ ALL | DISTINCT ] [ * | expression [ AS output_name ] [, expression [ AS output_name ]...] ]
-FROM TUMBLE(table_or_source, start_time, window_size);
+FROM TUMBLE ( table_or_source, start_time, window_size [, offset ] );
 ```
 
-*start_time* can be in either timestamp or timestamp with time zone format. Example of timestamp with time zone format: 2022-01-01 10:00:00+00:00.
+- *start_time* can be in either timestamp or timestamp with time zone format.
 
-*window_size* is in the format of `INTERVAL 'interval'`. Example: `INTERVAL '2 MINUTES'`. The standard SQL format, which places time units outside of quotation marks (for example, `INTERVAL '2' MINUTE`), is also supported.
+    Example of timestamp with time zone format: 2022-01-01 10:00:00+00:00.
+
+- *window_size* is in the format of `INTERVAL 'interval'`.
+
+    Example: `INTERVAL '2 MINUTES'`. The standard SQL format, which places time units outside of quotation marks (for example, `INTERVAL '2' MINUTE`), is also supported.
+
+- *offset* is an optional parameter that allows you to adjust the starting point of the tumbling windows.
+    
+    By default, tumbling windows are inclusive in the end of the window and exclusive in the beginning. By specifying *offset*, you can shift *start_time* by the specified duration.
+
 
 
 Suppose that we have a table, `taxi_trips`, that consists of these columns: `trip_id`, `taxi_id`, `completed_at`, `distance`, and `duration`.
@@ -77,12 +86,20 @@ See below for the syntax of the `hop()` window function.
 
 ```sql
 SELECT [ ALL | DISTINCT] [ * | expression [ AS output_name ] [, expression [ AS output_name ]...] ]
-FROM HOP(table_or_source, start_time, hop_size, window_size);
+FROM HOP ( table_or_source, start_time, hop_size, window_size [, offset ]);
 ```
 
-*start_time* can be in either timestamp or timestamp with time zone format. Example of timestamp with time zone format: 2022-01-01 10:00:00+00:00.
+- *start_time* can be in either timestamp or timestamp with time zone format.
 
-Both *hop_size* and *window_size* are in the format of `INTERVAL '<interval>'`. For example: `INTERVAL '2 MINUTES'`. The standard SQL format, which places time units outside of quotation marks (for example, `INTERVAL '2' MINUTE`), is also supported.
+    Example of timestamp with time zone format: 2022-01-01 10:00:00+00:00.
+
+- Both *hop_size* and *window_size* are in the format of `INTERVAL '<interval>'`.
+
+    For example: `INTERVAL '2 MINUTES'`. The standard SQL format, which places time units outside of quotation marks (for example, `INTERVAL '2' MINUTE`), is also supported.
+
+- *offset* is an optional parameter that allows you to adjust the starting point of the hopping windows.
+    
+    By default, hopping windows are inclusive in the end of the window and exclusive in the beginning. By specifying *offset*, you can shift *start_time* by the specified duration.
 
 Here is an example.
 


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info

- **Preview**: 
https://pr-685.d2fbku9n2b6wde.amplifyapp.com/docs/upcoming/sql-function-time-window/

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/8490

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/662

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
