### PR TITLE
feat(cloud-docs): attribute for buttons to redirect to cloud docs

### DIFF
--- a/src/theme/DefaultButton/index.tsx
+++ b/src/theme/DefaultButton/index.tsx
@@ -7,10 +7,11 @@ type Props = {
   text: string;
   doc?: string;
   url?: string;
+  cloud?: string;
   block?: boolean;
 };
 
-export default function DefaultButton({ text, doc, url, block }: Props) {
+export default function DefaultButton({ text, doc, url, block, cloud }: Props) {
   const history = useHistory();
   const { globalData } = useDocusaurusContext();
   const location = useLocation();
@@ -19,13 +20,17 @@ export default function DefaultButton({ text, doc, url, block }: Props) {
     <button
       onClick={() => {
         if (doc) {
-          globalData["docusaurus-plugin-content-docs"].default["versions"].map((v) => {
-            if (location.pathname.includes(v.path)) {
-              history.push(`${v.path}/${doc}`);
+          globalData["docusaurus-plugin-content-docs"].default["versions"].map(
+            (v) => {
+              if (location.pathname.includes(v.path)) {
+                history.push(`${v.path}/${doc}`);
+              }
             }
-          });
+          );
         } else if (url) {
           window.open(url, "_blank", "noopener,noreferrer");
+        } else if (cloud) {
+          history.push(`/cloud/${cloud}`);
         }
       }}
       className={block ? "default block" : "default"}

--- a/src/theme/LightButton/index.tsx
+++ b/src/theme/LightButton/index.tsx
@@ -7,10 +7,11 @@ type Props = {
   text: string;
   doc?: string;
   url?: string;
+  cloud?: string;
   block?: boolean;
 };
 
-export default function LightButton({ text, doc, url, block }: Props) {
+export default function LightButton({ text, doc, url, block, cloud }: Props) {
   const history = useHistory();
   const { globalData } = useDocusaurusContext();
   const location = useLocation();
@@ -19,13 +20,17 @@ export default function LightButton({ text, doc, url, block }: Props) {
     <button
       onClick={() => {
         if (doc) {
-          globalData["docusaurus-plugin-content-docs"].default["versions"].map((v) => {
-            if (location.pathname.includes(v.path)) {
-              history.push(`${v.path}/${doc}`);
+          globalData["docusaurus-plugin-content-docs"].default["versions"].map(
+            (v) => {
+              if (location.pathname.includes(v.path)) {
+                history.push(`${v.path}/${doc}`);
+              }
             }
-          });
+          );
         } else if (url) {
           window.open(url, "_blank", "noopener,noreferrer");
+        } else if (cloud) {
+          history.push(`/cloud/${cloud}`);
         }
       }}
       className={block ? "light block" : "light"}

--- a/src/theme/RollButton/index.tsx
+++ b/src/theme/RollButton/index.tsx
@@ -6,10 +6,11 @@ import "./style.css";
 type Props = {
   text: string;
   doc?: string;
+  cloud?: string;
   url?: string;
 };
 
-export default function RollButton({ text, doc, url }: Props) {
+export default function RollButton({ text, doc, url, cloud }: Props) {
   const history = useHistory();
   const { globalData } = useDocusaurusContext();
   const location = useLocation();
@@ -19,13 +20,17 @@ export default function RollButton({ text, doc, url }: Props) {
       <button
         onClick={() => {
           if (doc) {
-            globalData["docusaurus-plugin-content-docs"].default["versions"].map((v) => {
+            globalData["docusaurus-plugin-content-docs"].default[
+              "versions"
+            ].map((v) => {
               if (location.pathname.includes(v.path)) {
                 history.push(`${v.path}/${doc}`);
               }
             });
           } else if (url) {
             window.open(url, "_blank", "noopener,noreferrer");
+          } else if (cloud) {
+            history.push(`/cloud/${cloud}`);
           }
         }}
         className="button-3 learn-more"


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
add an attribute for buttons to redirect to cloud docs

- **Preview**: 
usage: `<rollButton text="Go Cloud" block cloud="about-whats-risingwave-cloud"/>`


- **Related code PR**: 

- **Related doc issue**: 
Resolves  #655 

- **Notes**: 


<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
