### PR TITLE
Add note about avro timezone behavior

### DIFF
--- a/docs/data-ingestion.md
+++ b/docs/data-ingestion.md
@@ -60,7 +60,7 @@ When creating a source, specify the format in the `ROW FORMAT` section of the `C
 
 For data in Avro format, you must specify a message and a schema file location. The schema file location can be an actual Web location that is in `http://...`, `https://...`, or `S3://...` format. For Kafka data in Avro, instead of a schema file location, you can provide a Confluent Schema Registry that RisingWave can get the schema from. For more details about using Schema Registry for Kafka data, see [Read schema from Schema Registry](/create-source/create-source-kafka.md#read-schemas-from-schema-registry). 
 
-Note that the timestamp displayed in RisingWave may be different from the upstream system as timezone information is lost through the process. It is related to the behavior of Avro parser. For details, see [Avro specifications](https://avro.apache.org/docs/1.11.1/specification/#timestamp-millisecond-precisionhttps://avro.apache.org/docs/1.11.1/specification/#timestamp-millisecond-precision).
+Note that the timestamp displayed in RisingWave may be different from the upstream system as timezone information is lost in Avro serialization.
 
 :::info
 

--- a/docs/data-ingestion.md
+++ b/docs/data-ingestion.md
@@ -60,6 +60,8 @@ When creating a source, specify the format in the `ROW FORMAT` section of the `C
 
 For data in Avro format, you must specify a message and a schema file location. The schema file location can be an actual Web location that is in `http://...`, `https://...`, or `S3://...` format. For Kafka data in Avro, instead of a schema file location, you can provide a Confluent Schema Registry that RisingWave can get the schema from. For more details about using Schema Registry for Kafka data, see [Read schema from Schema Registry](/create-source/create-source-kafka.md#read-schemas-from-schema-registry). 
 
+Note that the timestamp displayed in RisingWave may be different from the upstream system as timezone information is lost through the process.
+
 :::info
 
 For Avro data, you cannot specify the schema in the `schema_definition` section of a `CREATE SOURCE` or `CREATE TABLE` statement.

--- a/docs/data-ingestion.md
+++ b/docs/data-ingestion.md
@@ -60,7 +60,7 @@ When creating a source, specify the format in the `ROW FORMAT` section of the `C
 
 For data in Avro format, you must specify a message and a schema file location. The schema file location can be an actual Web location that is in `http://...`, `https://...`, or `S3://...` format. For Kafka data in Avro, instead of a schema file location, you can provide a Confluent Schema Registry that RisingWave can get the schema from. For more details about using Schema Registry for Kafka data, see [Read schema from Schema Registry](/create-source/create-source-kafka.md#read-schemas-from-schema-registry). 
 
-Note that the timestamp displayed in RisingWave may be different from the upstream system as timezone information is lost through the process.
+Note that the timestamp displayed in RisingWave may be different from the upstream system as timezone information is lost through the process. It is related to the behavior of Avro parser. For details, see [Avro specifications](https://avro.apache.org/docs/1.11.1/specification/#timestamp-millisecond-precisionhttps://avro.apache.org/docs/1.11.1/specification/#timestamp-millisecond-precision).
 
 :::info
 


### PR DESCRIPTION

## Info
- **Description**: 
Add note that timezone displayed in RW might be different from timezone info in upstream system.

- **Preview**: 
[ Paste the preview link to the edited page here. ]

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/8730

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/696

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
