### PR TITLE
update meta backup doc

### DIFF
--- a/docs/manage/meta-backup.md
+++ b/docs/manage/meta-backup.md
@@ -11,15 +11,15 @@ This guide introduces how to back up meta service data and restore from a backup
 
 A meta snapshot is a backup of meta service's data at a specific point in time. Meta snapshots are persisted in S3-compatible storage.
 
-Here's an example of how to specify target storage and set `storage_url` and `storage_directory`:
+Here's an example of how to specify target storage and set `backup_storage_url` and `backup_storage_directory`:
 
 ```
-[backup]
-storage_url = "s3://[bucket]"
-storage_directory = "backup"
+[system]
+backup_storage_url = "s3://[bucket]"
+backup_storage_directory = "backup"
 ```
 
-Typically, `storage_url` and `storage_directory` should not be changed after initializing the cluster. Otherwise, if they are changed, all meta snapshots taken previously become invalidated and shouldn't be used anymore.
+Typically, `backup_storage_url` and `backup_storage_directory` should not be changed after initializing the cluster. Otherwise, if they are changed, all meta snapshots taken previously become invalidated and shouldn't be used anymore.
 This is because the meta backup and recovery process does not replicate SST files. To ensure consistency between meta snapshots and SST files, the meta service additionally maintains the retention time for SSTs required by meta snapshots via monitoring the snapshot storage in use. That is to say, SST files required by meta snapshots from a snapshot storage that is not in use may be garbage collected at any time.
 
 
@@ -76,9 +76,11 @@ Use the following steps to restore from a meta snapshot.
     --meta-store-type etcd \
     --meta-snapshot-id [snapshot_id] \
     --etcd-endpoints [etcd_endpoints] \
-    --storage-url [storage_url]
+    --backup-storage-url [backup_storage_url]
+    --hummock_storage_url [hummock_storage_url]
+    --hummock_storage_dir [hummock_storage_dir]
     ```
-    `backup-restore` reads snapshot data from snapshot storage and writes them to `etcd`. 
+    `backup-restore` reads snapshot data from backup storage and writes them to etcd and hummock storage. 
     `backup-restore` is not included in the pre-built risingwave binary. Please build it from source by compiling the `risingwave_backup_cmd` package.
 4. Configure meta service to use the new meta store.
 

--- a/docs/manage/meta-backup.md
+++ b/docs/manage/meta-backup.md
@@ -77,8 +77,8 @@ Use the following steps to restore from a meta snapshot.
     --meta-snapshot-id [snapshot_id] \
     --etcd-endpoints [etcd_endpoints] \
     --backup-storage-url [backup_storage_url]
-    --hummock_storage_url [hummock_storage_url]
-    --hummock_storage_dir [hummock_storage_dir]
+    --hummock-storage-url [hummock_storage_url]
+    --hummock-storage-dir [hummock_storage_dir]
     ```
     `backup-restore` reads snapshot data from backup storage and writes them to etcd and hummock storage. 
     `backup-restore` is not included in the pre-built risingwave binary. Please build it from source by compiling the `risingwave_backup_cmd` package.


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
Update meta backup doc, because parameter names have changed in RisingWave kernel.

- **Preview**: 
https://github.com/risingwavelabs/risingwave-docs/blob/d9e3c783927238783d8754e7e9b457ffb56fdf44/docs/manage/meta-backup.md

- **Related code PR**: 
[ Provide the link to the code PR here. Delete this part if there's no code PR related. ]

- **Related doc issue**: 
Resolves [ Provide the link to the doc issue here. ]

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
