### PR TITLE
Adding index pages for sub-categories in SQL references

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -266,11 +266,24 @@ const sidebars = {
     label: 'SQL',
     collapsible: true,
     collapsed: true,
+    link: {
+      type: 'generated-index',
+      title: 'SQL references',
+      slug: '/sql-references',
+      keywords: ['SQL']
+    },
     items: 
     [
       {
         type: 'category',
         label: 'Commands',
+        link: {
+          type: 'generated-index',
+          title: 'SQL commands',
+          description: 'Overview of the SQL commands supported by RisingWave.',
+          slug: '/sql-commands',
+          keywords: ['SQL, commands']
+        },
         items: 
           [
             {
@@ -283,6 +296,13 @@ const sidebars = {
       {
         type: 'category',
         label: 'Query syntax',
+        link: {
+          type: 'generated-index',
+          title: 'Query syntax',
+          description: 'Syntax and usage of common query clauses.',
+          slug: '/query-syntax',
+          keywords: ['query, syntax']
+        },
         items: 
         [
           {
@@ -320,6 +340,7 @@ const sidebars = {
        {
           type: 'category',
           label: 'Data types',
+          link: {type: 'doc', id: 'sql/sql-data-types'},
           items:
           [
             {
@@ -352,6 +373,13 @@ const sidebars = {
       {
       type: 'category',
       label: 'Functions and operators',
+      link: {
+        type: 'generated-index',
+        title: 'SQL functions and operators',
+        description: 'Functions and operators that can be used in SQL queries.',
+        slug: '/sql-functions',
+        keywords: ['function, operator']
+      },
       items: 
         [
           {
@@ -425,6 +453,13 @@ const sidebars = {
         {
           type: 'category',
           label: 'Patterns',
+          link: {
+            type: 'generated-index',
+            title: 'Query patterns',
+            description: 'Commonly used patterns and techniques that can help build a more efficient data processing workflow.',
+            slug: '/sql-patterns',
+            keywords: ['pattern']
+          },
           items:
             [  {
                 type: 'doc',


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Adding index pages for some of the sub-categories in SQL references.
An index page, which is auto-generated, is an easy and simple alternative to an overview page.
Index pages (or overview pages) serve as landing pages when referenced from other places (like the cloud docs) or from the future home page of the docs.
We can remove the index pages when we want to create detailed overview pages for the sub-categories.

![2023-04-02 17 28 32](https://user-images.githubusercontent.com/100549427/229344459-7a97eac9-6eb4-4705-90f2-a31715c38339.gif)


- **Preview**: 
https://pr-714.d2fbku9n2b6wde.amplifyapp.com/docs/upcoming/sql-references/

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
