### PR TITLE
Add diagram to SHOW COLUMNS

### DIFF
--- a/docs/sql/commands/sql-show-columns.md
+++ b/docs/sql/commands/sql-show-columns.md
@@ -12,6 +12,23 @@ Use the `SHOW COLUMNS` command to view columns in the specified table, source, o
 ```sql
 SHOW COLUMNS FROM table_name;
 ```
+
+
+import rr from '@theme/RailroadDiagram'
+
+export const svg = rr.Diagram(
+    rr.Sequence(
+        rr.Terminal('SHOW COLUMNS'),
+        rr.Terminal('FROM'),
+        rr.NonTerminal('table_name'),
+        rr.Terminal(';')
+    )
+);
+
+<drawer SVG={svg} />
+
+
+
 ## Parameters
 |Parameter or clause        | Description           |
 |---------------------------|-----------------------|


### PR DESCRIPTION
Add diagram to SHOW COLUMNS.

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Add diagram to SHOW COLUMNS.

- **Preview**: 
[ Paste the preview link to the edited page here. ]

- **Related code PR**: 
N/A

- **Related doc issue**: 
Resolves no doc issue.

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
