### PR TITLE
Replace NOW() with PROCTIME()

### DIFF
--- a/docs/sql/syntax/sql-pattern-temporal-filter.md
+++ b/docs/sql/syntax/sql-pattern-temporal-filter.md
@@ -12,10 +12,10 @@ The following query returns all rows from the `sales` table where the `sale_date
 ```sql
 SELECT * 
 FROM sales 
-WHERE sale_date > NOW() - INTERVAL '1 week';
+WHERE sale_date > PROCTIME() - INTERVAL '1 week';
 ```
 
-The temporal filter in this query is `sale_date > NOW() - INTERVAL '1 week'`. It filters the rows based on the `sale_date` column and checks if it is within one week of the current time or `NOW()`.
+The temporal filter in this query is `sale_date > PROCTIME() - INTERVAL '1 week'`. It filters the rows based on the `sale_date` column and checks if it is within one week of the current time or `PROCTIME()`.
 
 
 The following query returns all rows from the `user_sessions` table where the sum of the `last_active` timestamp and double the `session_timeout` duration is greater than the current timestamp, indicating active user sessions. This query could be used to clean up old user sessions from the database by deleting any rows that no longer satisfy the condition.
@@ -23,7 +23,7 @@ The following query returns all rows from the `user_sessions` table where the su
 ```sql
 SELECT * 
 FROM user_sessions 
-WHERE last_active + session_timeout * 2 > NOW();
+WHERE last_active + session_timeout * 2 > PROCTIME();
 ```
 
-The temporal filter in this query is in the `WHERE` clause. It checks whether the timestamp of the last activity plus twice the session timeout is greater than the current time or `NOW()`. This indicates that the session is still active.
+The temporal filter in this query is in the `WHERE` clause. It checks whether the timestamp of the last activity plus twice the session timeout is greater than the current time or `PROCTIME()`. This indicates that the session is still active.


### PR DESCRIPTION
Replace NOW() with PROCTIME().

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Replace NOW() with PROCTIME().

- **Preview**: 
https://pr-817.d2fbku9n2b6wde.amplifyapp.com/docs/upcoming/sql-pattern-temporal-filters/

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/9144

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/803

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
