### PR TITLE
Add diagram for EXPLAIN

### DIFF
--- a/docs/sql/commands/sql-explain.md
+++ b/docs/sql/commands/sql-explain.md
@@ -15,6 +15,34 @@ Use the `EXPLAIN` command to show the execution plan of a statement.
 EXPLAIN [ ( option [ , ... ] ) ] statement;
 ```
 
+
+import rr from '@theme/RailroadDiagram'
+
+export const svg = rr.Diagram(
+    rr.Sequence(
+        rr.Terminal('EXPLAIN'),
+        rr.Optional(
+            rr.Sequence(
+                rr.Terminal('('),
+                rr.Sequence(
+                   rr.OneOrMore(
+                      rr.NonTerminal('option'),
+                      rr.Comment('space as delimiter'),
+                   ),
+                ),
+                rr.Terminal(')'),
+            ),
+            'skip'
+        ),
+        rr.NonTerminal('statement'),
+        rr.Terminal(';'),
+    )
+);
+
+<drawer SVG={svg} />
+
+
+
 ## Parameters
 
 |Parameter      | Description|


### PR DESCRIPTION
Add diagram for EXPLAIN.

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Add diagram for EXPLAIN.

- **Preview**: 
https://pr-752.d2fbku9n2b6wde.amplifyapp.com/docs/upcoming/sql-explain/

- **Related code PR**: 
N/A

- **Related doc issue**: 
Resolves no doc issue.

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
