### PR TITLE
Document isolation.level for Kafka source

### DIFF
--- a/docs/create-source/create-source-kafka.md
+++ b/docs/create-source/create-source-kafka.md
@@ -11,7 +11,7 @@ A source is a resource that RisingWave can read data from. You can create a sour
 
 Regardless of whether the data is persisted in RisingWave, you can create materialized views to perform analysis or data transformations.
 
-RisingWave only ingests committed data from Kafka as the Kafka consumer's `isolation.level` is set to `read_committed`. For more information on this field, see [Kafka's consumer configurations](https://kafka.apache.org/documentation/#consumerconfigs_isolation.level). This is the set behavior for RisingWave and not configurable.
+RisingWave supports exactly-once semantics by reading transactional messages only when the associated transaction has been committed. This is the set behavior for RisingWave and not configurable.
 
 ## Syntax
 

--- a/docs/create-source/create-source-kafka.md
+++ b/docs/create-source/create-source-kafka.md
@@ -11,6 +11,8 @@ A source is a resource that RisingWave can read data from. You can create a sour
 
 Regardless of whether the data is persisted in RisingWave, you can create materialized views to perform analysis or data transformations.
 
+RisingWave only ingests committed data from Kafka as the Kafka consumer's `isolation.level` is set to `read_committed`. For more information on this field, see [Kafka's consumer configurations](https://kafka.apache.org/documentation/#consumerconfigs_isolation.level). This is the set behavior for RisingWave and not configurable.
+
 ## Syntax
 
 ```sql


### PR DESCRIPTION

## Info
- **Description**: 
Add note on how RW only ingests committed data from Kafka due to `isolation.level = read_commited`.

- **Preview**: 
[ Paste the preview link to the edited page here. ]

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/9033

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/776

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
