### PR TITLE
style(layout): docs page max width

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -34,7 +34,7 @@
   --ifm-tabs-padding-vertical: 0.5rem !important;
   --ifm-navbar-height: 3rem;
 
-  --ifm-docs-page-width-xl: 1600px;
+  --ifm-docs-page-width-xl: 1580px;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -34,7 +34,7 @@
   --ifm-tabs-padding-vertical: 0.5rem !important;
   --ifm-navbar-height: 3rem;
 
-  --ifm-docs-page-width-xl: 1580px;
+  --ifm-docs-page-width-xl: 1280px;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -33,6 +33,8 @@
   --doc-sidebar-width: 260px !important;
   --ifm-tabs-padding-vertical: 0.5rem !important;
   --ifm-navbar-height: 3rem;
+
+  --ifm-docs-page-width-xl: 1600px;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -113,6 +115,16 @@ html[data-theme="dark"] {
 
 .theme-doc-sidebar-item-category-level-4 .menu__list .menu__link {
   padding-left: calc(var(--ifm-menu-link-padding-horizontal) + 0.5rem * 3);
+}
+
+/* custom nav bar */
+.navbar .navbar__inner {
+  max-width: var(--ifm-docs-page-width-xl);
+  display: flex;
+  justify-content: space-between;
+  flex: 0 0 100%;
+  align-items: center;
+  margin: 0 auto;
 }
 
 .navbar--fixed-top {

--- a/src/theme/DocPage/Layout/Main/index.js
+++ b/src/theme/DocPage/Layout/Main/index.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import clsx from 'clsx';
+import {useDocsSidebar} from '@docusaurus/theme-common/internal';
+import styles from './styles.module.css';
+export default function DocPageLayoutMain({hiddenSidebarContainer, children}) {
+  const sidebar = useDocsSidebar();
+  return (
+    <main
+      className={clsx(
+        styles.docMainContainer,
+        (hiddenSidebarContainer || !sidebar) && styles.docMainContainerEnhanced,
+      )}>
+      <div
+        className={clsx(
+          'container padding-top--md padding-bottom--lg',
+          styles.docItemWrapper,
+          hiddenSidebarContainer && styles.docItemWrapperEnhanced,
+        )}>
+        {children}
+      </div>
+    </main>
+  );
+}

--- a/src/theme/DocPage/Layout/Main/styles.module.css
+++ b/src/theme/DocPage/Layout/Main/styles.module.css
@@ -1,0 +1,21 @@
+.docMainContainer {
+  display: flex;
+  width: 100%;
+}
+
+@media (min-width: 997px) {
+  .docMainContainer {
+    flex-grow: 1;
+    max-width: calc(100% - var(--doc-sidebar-width));
+  }
+
+  .docMainContainerEnhanced {
+    max-width: calc(100% - var(--doc-sidebar-hidden-width));
+  }
+
+  .docItemWrapperEnhanced {
+    max-width: calc(
+      var(--ifm-container-width) + var(--doc-sidebar-width)
+    ) !important;
+  }
+}

--- a/src/theme/DocPage/Layout/Sidebar/ExpandButton/index.js
+++ b/src/theme/DocPage/Layout/Sidebar/ExpandButton/index.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import {translate} from '@docusaurus/Translate';
+import IconArrow from '@theme/Icon/Arrow';
+import styles from './styles.module.css';
+export default function DocPageLayoutSidebarExpandButton({toggleSidebar}) {
+  return (
+    <div
+      className={styles.expandButton}
+      title={translate({
+        id: 'theme.docs.sidebar.expandButtonTitle',
+        message: 'Expand sidebar',
+        description:
+          'The ARIA label and title attribute for expand button of doc sidebar',
+      })}
+      aria-label={translate({
+        id: 'theme.docs.sidebar.expandButtonAriaLabel',
+        message: 'Expand sidebar',
+        description:
+          'The ARIA label and title attribute for expand button of doc sidebar',
+      })}
+      tabIndex={0}
+      role="button"
+      onKeyDown={toggleSidebar}
+      onClick={toggleSidebar}>
+      <IconArrow className={styles.expandButtonIcon} />
+    </div>
+  );
+}

--- a/src/theme/DocPage/Layout/Sidebar/ExpandButton/index.js
+++ b/src/theme/DocPage/Layout/Sidebar/ExpandButton/index.js
@@ -1,8 +1,10 @@
 import React from 'react';
-import {translate} from '@docusaurus/Translate';
+import { translate } from '@docusaurus/Translate';
 import IconArrow from '@theme/Icon/Arrow';
 import styles from './styles.module.css';
-export default function DocPageLayoutSidebarExpandButton({toggleSidebar}) {
+
+export default function DocPageLayoutSidebarExpandButton({ toggleSidebar }) {
+
   return (
     <div
       className={styles.expandButton}

--- a/src/theme/DocPage/Layout/Sidebar/ExpandButton/index.js
+++ b/src/theme/DocPage/Layout/Sidebar/ExpandButton/index.js
@@ -3,7 +3,7 @@ import { translate } from '@docusaurus/Translate';
 import IconArrow from '@theme/Icon/Arrow';
 import styles from './styles.module.css';
 
-export default function DocPageLayoutSidebarExpandButton({ toggleSidebar }) {
+export default function DocPageLayoutSidebarExpandButton({ toggleSidebar, setUserClick }) {
 
   return (
     <div
@@ -22,8 +22,15 @@ export default function DocPageLayoutSidebarExpandButton({ toggleSidebar }) {
       })}
       tabIndex={0}
       role="button"
-      onKeyDown={toggleSidebar}
-      onClick={toggleSidebar}>
+      onKeyDown={() => {
+        toggleSidebar()
+        setUserClick(true)
+      }}
+      onClick={() => {
+        console.log('expand button clicked')
+        toggleSidebar()
+        setUserClick(true)
+      }}>
       <IconArrow className={styles.expandButtonIcon} />
     </div>
   );

--- a/src/theme/DocPage/Layout/Sidebar/ExpandButton/styles.module.css
+++ b/src/theme/DocPage/Layout/Sidebar/ExpandButton/styles.module.css
@@ -1,0 +1,27 @@
+@media (min-width: 997px) {
+  .expandButton {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color var(--ifm-transition-fast) ease;
+    background-color: var(--docusaurus-collapse-button-bg);
+  }
+
+  .expandButton:hover,
+  .expandButton:focus {
+    background-color: var(--docusaurus-collapse-button-bg-hover);
+  }
+
+  .expandButtonIcon {
+    transform: rotate(0);
+  }
+
+  [dir='rtl'] .expandButtonIcon {
+    transform: rotate(180deg);
+  }
+}

--- a/src/theme/DocPage/Layout/Sidebar/index.js
+++ b/src/theme/DocPage/Layout/Sidebar/index.js
@@ -1,0 +1,65 @@
+import React, {useState, useCallback} from 'react';
+import clsx from 'clsx';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import {useDocsSidebar} from '@docusaurus/theme-common/internal';
+import {useLocation} from '@docusaurus/router';
+import DocSidebar from '@theme/DocSidebar';
+import ExpandButton from '@theme/DocPage/Layout/Sidebar/ExpandButton';
+import styles from './styles.module.css';
+// Reset sidebar state when sidebar changes
+// Use React key to unmount/remount the children
+// See https://github.com/facebook/docusaurus/issues/3414
+function ResetOnSidebarChange({children}) {
+  const sidebar = useDocsSidebar();
+  return (
+    <React.Fragment key={sidebar?.name ?? 'noSidebar'}>
+      {children}
+    </React.Fragment>
+  );
+}
+export default function DocPageLayoutSidebar({
+  sidebar,
+  hiddenSidebarContainer,
+  setHiddenSidebarContainer,
+}) {
+  const {pathname} = useLocation();
+  const [hiddenSidebar, setHiddenSidebar] = useState(false);
+  const toggleSidebar = useCallback(() => {
+    if (hiddenSidebar) {
+      setHiddenSidebar(false);
+    }
+    setHiddenSidebarContainer((value) => !value);
+  }, [setHiddenSidebarContainer, hiddenSidebar]);
+  return (
+    <aside
+      className={clsx(
+        ThemeClassNames.docs.docSidebarContainer,
+        styles.docSidebarContainer,
+        hiddenSidebarContainer && styles.docSidebarContainerHidden,
+      )}
+      onTransitionEnd={(e) => {
+        if (!e.currentTarget.classList.contains(styles.docSidebarContainer)) {
+          return;
+        }
+        if (hiddenSidebarContainer) {
+          setHiddenSidebar(true);
+        }
+      }}>
+      <ResetOnSidebarChange>
+        <div
+          className={clsx(
+            styles.sidebarViewport,
+            hiddenSidebar && styles.sidebarViewportHidden,
+          )}>
+          <DocSidebar
+            sidebar={sidebar}
+            path={pathname}
+            onCollapse={toggleSidebar}
+            isHidden={hiddenSidebar}
+          />
+          {hiddenSidebar && <ExpandButton toggleSidebar={toggleSidebar} />}
+        </div>
+      </ResetOnSidebarChange>
+    </aside>
+  );
+}

--- a/src/theme/DocPage/Layout/Sidebar/index.js
+++ b/src/theme/DocPage/Layout/Sidebar/index.js
@@ -39,6 +39,9 @@ export default function DocPageLayoutSidebar({
     if (size.width <= 1200) {
       setHiddenSidebar(true);
       setHiddenSidebarContainer(true);
+    } else if (size.width >= 1536) {
+      setHiddenSidebar(false);
+      setHiddenSidebarContainer(false);
     }
   }, [size])
 

--- a/src/theme/DocPage/Layout/Sidebar/index.js
+++ b/src/theme/DocPage/Layout/Sidebar/index.js
@@ -1,15 +1,17 @@
-import React, {useState, useCallback} from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import clsx from 'clsx';
-import {ThemeClassNames} from '@docusaurus/theme-common';
-import {useDocsSidebar} from '@docusaurus/theme-common/internal';
-import {useLocation} from '@docusaurus/router';
+import { ThemeClassNames } from '@docusaurus/theme-common';
+import { useDocsSidebar } from '@docusaurus/theme-common/internal';
+import { useLocation } from '@docusaurus/router';
 import DocSidebar from '@theme/DocSidebar';
 import ExpandButton from '@theme/DocPage/Layout/Sidebar/ExpandButton';
 import styles from './styles.module.css';
+import useWindowSize from "./../../../../hooks/useWindowSize"
+
 // Reset sidebar state when sidebar changes
 // Use React key to unmount/remount the children
 // See https://github.com/facebook/docusaurus/issues/3414
-function ResetOnSidebarChange({children}) {
+function ResetOnSidebarChange({ children }) {
   const sidebar = useDocsSidebar();
   return (
     <React.Fragment key={sidebar?.name ?? 'noSidebar'}>
@@ -22,7 +24,9 @@ export default function DocPageLayoutSidebar({
   hiddenSidebarContainer,
   setHiddenSidebarContainer,
 }) {
-  const {pathname} = useLocation();
+
+  const size = useWindowSize();
+  const { pathname } = useLocation();
   const [hiddenSidebar, setHiddenSidebar] = useState(false);
   const toggleSidebar = useCallback(() => {
     if (hiddenSidebar) {
@@ -30,6 +34,14 @@ export default function DocPageLayoutSidebar({
     }
     setHiddenSidebarContainer((value) => !value);
   }, [setHiddenSidebarContainer, hiddenSidebar]);
+
+  useEffect(() => {
+    if (size.width <= 1200) {
+      setHiddenSidebar(true);
+      setHiddenSidebarContainer(true);
+    }
+  }, [size])
+
   return (
     <aside
       className={clsx(

--- a/src/theme/DocPage/Layout/Sidebar/index.js
+++ b/src/theme/DocPage/Layout/Sidebar/index.js
@@ -1,12 +1,12 @@
-import React, { useState, useCallback, useEffect } from 'react';
-import clsx from 'clsx';
-import { ThemeClassNames } from '@docusaurus/theme-common';
-import { useDocsSidebar } from '@docusaurus/theme-common/internal';
-import { useLocation } from '@docusaurus/router';
-import DocSidebar from '@theme/DocSidebar';
-import ExpandButton from '@theme/DocPage/Layout/Sidebar/ExpandButton';
-import styles from './styles.module.css';
-import useWindowSize from "./../../../../hooks/useWindowSize"
+import React, { useState, useCallback, useEffect } from "react";
+import clsx from "clsx";
+import { ThemeClassNames } from "@docusaurus/theme-common";
+import { useDocsSidebar } from "@docusaurus/theme-common/internal";
+import { useLocation } from "@docusaurus/router";
+import DocSidebar from "@theme/DocSidebar";
+import ExpandButton from "@theme/DocPage/Layout/Sidebar/ExpandButton";
+import styles from "./styles.module.css";
+import useWindowSize from "./../../../../hooks/useWindowSize";
 
 // Reset sidebar state when sidebar changes
 // Use React key to unmount/remount the children
@@ -14,7 +14,7 @@ import useWindowSize from "./../../../../hooks/useWindowSize"
 function ResetOnSidebarChange({ children }) {
   const sidebar = useDocsSidebar();
   return (
-    <React.Fragment key={sidebar?.name ?? 'noSidebar'}>
+    <React.Fragment key={sidebar?.name ?? "noSidebar"}>
       {children}
     </React.Fragment>
   );
@@ -24,33 +24,35 @@ export default function DocPageLayoutSidebar({
   hiddenSidebarContainer,
   setHiddenSidebarContainer,
 }) {
-
   const size = useWindowSize();
   const { pathname } = useLocation();
   const [hiddenSidebar, setHiddenSidebar] = useState(false);
+  const [userClick, setUserClick] = useState(false);
+
   const toggleSidebar = useCallback(() => {
     if (hiddenSidebar) {
       setHiddenSidebar(false);
     }
     setHiddenSidebarContainer((value) => !value);
+    setUserClick(true);
   }, [setHiddenSidebarContainer, hiddenSidebar]);
 
   useEffect(() => {
-    if (size.width <= 1200) {
+    if (size.width <= 1200 && !userClick) {
       setHiddenSidebar(true);
       setHiddenSidebarContainer(true);
-    } else if (size.width >= 1536) {
+    } else if (size.width >= 1200 && !userClick) {
       setHiddenSidebar(false);
       setHiddenSidebarContainer(false);
     }
-  }, [size])
+  }, [size, userClick]);
 
   return (
     <aside
       className={clsx(
         ThemeClassNames.docs.docSidebarContainer,
         styles.docSidebarContainer,
-        hiddenSidebarContainer && styles.docSidebarContainerHidden,
+        hiddenSidebarContainer && styles.docSidebarContainerHidden
       )}
       onTransitionEnd={(e) => {
         if (!e.currentTarget.classList.contains(styles.docSidebarContainer)) {
@@ -59,20 +61,27 @@ export default function DocPageLayoutSidebar({
         if (hiddenSidebarContainer) {
           setHiddenSidebar(true);
         }
-      }}>
+      }}
+    >
       <ResetOnSidebarChange>
         <div
           className={clsx(
             styles.sidebarViewport,
-            hiddenSidebar && styles.sidebarViewportHidden,
-          )}>
+            hiddenSidebar && styles.sidebarViewportHidden
+          )}
+        >
           <DocSidebar
             sidebar={sidebar}
             path={pathname}
             onCollapse={toggleSidebar}
             isHidden={hiddenSidebar}
           />
-          {hiddenSidebar && <ExpandButton toggleSidebar={toggleSidebar} />}
+          {hiddenSidebar && (
+            <ExpandButton
+              setUserClick={setUserClick}
+              toggleSidebar={toggleSidebar}
+            />
+          )}
         </div>
       </ResetOnSidebarChange>
     </aside>

--- a/src/theme/DocPage/Layout/Sidebar/styles.module.css
+++ b/src/theme/DocPage/Layout/Sidebar/styles.module.css
@@ -1,0 +1,32 @@
+:root {
+  --doc-sidebar-width: 300px;
+  --doc-sidebar-hidden-width: 30px;
+}
+
+.docSidebarContainer {
+  display: none;
+}
+
+@media (min-width: 997px) {
+  .docSidebarContainer {
+    display: block;
+    width: var(--doc-sidebar-width);
+    margin-top: calc(-1 * var(--ifm-navbar-height));
+    border-right: 1px solid var(--ifm-toc-border-color);
+    will-change: width;
+    transition: width var(--ifm-transition-fast) ease;
+    clip-path: inset(0);
+  }
+
+  .docSidebarContainerHidden {
+    width: var(--doc-sidebar-hidden-width);
+    cursor: pointer;
+  }
+
+  .sidebarViewport {
+    top: 0;
+    position: sticky;
+    height: 100%;
+    max-height: 100vh;
+  }
+}

--- a/src/theme/DocPage/Layout/index.js
+++ b/src/theme/DocPage/Layout/index.js
@@ -1,0 +1,28 @@
+import React, {useState} from 'react';
+import {useDocsSidebar} from '@docusaurus/theme-common/internal';
+import Layout from '@theme/Layout';
+import BackToTopButton from '@theme/BackToTopButton';
+import DocPageLayoutSidebar from '@theme/DocPage/Layout/Sidebar';
+import DocPageLayoutMain from '@theme/DocPage/Layout/Main';
+import styles from './styles.module.css';
+export default function DocPageLayout({children}) {
+  const sidebar = useDocsSidebar();
+  const [hiddenSidebarContainer, setHiddenSidebarContainer] = useState(false);
+  return (
+    <Layout wrapperClassName={styles.docsWrapper}>
+      <BackToTopButton />
+      <div className={styles.docPage}>
+        {sidebar && (
+          <DocPageLayoutSidebar
+            sidebar={sidebar.items}
+            hiddenSidebarContainer={hiddenSidebarContainer}
+            setHiddenSidebarContainer={setHiddenSidebarContainer}
+          />
+        )}
+        <DocPageLayoutMain hiddenSidebarContainer={hiddenSidebarContainer}>
+          {children}
+        </DocPageLayoutMain>
+      </div>
+    </Layout>
+  );
+}

--- a/src/theme/DocPage/Layout/styles.module.css
+++ b/src/theme/DocPage/Layout/styles.module.css
@@ -1,0 +1,12 @@
+.docPage {
+  max-width: var(--ifm-docs-page-width-xl);
+  margin: 0 auto;
+  display: flex;
+  width: 100%;
+  flex: 1 0;
+}
+
+.docsWrapper {
+  display: flex;
+  flex: 1 0 auto;
+}

--- a/src/theme/DocPage/index.js
+++ b/src/theme/DocPage/index.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import clsx from 'clsx';
+import {
+  HtmlClassNameProvider,
+  ThemeClassNames,
+  PageMetadata,
+} from '@docusaurus/theme-common';
+import {
+  docVersionSearchTag,
+  DocsSidebarProvider,
+  DocsVersionProvider,
+  useDocRouteMetadata,
+} from '@docusaurus/theme-common/internal';
+import DocPageLayout from '@theme/DocPage/Layout';
+import NotFound from '@theme/NotFound';
+import SearchMetadata from '@theme/SearchMetadata';
+function DocPageMetadata(props) {
+  const {versionMetadata} = props;
+  return (
+    <>
+      <SearchMetadata
+        version={versionMetadata.version}
+        tag={docVersionSearchTag(
+          versionMetadata.pluginId,
+          versionMetadata.version,
+        )}
+      />
+      <PageMetadata>
+        {versionMetadata.noIndex && (
+          <meta name="robots" content="noindex, nofollow" />
+        )}
+      </PageMetadata>
+    </>
+  );
+}
+export default function DocPage(props) {
+  const {versionMetadata} = props;
+  const currentDocRouteMetadata = useDocRouteMetadata(props);
+  if (!currentDocRouteMetadata) {
+    return <NotFound />;
+  }
+  const {docElement, sidebarName, sidebarItems} = currentDocRouteMetadata;
+  return (
+    <>
+      <DocPageMetadata {...props} />
+      <HtmlClassNameProvider
+        className={clsx(
+          // TODO: it should be removed from here
+          ThemeClassNames.wrapper.docsPages,
+          ThemeClassNames.page.docsDocPage,
+          props.versionMetadata.className,
+        )}>
+        <DocsVersionProvider version={versionMetadata}>
+          <DocsSidebarProvider name={sidebarName} items={sidebarItems}>
+            <DocPageLayout>{docElement}</DocPageLayout>
+          </DocsSidebarProvider>
+        </DocsVersionProvider>
+      </HtmlClassNameProvider>
+    </>
+  );
+}


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
- set the docs page's max-width to 1280px

- **Preview**: 


- **Related code PR**: 
#781 

- **Related doc issue**: 
Resolves #781 

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
