### PR TITLE
Document array slicing

### DIFF
--- a/docs/sql/data-types/data-type-array.md
+++ b/docs/sql/data-types/data-type-array.md
@@ -113,13 +113,21 @@ SELECT array[array[1],array[2],array[3]][-21432315:134124523][1:2];
 ```
 
 #### Differences from PostgreSQL
-Assume arr is of type T[][][]:
+In RisingWave, assume `arr` is of type T[][][]:
 
 - arr[x] is of type T[][]
 - arr[x][y] is interpreted as (arr[x])[y], and of type T[]
 - arr[x0:x1] is of type T[][][]
 - arr[x0:x1][y0:y1] is interpreted as (arr[x0:x1])[y0:y1], and of type T[][][]
 - arr[x0:x1][y] is interpreted as (arr[x0:x1])[y], and of type T[][]
+
+In PostgreSQL, a 3-dimensional array `arr` is still of type T[]:
+
+- arr[x] or arr[x][y] is of type T but due to insufficient number of indices is of `NULL` value
+- arr[x][y][z] is of type T
+- arr[x0:x1][y0:y1][z0:z1] is of type T[] and 3-dimensional
+- arr[x0:x1] is interpreted as arr[x0:x1][:][:], and of type T[] and 3-dimensional
+- arr[x0:x1][y] is interpreted as arr[x0:x1][1:y][:], and of type T[] and 3-dimensional
 
 ### Unnest data from an array
 

--- a/docs/sql/data-types/data-type-array.md
+++ b/docs/sql/data-types/data-type-array.md
@@ -92,6 +92,35 @@ FROM taxi;
 'ABCD1234'
 ```
 
+### Retrieve slice of an array
+
+To retrieve data in an array, use the `ARRAY_COLUMN[n:m]` syntax, where `n` and `m` are integers representing indices and are both inclusive. Either `n`, `m`, or both can be omitted. Relative positions start from 1. In multidimensial arrays, arrays with unmatching dimensions are allowed.
+
+#### Examples
+
+Retrieve the entire array with `n` omitted.
+```sql
+SELECT array[1,NULL,2][:3];
+----Result
+{1,NULL,2}
+```
+
+Retrieve the first two elements from a multidimensional array.
+```sql
+SELECT array[array[1],array[2],array[3]][-21432315:134124523][1:2];
+----
+{{1},{2}}
+```
+
+#### Differences from PostgreSQL
+Assume arr is of type T[][][]:
+
+- arr[x] is of type T[][]
+- arr[x][y] is interpreted as (arr[x])[y], and of type T[]
+- arr[x0:x1] is of type T[][][]
+- arr[x0:x1][y0:y1] is interpreted as (arr[x0:x1])[y0:y1], and of type T[][][]
+- arr[x0:x1][y] is interpreted as (arr[x0:x1])[y], and of type T[][]
+
 ### Unnest data from an array
 
 You can use the `unnest()` function to spread values in an array into seperate rows.


### PR DESCRIPTION

## Info
- **Description**: 
Document array slicing under SQL -> Data types -> Array

- **Preview**: 
[ Paste the preview link to the edited page here. ]

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/9362

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/807

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
