### PR TITLE
feat(style): search toolbox highlight color theme and link groups color

### DIFF
--- a/src/components/FeedbackForm/IssueIcon.tsx
+++ b/src/components/FeedbackForm/IssueIcon.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+type Props = {
+  fill: string;
+};
+
+function IssueIcon({ fill }: Props) {
+  return (
+    <svg
+      aria-hidden="true"
+      height="16"
+      viewBox="0 0 16 16"
+      version="1.1"
+      width="16"
+      data-view-component="true"
+      className="octicon octicon-issue-opened UnderlineNav-octicon d-none d-sm-inline"
+    >
+      <path fill={fill} d="M8 9.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path>
+      <path
+        fill={fill}
+        d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"
+      ></path>
+    </svg>
+  );
+}
+
+export default IssueIcon;

--- a/src/components/FeedbackForm/PullRequestIcon.tsx
+++ b/src/components/FeedbackForm/PullRequestIcon.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+type Props = {
+  fill: string;
+};
+
+function PullRequestIcon({ fill }: Props) {
+  return (
+    <svg
+      aria-hidden="true"
+      height="16"
+      viewBox="0 0 16 16"
+      version="1.1"
+      width="16"
+      data-view-component="true"
+      className="octicon octicon-git-pull-request UnderlineNav-octicon d-none d-sm-inline"
+    >
+      <path
+        fill={fill}
+        d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"
+      ></path>
+    </svg>
+  );
+}
+
+export default PullRequestIcon;

--- a/src/components/FeedbackForm/index.js
+++ b/src/components/FeedbackForm/index.js
@@ -1,6 +1,4 @@
 import React, { useState, useEffect } from "react";
-import PullRequestIcon from "@site/static/img/github_pr.svg";
-import IssueIcon from "@site/static/img/github_issue.svg";
 import { Button, Typography, Stack } from "@mui/material";
 import CommunityLinkGroup from "@site/src/components/LinkGroup";
 import { sendFeedback } from "@site/src/api/feedback";
@@ -10,13 +8,22 @@ import "react-toastify/dist/ReactToastify.css";
 import styles from "./index.module.css";
 import { Widget } from "@happyreact/react";
 import "@happyreact/react/theme.css";
