### PR TITLE
Fix binary links in 0.18.0

### DIFF
--- a/versioned_docs/version-0.18.0/deploy/risingwave-local.md
+++ b/versioned_docs/version-0.18.0/deploy/risingwave-local.md
@@ -24,7 +24,7 @@ import TabItem from '@theme/TabItem';
 1. Download the pre-built binary.
 
     ```shell
-    wget https://github.com/risingwavelabs/risingwave/releases/download/v0.1.17/risingwave-v0.1.17-x86_64-unknown-linux.tar.gz
+    wget https://github.com/risingwavelabs/risingwave/releases/download/v0.18.0/risingwave-v0.18.0-x86_64-unknown-linux.tar.gz
     ```
 
     > You can find previous binary releases in [Release notes](/release-notes.md).
@@ -32,7 +32,7 @@ import TabItem from '@theme/TabItem';
 2. Unzip the binary.
 
     ```shell
-    tar xvf risingwave-v0.1.17-x86_64-unknown-linux.tar.gz
+    tar xvf risingwave-v0.18.0-x86_64-unknown-linux.tar.gz
     ```
 
 3. Start RisingWave in playground mode.


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/853


<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
