### PR TITLE
fix(cloud): remove cloud verions and fix 

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -18,6 +18,7 @@
   --ifm-color-navy-blue-300: #98c6d9;
   --ifm-color-neutral-400: #b3b3b3;
   --ifm-color-neutral-900: #16171a;
+  --ifm-navbar-link-color: #e3e3e3;
   --ifm-code-font-size: 90%;
   --ifm-font-size-base: 92%;
   --ifm-z-index-fixed: 200;
@@ -113,10 +114,6 @@ html[data-theme="dark"] {
 
 [data-theme="dark"] .navbar--fixed-top {
   background-color: #001f2bef;
-}
-
-.navbar__link {
-  color: #e3e3e3;
 }
 
 .clean-btn {
@@ -459,6 +456,8 @@ table tr:first-child {
   }
 }
 
+.plugin-id-cloud .navbar-sidebar li.menu__list-item.menu__list-item--collapsed,
+.plugin-id-cloud .dropdown,
 .hr-powered-by {
   display: none !important;
 }

--- a/src/theme/DefaultButton/index.tsx
+++ b/src/theme/DefaultButton/index.tsx
@@ -20,13 +20,13 @@ export default function DefaultButton({ text, doc, url, block, cloud }: Props) {
     <button
       onClick={() => {
         if (doc) {
-          globalData["docusaurus-plugin-content-docs"].default["versions"].map(
-            (v) => {
-              if (location.pathname.includes(v.path)) {
-                history.push(`${v.path}/${doc}`);
-              }
+          globalData["docusaurus-plugin-content-docs"].default["versions"].map((v) => {
+            if (location.pathname.includes(v.path)) {
+              history.push(`${v.path}/${doc}`);
+            } else if (location.pathname.includes("cloud")) {
+              history.push(`/docs/current/${doc}`);
             }
-          );
+          });
         } else if (url) {
           window.open(url, "_blank", "noopener,noreferrer");
         } else if (cloud) {

--- a/src/theme/LightButton/index.tsx
+++ b/src/theme/LightButton/index.tsx
@@ -20,13 +20,13 @@ export default function LightButton({ text, doc, url, block, cloud }: Props) {
     <button
       onClick={() => {
         if (doc) {
-          globalData["docusaurus-plugin-content-docs"].default["versions"].map(
-            (v) => {
-              if (location.pathname.includes(v.path)) {
-                history.push(`${v.path}/${doc}`);
-              }
+          globalData["docusaurus-plugin-content-docs"].default["versions"].map((v) => {
+            if (location.pathname.includes(v.path)) {
+              history.push(`${v.path}/${doc}`);
+            } else if (location.pathname.includes("cloud")) {
+              history.push(`/docs/current/${doc}`);
             }
-          );
+          });
         } else if (url) {
           window.open(url, "_blank", "noopener,noreferrer");
         } else if (cloud) {

--- a/src/theme/OutlinedCard/index.tsx
+++ b/src/theme/OutlinedCard/index.tsx
@@ -58,6 +58,8 @@ export default function OutlinedCard({
           globalData["docusaurus-plugin-content-docs"].default["versions"].map((v) => {
             if (location.pathname.includes(v.path)) {
               history.push(`${v.path}/${doc}`);
+            } else if (location.pathname.includes("cloud")) {
+              history.push(`/docs/current/${doc}`);
             }
           });
         } else if (url) {
@@ -87,6 +89,8 @@ export default function OutlinedCard({
                       globalData["docusaurus-plugin-content-docs"].default["versions"].map((v) => {
                         if (location.pathname.includes(v.path)) {
                           history.push(`${v.path}/${link.doc}`);
+                        } else if (location.pathname.includes("cloud")) {
+                          history.push(`/docs/current/${doc}`);
                         }
                       });
                     }

--- a/src/theme/RollButton/index.tsx
+++ b/src/theme/RollButton/index.tsx
@@ -20,11 +20,11 @@ export default function RollButton({ text, doc, url, cloud }: Props) {
       <button
         onClick={() => {
           if (doc) {
-            globalData["docusaurus-plugin-content-docs"].default[
-              "versions"
-            ].map((v) => {
+            globalData["docusaurus-plugin-content-docs"].default["versions"].map((v) => {
               if (location.pathname.includes(v.path)) {
                 history.push(`${v.path}/${doc}`);
+              } else if (location.pathname.includes("cloud")) {
+                history.push(`/docs/current/${doc}`);
               }
             });
           } else if (url) {


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
  - remove the dropdown and version on the nav bar on Cloud docs
  - buttons can redirect to kernel docs now (redirect to 'current' version by default)
  - highlight the current docs on nav bar

- **Preview**: 


- **Related code PR**: 


- **Related doc issue**: 


- **Notes**: 


<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