+import { useColorMode } from "@docusaurus/theme-common";
+import IssueIcon from "./IssueIcon";
+import PullRequestIcon from "./PullRequestIcon";
 
 export default function FeedbackForm(props) {
+  const { isDarkTheme } = useColorMode();
+  const [dark, setDark] = useState(false);
   const [formData, setFormData] = useState({
     description: "",
     like: false,
     unlike: false,
   });
+
+  useEffect(() => {
+    setDark(isDarkTheme);
+  }, [isDarkTheme]);
 
   const handleChange = (e) => {
     setFormData({
@@ -109,7 +116,7 @@ export default function FeedbackForm(props) {
                 className={styles.footerButton}
                 variant="outlined"
                 onClick={() => window.open(props.requestIssueUrl)}
-                startIcon={<IssueIcon />}
+                startIcon={<IssueIcon fill={dark ? "#48dcbc" : "#0098ef"} />}
               >
                 File an issue
               </Button>
@@ -117,7 +124,7 @@ export default function FeedbackForm(props) {
                 className={styles.footerButton}
                 variant="outlined"
                 onClick={() => window.open(props.editUrl)}
-                startIcon={<PullRequestIcon style={{ color: "red" }} />}
+                startIcon={<PullRequestIcon fill={dark ? "#48dcbc" : "#0098ef"} />}
               >
                 Edit this page
               </Button>

--- a/src/components/FeedbackForm/index.module.css
+++ b/src/components/FeedbackForm/index.module.css
@@ -52,6 +52,11 @@ button.footerButton {
   font-family: var(--ifm-font-family-base);
 }
 
+[data-theme="dark"] button.footerButton {
+  border: 1px solid var(--ifm-button-color);
+  color: var(--ifm-button-color);
+}
+
 p.rightText {
   font-weight: 100;
   margin-right: 20px;
@@ -148,6 +153,11 @@ p.rightText {
   border: #0098ef 1px solid;
   border-radius: 4px;
   margin-bottom: 1rem;
+}
+
+[data-theme="dark"] .happyReact .reaction {
+  border: 1px solid var(--ifm-button-color);
+  color: var(--ifm-button-color);
 }
 
 .happyReact .reaction:hover {

--- a/src/components/LinkGroup/index.js
+++ b/src/components/LinkGroup/index.js
@@ -8,23 +8,24 @@ const buttonSize = 36;
 
 const LinkButton = styled("div")({
   backgroundColor: "#8080803b",
-  // padding: "10px",
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
   width: `${buttonSize}px`,
   height: `${buttonSize}px`,
   borderRadius: "10px",
+  transition: "border-radius 1s ease-out",
 });
 
 const FoldedTextSpan = styled("span")({
+  paddingLeft: "4px",
   color: "#8294CC",
   fontSize: "12px",
   fontWeight: "bold",
 });
 
 const FoldedTab = styled("div")({
-  backgroundColor: "#EBEDF0",
+  backgroundColor: "#8080803b",
   height: `${buttonSize}px`,
   borderTopLeftRadius: "10px",
   borderBottomLeftRadius: "10px",
@@ -39,7 +40,7 @@ const FoldedTab = styled("div")({
 const FoldedTabContainer = styled(Collapse)({
   position: "absolute",
   top: `${buttonSize / 3.6}px`,
-  right: `${buttonSize + 2}px`,
+  right: `${buttonSize + 10}px`,
 });
 
 const LinkImg = styled("img")({
@@ -60,16 +61,16 @@ const LinkItem = (props) => {
       onClick={() => { openWindow(props.link) }}
     >
       <FoldedTabContainer className={styles.foldedTab} orientation="horizontal" in={props.focusing}>
-        <FoldedTab>
+        <FoldedTab className={styles.foldedTabSpan}>
           <FoldedTextSpan>
             {props.label}
           </FoldedTextSpan>
         </FoldedTab>
       </FoldedTabContainer>
-      <LinkButton className={styles.linkButton}>
+      <LinkButton className={`${styles.linkButton} ${props.focusing ? `${styles.linkButtonNoLeftBorder}` : ""}`}>
         <LinkImg src={props.imgUrl} />
       </LinkButton>
-    </div>
+    </div >
   );
 };
 

--- a/src/components/LinkGroup/index.js
+++ b/src/components/LinkGroup/index.js
@@ -19,7 +19,7 @@ const LinkButton = styled("div")({
 
 const FoldedTextSpan = styled("span")({
   paddingLeft: "4px",
-  color: "#8294CC",
+  color: "var(--ifm-font-color-base)",
   fontSize: "12px",
   fontWeight: "bold",
 });

--- a/src/components/LinkGroup/index.module.css
+++ b/src/components/LinkGroup/index.module.css
@@ -14,6 +14,12 @@
   margin: 10px;
 }
 
+.linkButtonNoLeftBorder {
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+  transition: all 0.1s !important;
+}
+
 @media (max-width: 996px) {
   .container {
     position: static;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -21,6 +21,7 @@
   --ifm-navbar-link-color: #16171a;
   --ifm-button-background-color: var(--ifm-color-primary-dark);
   --ifm-button-hover-background-color: #0179be;
+  --ifm-button-color: #0179be;
 
   --ifm-code-font-size: 90%;
   --ifm-font-size-base: 92%;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -61,6 +61,8 @@
   --ifm-color-success-light: rgb(38, 178, 38);
   --ifm-color-success-lighter: rgba(77, 191, 77, 0.212);
   --ifm-color-success-lightest: rgb(128, 210, 128);
+
+  --docsearch-primary-color: var(--ifm-color-primary-darkest) !important;
 }
 
 html[data-theme="dark"] {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -84,7 +84,7 @@ html[data-theme="dark"] {
   --ifm-hover-overlay: #ffffff0d;
   --ifm-color-content: #e3e3e3;
   --ifm-color-content-secondary: #fff;
-  --ifm-link-color: #86f2dd;
+  --ifm-link-color: #48dcbc;
   --ifm-tabs-color-active-border: #86f2dd;
   --ifm-tabs-color-active: #86f2dd;
   --ifm-code-background: #fafafa28;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -19,6 +19,9 @@
   --ifm-color-neutral-400: #b3b3b3;
   --ifm-color-neutral-900: #16171a;
   --ifm-navbar-link-color: #16171a;
+  --ifm-button-background-color: var(--ifm-color-primary-dark);
+  --ifm-button-hover-background-color: #0179be;
+
   --ifm-code-font-size: 90%;
   --ifm-font-size-base: 92%;
   --ifm-z-index-fixed: 200;
@@ -49,6 +52,15 @@
   --ifm-background-color: #1f2765;
   --ifm-navbar-link-color: #e3e3e3;
   --ifm-heading-color: #e3e3e3;
+
+  --ifm-button-background-color: linear-gradient(
+      0deg,
+      rgba(72, 220, 188, 0.1),
+      rgba(72, 220, 188, 0.1)
+    ),
+    #0a3246;
+  --ifm-button-hover-background-color: #102432;
+  --ifm-button-color: #48dcbc;
 
   --ifm-blockquote-color: #b8c4c9;
   --ifm-font-color-base: #b8c4c9;

--- a/src/theme/Capsule/index.tsx
+++ b/src/theme/Capsule/index.tsx
@@ -3,6 +3,7 @@ import NotifyButton from "../NotifyButton";
 import styles from "./styles.module.css";
 import Tooltip from "@mui/material/Tooltip";
 import { getLike, postLike } from "../../api/feedback";
+import { useColorMode } from "@docusaurus/theme-common";
 
 type Props = {
   note: string;
@@ -11,6 +12,11 @@ type Props = {
 function Capsule({ note }: Props) {
   const [clicked, setClicked] = useState(false);
   const [count, setCount] = useState(0);
+  const { isDarkTheme } = useColorMode();
+  const [dark, setDark] = useState(false);
+  useEffect(() => {
+    setDark(isDarkTheme);
+  }, [isDarkTheme]);
 
   useEffect(() => {
     if (!note) return;
@@ -45,11 +51,11 @@ function Capsule({ note }: Props) {
         <div className={styles.capsuleLeft} onClick={LikeFeature}>
           {clicked ? (
             <div className={styles.countLeft}>
-              <FillThumbsUpIcon size="16" />
+              <FillThumbsUpIcon fill={dark ? "#48dcbc" : "#0098EF"} size="16" />
               <span className={styles.count}>{count}</span>
             </div>
           ) : (
-            <ThumbsUpIcon size="16" />
+            <ThumbsUpIcon fill={dark ? "#48dcbc" : "#0098EF"} size="16" />
           )}
         </div>
       </Tooltip>
@@ -64,10 +70,11 @@ function Capsule({ note }: Props) {
 export default Capsule;
 
 type ButtonSize = {
+  fill: string;
   size?: string;
 };
 
-const ThumbsUpIcon = ({ size }: ButtonSize) => (
+const ThumbsUpIcon = ({ fill, size }: ButtonSize) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"
@@ -76,13 +83,13 @@ const ThumbsUpIcon = ({ size }: ButtonSize) => (
   >
     <path fill="none" d="M0 0h24v24H0z" />
     <path
-      fill="#0098EF"
+      fill={fill}
       d="M14.6 8H21a2 2 0 0 1 2 2v2.104a2 2 0 0 1-.15.762l-3.095 7.515a1 1 0 0 1-.925.619H2a1 1 0 0 1-1-1V10a1 1 0 0 1 1-1h3.482a1 1 0 0 0 .817-.423L11.752.85a.5.5 0 0 1 .632-.159l1.814.907a2.5 2.5 0 0 1 1.305 2.853L14.6 8zM7 10.588V19h11.16L21 12.104V10h-6.4a2 2 0 0 1-1.938-2.493l.903-3.548a.5.5 0 0 0-.261-.571l-.661-.33-4.71 6.672c-.25.354-.57.644-.933.858zM5 11H3v8h2v-8z"
     />
   </svg>
 );
 
-const FillThumbsUpIcon = ({ size }: ButtonSize) => (
+const FillThumbsUpIcon = ({ fill, size }: ButtonSize) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"
@@ -91,7 +98,7 @@ const FillThumbsUpIcon = ({ size }: ButtonSize) => (
   >
     <path fill="none" d="M0 0h24v24H0z" />
     <path
-      fill="#0098EF"
+      fill={fill}
       d="M2 9h3v12H2a1 1 0 0 1-1-1V10a1 1 0 0 1 1-1zm5.293-1.293l6.4-6.4a.5.5 0 0 1 .654-.047l.853.64a1.5 1.5 0 0 1 .553 1.57L14.6 8H21a2 2 0 0 1 2 2v2.104a2 2 0 0 1-.15.762l-3.095 7.515a1 1 0 0 1-.925.619H8a1 1 0 0 1-1-1V8.414a1 1 0 0 1 .293-.707z"
     />
   </svg>

--- a/src/theme/DefaultButton/index.tsx
+++ b/src/theme/DefaultButton/index.tsx
@@ -17,16 +17,18 @@ export default function DefaultButton({ text, doc, url, block, cloud }: Props) {
   const location = useLocation();
 
   return (
-    <button
+    <div
       onClick={() => {
         if (doc) {
-          globalData["docusaurus-plugin-content-docs"].default["versions"].map((v) => {
-            if (location.pathname.includes(v.path)) {
-              history.push(`${v.path}/${doc}`);
-            } else if (location.pathname.includes("cloud")) {
-              history.push(`/docs/current/${doc}`);
+          globalData["docusaurus-plugin-content-docs"].default["versions"].map(
+            (v) => {
+              if (location.pathname.includes(v.path)) {
+                history.push(`${v.path}/${doc}`);
+              } else if (location.pathname.includes("cloud")) {
+                history.push(`/docs/current/${doc}`);
+              }
             }
-          });
+          );
         } else if (url) {
           window.open(url, "_blank", "noopener,noreferrer");
         } else if (cloud) {
@@ -36,6 +38,6 @@ export default function DefaultButton({ text, doc, url, block, cloud }: Props) {
       className={block ? "default block" : "default"}
     >
       {text}
-    </button>
+    </div>
   );
 }

--- a/src/theme/DefaultButton/style.css
+++ b/src/theme/DefaultButton/style.css
@@ -1,17 +1,17 @@
 .default {
+  cursor: pointer;
   margin: 4px 0;
   margin-right: 8px;
   display: inline-block;
   appearance: none;
   font-size: var(--ifm-font-size-base);
-  background-color: var(--ifm-color-primary-darker);
-  border: 1px solid #71bde9;
-  border-radius: 6px;
+  background: var(--ifm-button-background-color);
+  border-radius: 4px;
   box-sizing: border-box;
   color: #fff;
   font-weight: 500;
-  line-height: 20px;
-  padding: 6px 16px;
+  line-height: 24px;
+  padding: 8px 18px;
   position: relative;
   text-align: center;
   text-decoration: none;
@@ -20,18 +20,24 @@
   transition: all 0.2s cubic-bezier(0.3, 0, 0.5, 1);
 }
 
+[data-theme="dark"] .default {
+  background: #48dcbc;
+  color: #091720;
+}
+
 .default:focus:not(:focus-visible):not(.focus-visible) {
   box-shadow: none;
   outline: none;
 }
 
 .default:hover {
-  background-color: var(--ifm-color-primary-dark);
+  background-color: var(--ifm-color-primary-darker);
 }
 
 [data-theme="dark"] .default:hover {
-  background-color: #6cc3f2;
-  border: 1px solid #71bde9;
+  background: linear-gradient(0deg, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.3)),
+    #86f2dd;
+  color: #102432;
 }
 
 .default:focus {

--- a/src/theme/DefaultButton/style.css
+++ b/src/theme/DefaultButton/style.css
@@ -17,7 +17,6 @@
   text-decoration: none;
   vertical-align: middle;
   white-space: nowrap;
-  transition: all 0.2s cubic-bezier(0.3, 0, 0.5, 1);
 }
 
 [data-theme="dark"] .default {

--- a/src/theme/LightButton/index.tsx
+++ b/src/theme/LightButton/index.tsx
@@ -17,16 +17,18 @@ export default function LightButton({ text, doc, url, block, cloud }: Props) {
   const location = useLocation();
 
   return (
-    <button
+    <div
       onClick={() => {
         if (doc) {
-          globalData["docusaurus-plugin-content-docs"].default["versions"].map((v) => {
-            if (location.pathname.includes(v.path)) {
-              history.push(`${v.path}/${doc}`);
-            } else if (location.pathname.includes("cloud")) {
-              history.push(`/docs/current/${doc}`);
+          globalData["docusaurus-plugin-content-docs"].default["versions"].map(
+            (v) => {
+              if (location.pathname.includes(v.path)) {
+                history.push(`${v.path}/${doc}`);
+              } else if (location.pathname.includes("cloud")) {
+                history.push(`/docs/current/${doc}`);
+              }
             }
-          });
+          );
         } else if (url) {
           window.open(url, "_blank", "noopener,noreferrer");
         } else if (cloud) {
@@ -36,6 +38,6 @@ export default function LightButton({ text, doc, url, block, cloud }: Props) {
       className={block ? "light block" : "light"}
     >
       {text}
-    </button>
+    </div>
   );
 }

--- a/src/theme/LightButton/style.css
+++ b/src/theme/LightButton/style.css
@@ -1,51 +1,43 @@
 .light {
+  cursor: pointer;
   margin: 4px 0;
   margin-right: 8px;
   display: inline-block;
   appearance: none;
   font-size: var(--ifm-font-size-base);
-  background-color: #fafbfc;
-  border: 1px solid rgba(27, 31, 35, 0.15);
-  border-radius: 6px;
-  box-sizing: border-box;
-  color: #24292e;
+  border-radius: 4px;
+  color: var(--ifm-button-color);
+  background: var(--ifm-button-background-color);
   font-weight: 500;
-  line-height: 20px;
+  line-height: 24px;
   list-style: none;
-  padding: 6px 16px;
+  padding: 8px 18px;
   position: relative;
-  transition: background-color 0.2s cubic-bezier(0.3, 0, 0.5, 1);
-  user-select: none;
-  -webkit-user-select: none;
-  touch-action: manipulation;
   vertical-align: middle;
   white-space: nowrap;
   word-wrap: break-word;
+  transition: background-color 0.2s cubic-bezier(0.3, 0, 0.5, 1);
 }
 
 .light:hover {
-  background-color: #b5b9c21c;
+  background-color: var(--ifm-button-hover-background-color);
   text-decoration: none;
   transition-duration: 0.1s;
 }
 
 [data-theme="dark"] .light {
-  box-shadow: none;
-  background-color: transparent;
-  border: 1px solid var(--ifm-color-primary-light);
-  color: #fff;
+  background: var(--ifm-button-background-color);
 }
 
 [data-theme="dark"] .light:hover {
-  background-color: var(--ifm-color-primary-darker);
+  background-color: var(--ifm-button-hover-background-color);
   text-decoration: none;
   transition-duration: 0.1s;
 }
 
 [data-theme="dark"] .default:active {
-  background-color: #3962d4;
-  border: 1px solid #5a7ee1;
-  transition-duration: 0.1s;
+  background-color: var(--ifm-button-hover-background-color);
+  /* transition-duration: 0.1s; */
 }
 
 .light:disabled {
@@ -57,11 +49,6 @@
 
 .light:active {
   background-color: #edeff2;
-  transition: none 0s;
-}
-
-[data-theme="dark"] .light:active {
-  background-color: #567de6;
   transition: none 0s;
 }
 

--- a/src/theme/LightButton/style.css
+++ b/src/theme/LightButton/style.css
@@ -6,8 +6,8 @@
   appearance: none;
   font-size: var(--ifm-font-size-base);
   border-radius: 4px;
-  color: var(--ifm-button-color);
-  background: var(--ifm-button-background-color);
+  color: #0098ef;
+  background: #0098ef2e;
   font-weight: 500;
   line-height: 24px;
   list-style: none;
@@ -20,12 +20,13 @@
 }
 
 .light:hover {
-  background-color: var(--ifm-button-hover-background-color);
+  background-color: #00a2ff62;
   text-decoration: none;
   transition-duration: 0.1s;
 }
 
 [data-theme="dark"] .light {
+  color: var(--ifm-button-color);
   background: var(--ifm-button-background-color);
 }
 
@@ -37,7 +38,6 @@
 
 [data-theme="dark"] .default:active {
   background-color: var(--ifm-button-hover-background-color);
-  /* transition-duration: 0.1s; */
 }
 
 .light:disabled {

--- a/src/theme/NotifyButton/index.tsx
+++ b/src/theme/NotifyButton/index.tsx
@@ -4,6 +4,7 @@ import "./style.css";
 import { toast } from "react-toastify";
 import { postNotification } from "../../api/feedback";
 import Tooltip from "@mui/material/Tooltip";
+import { useColorMode } from "@docusaurus/theme-common";
 
 type Props = {
   note: string;
@@ -14,6 +15,12 @@ function NotifyButton({ note, size }: Props) {
   const [shown, setShown] = useState(false);
   const [valid, setValid] = useState(false);
   const [email, setEmail] = useState("");
+
+  const { isDarkTheme } = useColorMode();
+  const [dark, setDark] = useState(false);
+  useEffect(() => {
+    setDark(isDarkTheme);
+  }, [isDarkTheme]);
 
   const getNotify = () => {
     const emailValid = email.match(/^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/i);
@@ -28,7 +35,8 @@ function NotifyButton({ note, size }: Props) {
         setShown(false);
       })
       .catch((err) => {
-        if (err.response) toast.info(err.response.data.msg ?? "Something went wrong :(");
+        if (err.response)
+          toast.info(err.response.data.msg ?? "Something went wrong :(");
         else if (err.request) toast.error("Something went wrong :(");
       })
       .finally(() => setEmail(""));
@@ -51,7 +59,9 @@ function NotifyButton({ note, size }: Props) {
             required
             onChange={(e) => {
               setEmail(e.target.value);
-              setValid(!!e.target.value.match(/^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/i));
+              setValid(
+                !!e.target.value.match(/^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/i)
+              );
             }}
           />
           <button type="submit" disabled={!valid} onClick={getNotify}>
@@ -61,8 +71,12 @@ function NotifyButton({ note, size }: Props) {
       }
     >
       <Tooltip title="Notify me when it's available" arrow>
-        <div className="notify-button" id="app-title" onClick={() => setShown(!shown)}>
-          <NotifyIconDefault size={size} />
+        <div
+          className="notify-button"
+          id="app-title"
+          onClick={() => setShown(!shown)}
+        >
+          <NotifyIconDefault fill={dark ? "#48dcbc" : "#0098EF"} size={size} />
         </div>
       </Tooltip>
     </Popover>
@@ -72,10 +86,11 @@ function NotifyButton({ note, size }: Props) {
 export default NotifyButton;
 
 type ButtonSize = {
+  fill: string;
   size?: string;
 };
 
-const NotifyIconDefault = ({ size }: ButtonSize) => {
+const NotifyIconDefault = ({ fill, size }: ButtonSize) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -85,7 +100,7 @@ const NotifyIconDefault = ({ size }: ButtonSize) => {
     >
       <path fill="none" d="M0 0h24v24H0z" />
       <path
-        fill="#0098EF"
+        fill={fill}
         d="M18 10a6 6 0 1 0-12 0v8h12v-8zm2 8.667l.4.533a.5.5 0 0 1-.4.8H4a.5.5 0 0 1-.4-.8l.4-.533V10a8 8 0 1 1 16 0v8.667zM9.5 21h5a2.5 2.5 0 1 1-5 0z"
       />
     </svg>

--- a/src/theme/OutlinedCard/index.tsx
+++ b/src/theme/OutlinedCard/index.tsx
@@ -8,6 +8,7 @@ import Typography from "@mui/material/Typography";
 import { useHistory, useLocation } from "@docusaurus/router";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import styles from "./styles.module.css";
+import { useColorMode } from "@docusaurus/theme-common";
 
 type LinkProps = {
   text: string;
@@ -42,6 +43,11 @@ export default function OutlinedCard({
   const history = useHistory();
   const { globalData } = useDocusaurusContext();
   const location = useLocation();
+  const { isDarkTheme } = useColorMode();
+  const [dark, setDark] = React.useState(false);
+  React.useEffect(() => {
+    setDark(isDarkTheme);
+  }, [isDarkTheme]);
 
   return (
     <Card
@@ -55,13 +61,15 @@ export default function OutlinedCard({
       onClick={() => {
         if (links) return;
         if (doc) {
-          globalData["docusaurus-plugin-content-docs"].default["versions"].map((v) => {
-            if (location.pathname.includes(v.path)) {
-              history.push(`${v.path}/${doc}`);
-            } else if (location.pathname.includes("cloud")) {
-              history.push(`/docs/current/${doc}`);
+          globalData["docusaurus-plugin-content-docs"].default["versions"].map(
+            (v) => {
+              if (location.pathname.includes(v.path)) {
+                history.push(`${v.path}/${doc}`);
+              } else if (location.pathname.includes("cloud")) {
+                history.push(`/docs/current/${doc}`);
+              }
             }
-          });
+          );
         } else if (url) {
           window.open(url, "_blank", "noopener,noreferrer");
         } else if (cloud) {
@@ -86,7 +94,9 @@ export default function OutlinedCard({
                     if (link.url) {
                       window.open(link.url, "_blank", "noopener,noreferrer");
                     } else if (link.doc) {
-                      globalData["docusaurus-plugin-content-docs"].default["versions"].map((v) => {
+                      globalData["docusaurus-plugin-content-docs"].default[
+                        "versions"
+                      ].map((v) => {
                         if (location.pathname.includes(v.path)) {
                           history.push(`${v.path}/${link.doc}`);
                         } else if (location.pathname.includes("cloud")) {
@@ -99,7 +109,9 @@ export default function OutlinedCard({
                   <Typography className={styles.cardLink}>
                     {link.text}
                     {link.url && <ExternalArrow />}
-                    {link.doc && <RightArrow />}
+                    {link.doc && (
+                      <RightArrow fill={dark ? "#48dcbc" : "#0098ef"} />
+                    )}
                   </Typography>
                 </div>
               );
@@ -119,7 +131,10 @@ export default function OutlinedCard({
   );
 }
 
-const RightArrow = () => (
+type IconProps = {
+  fill: string;
+};
+const RightArrow = ({ fill }: IconProps) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"
@@ -130,7 +145,7 @@ const RightArrow = () => (
     <path fill="none" d="M0 0h24v24H0z" />
     <path
       d="M16.172 11l-5.364-5.364 1.414-1.414L20 12l-7.778 7.778-1.414-1.414L16.172 13H4v-2z"
-      fill="#95adee"
+      fill={fill}
     />
   </svg>
 );

--- a/src/theme/OutlinedCard/styles.module.css
+++ b/src/theme/OutlinedCard/styles.module.css
@@ -28,6 +28,11 @@ div.cardContainer:hover {
   box-shadow: 0 0 0 1px #cddbff;
 }
 
+[data-theme="dark"] div.cardContainer:hover {
+  border: 1px solid #48dcbc;
+  box-shadow: 0 0 0 1px #48dcbc;
+}
+
 div.cardContent {
   padding-bottom: 1rem;
   font-family: var(--ifm-font-family-base);
@@ -72,7 +77,7 @@ p.cardLinks {
 
 p.cardLink {
   cursor: pointer;
-  color: #95adee;
+  color: var(--ifm-button-color);
   font-size: 1rem;
   margin-bottom: 0.1rem;
   margin-right: 4px;
@@ -80,12 +85,12 @@ p.cardLink {
 }
 
 p.cardLink:hover {
-  color: #95adee88;
+  color: var(--ifm-menu-color-active);
   border-bottom: 1px dotted #95adee88;
 }
 
 div.flexBox {
-  color: #95adee;
+  color: var(--ifm-button-color);
   font-size: 1.1rem;
   display: flex;
   align-items: center;
@@ -93,15 +98,15 @@ div.flexBox {
 }
 
 p.cardLink:hover .externalArrowIcon path {
-  stroke: #afc2f5;
+  stroke: var(--ifm-menu-color-active);
 }
 
 [data-theme="dark"] .externalArrowIcon path {
-  stroke: #afc2f5;
+  stroke: #48dcbc;
 }
 
 [data-theme="dark"] p.cardLink:hover .externalArrowIcon path {
-  stroke: #8da8f1;
+  stroke: var(--ifm-menu-color-active);
 }
 
 p.cardLink:hover .rightArrowIcon path:nth-child(2) {

--- a/src/theme/RollButton/style.css
+++ b/src/theme/RollButton/style.css
@@ -26,7 +26,7 @@
   margin: 0;
   width: 2.5rem;
   height: 2.5rem;
-  background: var(--ifm-color-primary-darker);
+  background: var(--ifm-button-background-color);
   border-radius: 1.625rem;
 }
 
@@ -74,7 +74,7 @@
 }
 
 .button-3:hover .circle {
-  width: 10rem;
+  width: 10.5rem;
 }
 
 .button-3:hover .circle .icon.arrow {

--- a/static/img/github_issue.svg
+++ b/static/img/github_issue.svg
@@ -1,5 +1,0 @@
-<svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true"
-    class="octicon octicon-issue-opened UnderlineNav-octicon d-none d-sm-inline">
-    <path fill="#0098ef" d="M8 9.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path>
-    <path fill="#0098ef" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"></path>
-</svg>

--- a/static/img/github_pr.svg
+++ b/static/img/github_pr.svg
@@ -1,6 +1,0 @@
-<svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true"
-    class="octicon octicon-git-pull-request UnderlineNav-octicon d-none d-sm-inline">
-    <path fill="#0098ef"
-        d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z">
-    </path>
-</svg>


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
- fix the link group's background color 
- change docu search toolbox's highlight color

- **Preview**: 

![image](https://github.com/risingwavelabs/risingwave-docs/assets/54789193/19549260-4a38-439f-bbf2-e66aa9047681)

![image](https://github.com/risingwavelabs/risingwave-docs/assets/54789193/34ad421d-825c-45ad-9fdb-93c84d249651)

- **Related code PR**: 

- **Related doc issue**: 


- **Notes**: 

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
