### PR TITLE
Add code format for db and table names

### DIFF
--- a/docs/sql/commands/sql-create-schema.md
+++ b/docs/sql/commands/sql-create-schema.md
@@ -38,7 +38,7 @@ rr.Stack(
 |---------------------------|-----------------------|
 |*schema_name*                   |The name of the schema to be created.|
 |<b>IF NOT EXISTS</b> clause      |Creates a schema if the schema name has not already been used. Otherwise throws an error.|
-|*database_name*                 |The name of the database for the schema to be created in. If not specified, the schema will be created in the default database "dev".|
+|*database_name*                 |The name of the database for the schema to be created in. If not specified, the schema will be created in the default database `dev`.|
 
 ## Example
 ```sql

--- a/docs/sql/commands/sql-describe.md
+++ b/docs/sql/commands/sql-describe.md
@@ -46,7 +46,7 @@ export const svg = rr.Diagram(
 
 ## Example
 
-This statement shows the columns and indexes of the "t1" table:
+This statement shows the columns and indexes of the `t1` table:
 ```sql
 DESCRIBE t1;
 ```

--- a/docs/sql/commands/sql-drop-database.md
+++ b/docs/sql/commands/sql-drop-database.md
@@ -45,7 +45,7 @@ export const svgtwo = rr.Diagram(
 
 ## Examples
 
-This statement removes the "rw_db" database which contains two schemas, "rw_schema" and "public" (default schema):
+This statement removes the `rw_db` database which contains two schemas, "rw_schema" and "public" (default schema):
 
 ```sql
 DROP SCHEMA rw_db.rw_schema;

--- a/docs/sql/commands/sql-drop-database.md
+++ b/docs/sql/commands/sql-drop-database.md
@@ -45,7 +45,7 @@ export const svgtwo = rr.Diagram(
 
 ## Examples
 
-This statement removes the `rw_db` database which contains two schemas, "rw_schema" and "public" (default schema):
+This statement removes the `rw_db` database which contains two schemas, `rw_schema` and `public` (default schema):
 
 ```sql
 DROP SCHEMA rw_db.rw_schema;

--- a/docs/sql/commands/sql-drop-index.md
+++ b/docs/sql/commands/sql-drop-index.md
@@ -49,7 +49,7 @@ export const svg = rr.Diagram(
 
 ## Examples
 
-This statement removes the "id_index" index from the "taxi_trips" table in the default schema ("public"):
+This statement removes the "id_index" index from the `taxi_trips` table in the default schema ("public"):
 
 ```sql
 DROP INDEX id_index;

--- a/docs/sql/commands/sql-drop-index.md
+++ b/docs/sql/commands/sql-drop-index.md
@@ -42,20 +42,20 @@ export const svg = rr.Diagram(
 |Parameter                  | Description           |
 |---------------------------|-----------------------|
 |**IF EXISTS** clause       |Do not return an error if the specified index does not exist.|
-|*schema_name*                   |The schema of the index that you want to remove. <br /> You can use [`SHOW SCHEMAS`](sql-show-schemas.md) to get a list of all available schemas. If you don't specify a schema, the specified index in the default schema "public" will be removed.|
+|*schema_name*                   |The schema of the index that you want to remove. <br /> You can use [`SHOW SCHEMAS`](sql-show-schemas.md) to get a list of all available schemas. If you don't specify a schema, the specified index in the default schema `public` will be removed.|
 |*index_name*                    |The name of the index to remove. <br/> You can use [`DESCRIBE`](sql-describe.md) to show the indexes of a table.|
 
 
 
 ## Examples
 
-This statement removes the "id_index" index from the `taxi_trips` table in the default schema ("public"):
+This statement removes the `id_index` index from the `taxi_trips` table in the default schema (`public`):
 
 ```sql
 DROP INDEX id_index;
 ```
 
-This statement removes the "ad_id_index" index from the "ad_ctr_5min" materialized view in the "rw_schema" schema:
+This statement removes the `ad_id_index` index from the `ad_ctr_5min` materialized view in the `rw_schema` schema:
 
 ```sql
 DROP INDEX rw_schema.id_index;

--- a/docs/sql/commands/sql-drop-mv.md
+++ b/docs/sql/commands/sql-drop-mv.md
@@ -45,20 +45,20 @@ export const svg = rr.Diagram(
 
 |Parameter                  | Description           |
 |---------------------------|-----------------------|
-|*schema_name*                   |Specify the name of a schema to remove the materialized view in that schema. You can use [`SHOW SCHEMAS`](sql-show-schemas.md) to get a list of all available schemas. If you don't specify a schema, the specified materialized view in the default schema "public" will be removed.|
+|*schema_name*                   |Specify the name of a schema to remove the materialized view in that schema. You can use [`SHOW SCHEMAS`](sql-show-schemas.md) to get a list of all available schemas. If you don't specify a schema, the specified materialized view in the default schema `public` will be removed.|
 |*mv_name*                       |The name of the materialized view to remove. You can use [`SHOW MATERIALIZED VIEWS`](sql-show-mv.md) to get a list of all available materialized views.|
 
 
 
 ## Examples
 
-This statement removes the "ad_ctr_5min" materialized view in the default schema ("public") from the database:
+This statement removes the `ad_ctr_5min` materialized view in the default schema (`public`) from the database:
 
 ```sql
 DROP MATERIALIZED VIEW ad_ctr_5min;
 ```
 
-This statement removes the "ad_ctr_5min" materialized view in the "rw_schema" schema from the database:
+This statement removes the `ad_ctr_5min` materialized view in the `rw_schema` schema from the database:
 
 ```sql
 DROP MATERIALIZED VIEW IF EXISTS rw_schema.ad_ctr_5min;

--- a/docs/sql/commands/sql-drop-schema.md
+++ b/docs/sql/commands/sql-drop-schema.md
@@ -53,14 +53,14 @@ export const svg = rr.Diagram(
 
 ## Examples
 
-This statement removes the "rw_schema" schema from the "rw_db" database:
+This statement removes the "rw_schema" schema from the `rw_db` database:
 
 ```sql
 DROP SCHEMA rw_db.rw_schema;
 ```
 
 
-This statement removes the "rw_schema" schema from the "dev" database (default database):
+This statement removes the "rw_schema" schema from the `dev` database (default database):
 
 ```sql
 DROP SCHEMA rw_schema;

--- a/docs/sql/commands/sql-drop-schema.md
+++ b/docs/sql/commands/sql-drop-schema.md
@@ -47,20 +47,20 @@ export const svg = rr.Diagram(
 |---------------------------|-----------------------|
 |**IF EXISTS** clause       |Do not return an error if the specified schema does not exist.|
 |*database*                 |Specify the name of a database to remove the schema in that database. You can use [`SHOW  DATABASES`](sql-show-databases.md) to get a list of all available databases. If you don't specify a database, the specified schema in the default database will be removed.|
-|*schema*                   |The name of the schema you want to remove. The default schema is "public". You can use [`SHOW SCHEMAS`](sql-show-schemas.md) to get a list of all available schemas.|
+|*schema*                   |The name of the schema you want to remove. The default schema is `public`. You can use [`SHOW SCHEMAS`](sql-show-schemas.md) to get a list of all available schemas.|
 
 
 
 ## Examples
 
-This statement removes the "rw_schema" schema from the `rw_db` database:
+This statement removes the `rw_schema` schema from the `rw_db` database:
 
 ```sql
 DROP SCHEMA rw_db.rw_schema;
 ```
 
 
-This statement removes the "rw_schema" schema from the `dev` database (default database):
+This statement removes the `rw_schema` schema from the `dev` database (default database):
 
 ```sql
 DROP SCHEMA rw_schema;

--- a/docs/sql/commands/sql-drop-source.md
+++ b/docs/sql/commands/sql-drop-source.md
@@ -43,21 +43,21 @@ export const svg = rr.Diagram(
 
 |Parameter                  | Description           |
 |---------------------------|-----------------------|
-|*schema_name*                   |The schema of the source that you want to remove. You can use [`SHOW SCHEMAS`](sql-show-schemas.md) to get a list of all available schemas. If you don't specify a schema, the specified source in the default schema "public" will be removed.|
+|*schema_name*                   |The schema of the source that you want to remove. You can use [`SHOW SCHEMAS`](sql-show-schemas.md) to get a list of all available schemas. If you don't specify a schema, the specified source in the default schema `public` will be removed.|
 |*source_name*                   |The name of the source to remove.|
 
 
 
 ## Examples
 
-This statement removes the "rw_source" source in the default schema ("public") from the database:
+This statement removes the `rw_source` source in the default schema (`public`) from the database:
 
 ```sql
 DROP SOURCE rw_source;
 ```
 
 
-This statement removes the "rw_source" source in the "rw_schema" schema from the database:
+This statement removes the `rw_source` source in the `rw_schema` schema from the database:
 
 ```sql
 DROP SOURCE IF EXISTS rw_schema.rw_source;

--- a/docs/sql/commands/sql-drop-table.md
+++ b/docs/sql/commands/sql-drop-table.md
@@ -51,13 +51,13 @@ export const svg = rr.Diagram(
 
 ## Examples
 
-This statement removes the "taxi_trips" table in the default schema ("public") from the database:
+This statement removes the `taxi_trips` table in the default schema ("public") from the database:
 
 ```sql
 DROP TABLE taxi_trips;
 ```
 
-This statement removes the "taxi_trips" table in the "rw_schema" schema from the database:
+This statement removes the `taxi_trips` table in the "rw_schema" schema from the database:
 
 ```sql
 DROP TABLE IF EXISTS rw_schema.taxi_trips;

--- a/docs/sql/commands/sql-drop-table.md
+++ b/docs/sql/commands/sql-drop-table.md
@@ -44,20 +44,20 @@ export const svg = rr.Diagram(
 
 |Parameter                  | Description           |
 |---------------------------|-----------------------|
-|*schema*                   |Specify the name of a schema to remove the table in that schema. You can use [`SHOW SCHEMAS`](sql-show-schemas.md) to get a list of all available schemas. If you don't specify a schema, the specified source in the default schema "public" will be removed.|
+|*schema*                   |Specify the name of a schema to remove the table in that schema. You can use [`SHOW SCHEMAS`](sql-show-schemas.md) to get a list of all available schemas. If you don't specify a schema, the specified source in the default schema `public` will be removed.|
 |*table*                    |The name of the table to remove. You can use [`SHOW TABLES`](sql-show-tables.md) to get a list of all available tables.|
 
 
 
 ## Examples
 
-This statement removes the `taxi_trips` table in the default schema ("public") from the database:
+This statement removes the `taxi_trips` table in the default schema (`public`) from the database:
 
 ```sql
 DROP TABLE taxi_trips;
 ```
 
-This statement removes the `taxi_trips` table in the "rw_schema" schema from the database:
+This statement removes the `taxi_trips` table in the `rw_schema` schema from the database:
 
 ```sql
 DROP TABLE IF EXISTS rw_schema.taxi_trips;

--- a/docs/sql/commands/sql-insert.md
+++ b/docs/sql/commands/sql-insert.md
@@ -45,7 +45,7 @@ The table `taxi_trips` has three columns:
 }
 ```
 
-The following statement inserts four new rows into "taxi_trips".
+The following statement inserts four new rows into `taxi_trips`.
 
 ```sql
 INSERT INTO taxi_trips 
@@ -68,7 +68,7 @@ SELECT * FROM taxi_trips ORDER BY id;
   4 |        9 | 
 ```
 
-The following statement inserts all rows in another table name "taxi_trips_new" into "taxi_trips". The two tables have the same column setup. Also, it returns the value of *id* for the inserted rows.
+The following statement inserts all rows in another table name `taxi_trips_new` into `taxi_trips`. The two tables have the same column setup. Also, it returns the value of *id* for the inserted rows.
 
 ```sql
 INSERT INTO taxi_trips 

--- a/docs/sql/commands/sql-show-internal-tables.md
+++ b/docs/sql/commands/sql-show-internal-tables.md
@@ -37,7 +37,7 @@ export const svg = rr.Diagram(
 ## Parameters
 |Parameter   | Description           |
 |---------------------------|-----------------------|
-|*schema_name*                   |The schema in which tables will be listed. If not given, tables from the default schema, "public", will be listed.|
+|*schema_name*                   |The schema in which tables will be listed. If not given, tables from the default schema, `public`, will be listed.|
 
 
 ## Example

--- a/docs/sql/commands/sql-show-mv.md
+++ b/docs/sql/commands/sql-show-mv.md
@@ -37,7 +37,7 @@ export const svg = rr.Diagram(
 ## Parameters
 |Parameter      | Description           |
 |---------------------------|-----------------------|
-|*schema_name*                   |The schema in which the materialized views will be listed. If not given, materialized views from the default schema, "public", will be listed|
+|*schema_name*                   |The schema in which the materialized views will be listed. If not given, materialized views from the default schema, `public`, will be listed|
 
 
 ## Example

--- a/docs/sql/commands/sql-show-schemas.md
+++ b/docs/sql/commands/sql-show-schemas.md
@@ -5,7 +5,7 @@ description: Show existing schemas.
 slug: /sql-show-schemas
 ---
 
-Use the `SHOW SCHEMAS` command to show schemas in the "dev" database.
+Use the `SHOW SCHEMAS` command to show schemas in the `dev` database.
 
 ## Syntax
 

--- a/docs/sql/commands/sql-show-sources.md
+++ b/docs/sql/commands/sql-show-sources.md
@@ -35,7 +35,7 @@ export const svg = rr.Diagram(
 ## Parameters
 |Parameter or clause        | Description           |
 |---------------------------|-----------------------|
-|*schema_name*                   |The schema of the sources to be listed. The default schema is "public".|
+|*schema_name*                   |The schema of the sources to be listed. The default schema is `public`.|
 
 
 ## Example

--- a/docs/sql/commands/sql-show-tables.md
+++ b/docs/sql/commands/sql-show-tables.md
@@ -36,7 +36,7 @@ export const svg = rr.Diagram(
 ## Parameters
 |Parameter   | Description           |
 |---------------------------|-----------------------|
-|*schema_name*                   |The schema in which tables will be listed. If not given, tables from the default schema, "public", will be listed.|
+|*schema_name*                   |The schema in which tables will be listed. If not given, tables from the default schema, `public`, will be listed.|
 
 
 ## Example

--- a/docs/sql/query-syntax/query-syntax-value-exp.md
+++ b/docs/sql/query-syntax/query-syntax-value-exp.md
@@ -39,7 +39,7 @@ CREATE TABLE t (v1 int, v2 int);
 INSERT INTO t VALUES (1,12), (2,13), (3,30);
 ```
 
-The row constructor in the statement below returns all rows in table "t" in the form of row values `(,)`.
+The row constructor in the statement below returns all rows in table `t` in the form of row values `(,)`.
 
 ```sql
 SELECT row (v1, v2*2) AS demo FROM t;


### PR DESCRIPTION
Add code format for db and table names.

<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Add code format for db and table names.

- **Preview**: 
[ Paste the preview link to the edited page here. Edit this item after you submit the PR and the preview is ready. ]

- **Related code PR**: 
N/A

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/620

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
