### PR TITLE
Depreciate use_transaction for Kafka sink

### DIFF
--- a/docs/guides/create-sink-kafka.md
+++ b/docs/guides/create-sink-kafka.md
@@ -7,7 +7,7 @@ slug: /create-sink-kafka
 
 This topic describes how to sink data from RisingWave to a Kafka broker and how to specify security (encryption and authentication) settings.
 
-A sink is an external target that you can send data to. To stream data out of RisingWave, you need to create a sink. Use the `CREATE SINK` statement to create a sink. You can create a sink with data from a materialized source, a materialized view, or a table.
+A sink is an external target that you can send data to. To stream data out of RisingWave, you need to create a sink. Use the `CREATE SINK` statement to create a sink. You can create a sink with data from a materialized source, a materialized view, or a table. RisingWave only supports writing messages in non-transactional mode.
 
 ## Syntax
 
@@ -35,7 +35,6 @@ All WITH options are required except `force_append_only` and `primary_key`.
 |type|Data format. Allowed formats:<ul><li> `append-only`: Output data with insert operations.</li><li> `debezium`: Output change data capture (CDC) log in Debezium format.</li><li> `upsert`: Output data as a changelog stream. `primary_key` must be specified in this case. </li></ul>|
 |force_append_only| If `true`, forces the sink to be `append-only`, even if it cannot be.| 
 |primary_key| The primary keys of the sink. Use ',' to delimit the primary key columns. If the external sink has its own primary key, this field should not be specified.| 
-|use_transaction| If set to `false`, the connector will use at-least-once processing, allowing for non-atomic writes. This might cause duplicated results. By default, `use_transaction` is `true`.|
 
 
 ## Examples


### PR DESCRIPTION

## Info
- **Description**: 
Depreciate use_transaction for Kafka sink and note that RW only supports non-txn mode.

- **Preview**: 
[ Paste the preview link to the edited page here. ]

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/9207

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/801

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
