### PR TITLE
Add note on empty cells for S3 source

### DIFF
--- a/docs/create-source/create-source-s3.md
+++ b/docs/create-source/create-source-s3.md
@@ -92,6 +92,9 @@ export const svg = rr.Diagram(
 |match_pattern| Conditional. This field is used to find object keys in `s3.bucket_name` that match the given pattern. Standard Unix-style glob syntax is supported. |
 |s3.endpoint_url| Conditional. The host URL for an S3-compatible object storage server. This allows users to use a different server instead of the standard S3 server. | 
 
+:::note
+Empty cells in CSV files will be parsed to `NULL`.
+:::
 
 ## Example
 Here is an example of connecting RisingWave to an S3 source to read data from individual streams.


### PR DESCRIPTION

## Info
- **Description**: 
Add note on behavior of empty cells for S3 source

- **Preview**: 
[ Paste the preview link to the edited page here. ]

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/8709

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/695

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
