### PR TITLE
fix: add --server-side argument to kubectl apply command while instal…

### DIFF
--- a/docs/deploy/risingwave-kubernetes.md
+++ b/docs/deploy/risingwave-kubernetes.md
@@ -64,7 +64,7 @@ Before the deployment, ensure that the following requirements are satisfied.
 1. Install the Operator.
 
     ```shell
-    kubectl apply -f https://github.com/risingwavelabs/risingwave-operator/releases/latest/download/risingwave-operator.yaml
+    kubectl apply --server-side -f https://github.com/risingwavelabs/risingwave-operator/releases/latest/download/risingwave-operator.yaml
     ```
 
 1. ***(Optional)*** Check if the Pods are running.

--- a/versioned_docs/version-0.18.0/deploy/risingwave-kubernetes.md
+++ b/versioned_docs/version-0.18.0/deploy/risingwave-kubernetes.md
@@ -64,7 +64,7 @@ Before the deployment, ensure that the following requirements are satisfied.
 1. Install the Operator.
 
     ```shell
-    kubectl apply -f https://github.com/risingwavelabs/risingwave-operator/releases/latest/download/risingwave-operator.yaml
+    kubectl apply --server-side -f https://github.com/risingwavelabs/risingwave-operator/releases/latest/download/risingwave-operator.yaml
     ```
 
 1. ***(Optional)*** Check if the Pods are running.


### PR DESCRIPTION
…ling the operator

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
[ What's changed? ]
The current `risingwave-operator.yaml` is too long for `kubectl apply` to work. Use `--server-side` as a workaround. 
P.S. I didn't update docs with versions below `v0.18.0` because they are not compatible with the latest operator.

- **Preview**: 
[ Paste the preview link to the edited page here. ]

- **Related code PR**: 
[ Provide the link to the code PR here. For example, https://github.com/risingwavelabs/risingwave/pull/4085. Delete this part if there's no code PR related. ]

- **Related doc issue**: 
Resolves [ Provide the link to the doc issue here. ]

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
