### PR TITLE
feat(components): platform detector

### DIFF
--- a/src/components/FeedbackForm/index.js
+++ b/src/components/FeedbackForm/index.js
@@ -13,17 +13,18 @@ import IssueIcon from "./IssueIcon";
 import PullRequestIcon from "./PullRequestIcon";
 
 export default function FeedbackForm(props) {
-  const { isDarkTheme } = useColorMode();
-  const [dark, setDark] = useState(false);
   const [formData, setFormData] = useState({
     description: "",
     like: false,
     unlike: false,
   });
 
+  const { colorMode } = useColorMode();
+  const [dark, setDark] = useState(false);
   useEffect(() => {
-    setDark(isDarkTheme);
-  }, [isDarkTheme]);
+    setDark(colorMode === "dark");
+  }, [colorMode]);
+
 
   const handleChange = (e) => {
     setFormData({

--- a/src/pages/landing/index.js
+++ b/src/pages/landing/index.js
@@ -41,12 +41,11 @@ const HeroBanner = styled("div")(() => ({
 function HomepageHeader() {
   const windowSize = useWindowSize();
   const { siteMetadata } = useDocusaurusContext();
-  const { isDarkTheme } = useColorMode();
+  const { colorMode } = useColorMode();
   const [dark, setDark] = useState(false);
-
   useEffect(() => {
-    setDark(isDarkTheme);
-  }, [isDarkTheme]);
+    setDark(colorMode === "dark");
+  }, [colorMode]);
 
   return (
     <HeroBanner>

--- a/src/theme/Capsule/index.tsx
+++ b/src/theme/Capsule/index.tsx
@@ -12,11 +12,11 @@ type Props = {
 function Capsule({ note }: Props) {
   const [clicked, setClicked] = useState(false);
   const [count, setCount] = useState(0);
-  const { isDarkTheme } = useColorMode();
+  const { colorMode } = useColorMode();
   const [dark, setDark] = useState(false);
   useEffect(() => {
-    setDark(isDarkTheme);
-  }, [isDarkTheme]);
+    setDark(colorMode === "dark");
+  }, [colorMode]);
 
   useEffect(() => {
     if (!note) return;

--- a/src/theme/MDXComponents/index.js
+++ b/src/theme/MDXComponents/index.js
@@ -14,6 +14,7 @@ import "./styles.css"; // MDX elements are wrapped through the MDX pragma. In so
 // with Head/Helmet) we need to unwrap those elements.
 import RollButton from "@theme/RollButton";
 import DefaultButton from "@theme/DefaultButton";
+import PlatformDetector from "@theme/PlatformDetector";
 import LightButton from "@theme/LightButton";
 import NotifyButton from "@theme/NotifyButton";
 import DefaultNotify from "@theme/DefaultNotify";
@@ -91,5 +92,6 @@ const MDXComponents = {
   vstepper: VerticalStepper,
   card: OutlinedCard,
   grid: ResponsiveGrid,
+  platformDetector: PlatformDetector,
 };
 export default MDXComponents;

--- a/src/theme/NotifyButton/index.tsx
+++ b/src/theme/NotifyButton/index.tsx
@@ -16,11 +16,12 @@ function NotifyButton({ note, size }: Props) {
   const [valid, setValid] = useState(false);
   const [email, setEmail] = useState("");
 
-  const { isDarkTheme } = useColorMode();
+  const { colorMode } = useColorMode();
   const [dark, setDark] = useState(false);
   useEffect(() => {
-    setDark(isDarkTheme);
-  }, [isDarkTheme]);
+    setDark(colorMode === "dark");
+  }, [colorMode]);
+
 
   const getNotify = () => {
     const emailValid = email.match(/^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/i);

--- a/src/theme/OutlinedCard/index.tsx
+++ b/src/theme/OutlinedCard/index.tsx
@@ -43,11 +43,11 @@ export default function OutlinedCard({
   const history = useHistory();
   const { globalData } = useDocusaurusContext();
   const location = useLocation();
-  const { isDarkTheme } = useColorMode();
+  const { colorMode } = useColorMode();
   const [dark, setDark] = React.useState(false);
   React.useEffect(() => {
-    setDark(isDarkTheme);
-  }, [isDarkTheme]);
+    setDark(colorMode === "dark");
+  }, [colorMode]);
 
   return (
     <Card

--- a/src/theme/PlatformDetector/index.tsx
+++ b/src/theme/PlatformDetector/index.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect } from "react";
+import { useHistory, useLocation } from "@docusaurus/router";
+type Props = {
+    queryString: string
+};
+
+function getCurrentPlatform () {
+  const platform = window.navigator.platform;
+  if (/Mac/.test(platform)) {
+    return "macOS";
+  } else if (/Win/.test(platform)) {
+    return "Windows";
+  } else if (/Linux/.test(platform)) {
+    return "Linux";
+  } else {
+    return "unknown platform";
+  }
+}
+
+function PlatformDetector({queryString}: Props) {
+  const history = useHistory();
+  const location = useLocation();
+
+  useEffect(()=>{
+    switch (getCurrentPlatform()) {
+      case "macOS":
+        history.push(`${location.pathname.toString()}?${queryString}=macos`)
+        break;
+      case "Windows":
+        history.push(`${location.pathname.toString()}?${queryString}=linux`)
+        break;
+      case "Linux":
+        history.push(`${location.pathname.toString()}?${queryString}=linux`)
+        break;
+      default:
+    }
+  },[])
+
+  return <></>;
+}
+
+export default PlatformDetector;

--- a/versioned_docs/version-0.18.0/deploy/risingwave-local.md
+++ b/versioned_docs/version-0.18.0/deploy/risingwave-local.md
@@ -63,7 +63,8 @@ import TabItem from '@theme/TabItem';
 
     Select your operating system and run the following commands to install the dependencies.
 
-    <Tabs>
+    <platformDetector queryString="current-os" />
+    <Tabs groupId="current-os" queryString>
     <TabItem value="macos" label="macOS" default>
 
     ```shell
@@ -90,7 +91,7 @@ import TabItem from '@theme/TabItem';
     </TabItem>
     </Tabs>
 
-3. Start RisingWave.
+1. Start RisingWave.
 
     To compile and start RisingWave, you can use [RiseDev](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#set-up-the-development-environment), the developer's tool for RisingWave.
   


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info
- **Description**: 
- add a component to detect platform

- **Preview**: 
![image](https://github.com/risingwavelabs/risingwave-docs/assets/54789193/b5e71feb-1536-4b3f-a189-eb5991c34e51)


- **Usage**:
```markdown

<platformDetector queryString="current-os" /> 
<Tabs groupId="current-os" queryString>
    <TabItem value="macos" label="macOS" default>
        ....
    </TabItem>

    <TabItem value="linux" label="Linux">
        .....
    </TabItem>
</Tabs>
```


- **Related code PR**: 


- **Related doc issue**: 
Resolves #526 

- **Notes**: 


<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
