### PR TITLE
Fixing the ref link to aggregate expressions

### DIFF
--- a/docs/sql/functions-operators/sql-function-aggregate.md
+++ b/docs/sql/functions-operators/sql-function-aggregate.md
@@ -6,7 +6,7 @@ title: Aggregate functions
 
 Aggregate functions compute a single result from a set of input values. 
 
-The DISTINCT option, ORDER BY clauses, and FILTER clauses can be used in aggregate expressions. The DISTINCT option cannot be used with an ORDER BY clause. For details about the supported syntax, see [Aggregate expressions](/sql/syntax/sql-syntax-value-exp.md).
+The DISTINCT option, ORDER BY clauses, and FILTER clauses can be used in aggregate expressions. The DISTINCT option cannot be used with an ORDER BY clause. For details about the supported syntax, see [Aggregate expressions](/sql/query-syntax/query-syntax-value-exp.md/#aggregate-expressions).
 
 
 |Function|Description|

--- a/versioned_docs/version-0.18.0/sql/functions-operators/sql-function-aggregate.md
+++ b/versioned_docs/version-0.18.0/sql/functions-operators/sql-function-aggregate.md
@@ -6,7 +6,7 @@ title: Aggregate functions
 
 Aggregate functions compute a single result from a set of input values. 
 
-The DISTINCT option, ORDER BY clauses, and FILTER clauses can be used in aggregate expressions. The DISTINCT option cannot be used with an ORDER BY clause. For details about the supported syntax, see [Aggregate expressions](/sql/syntax/sql-syntax-value-exp.md).
+The DISTINCT option, ORDER BY clauses, and FILTER clauses can be used in aggregate expressions. The DISTINCT option cannot be used with an ORDER BY clause. For details about the supported syntax, see [Aggregate expressions](/sql/query-syntax/query-syntax-value-exp.md/#aggregate-expressions).
 
 
 |Function|Description|


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
[ What's changed? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
