### PR TITLE
Document trunc, ln, log10 (log), exp, cbrt (||/)

### DIFF
--- a/docs/sql/functions-operators/sql-function-mathematical.md
+++ b/docs/sql/functions-operators/sql-function-mathematical.md
@@ -17,6 +17,7 @@ title: Mathematical functions and operators
 | / | `operand1 / operand2` <br /> Division (results are truncated for integers). <br /> | 3 / 2 → 1 <br /> 3.0 / 2 → 1.5 <br />  3 / 1.8 → 1.666... |
 | % | `operand1 * operand2` <br /> Remainder (valid for smallint/int/bigint/numeric). <br /> | 3 % 2 → 1 |
 | ^ | `operand1 ^ operand2` <br /> Exponent. <br /> | 2.0 ^ -2 → 0.25 |
+| \|\|/ | `\|\|/operand` <br /> Cube root. <br /> | \|\|/27 → 3 |
 
 
 ## Mathematical functions
@@ -24,13 +25,17 @@ title: Mathematical functions and operators
 | Function | Description | Example |
 | ----------- | ----------- | ----------- | 
 | abs ( *input_value* ) → *absolute_value* <br /> @ ( *input_value* ) → *absolute_value* | Returns the absolute value of *input_value*. The *input_value* can be type int or decimal. The return type is the same as the *input_value* type. | abs(-3) → 3 <br /> @(-3) → 3 |
+| cbrt ( *double_precision_input* ) → *double_precision_output* | Returns the cube root of the input. | cbrt(27) → 3 |
 | ceil ( *numeric_input* ) → *integer_output* <br /> ceil ( *double_precision_input* ) → *integer_output* | Returns the nearest integer greater than or equal to the argument. ceiling() can also be used an alias for ceil(). | ceil(1.23559) → 2 <br /> ceiling(-1.23559) → -1 |
-| exp ( *double_precision_input* ) → *double_precision_output* | Returns the exponential value of *numeric*. | exp(2.0) → 7.38905609893065 |
+| exp ( *double_precision_input* ) → *double_precision_output* <br /> exp ( *numeric_input* ) → *numeric_output*| Returns the exponential value of *numeric*. | exp(2.0) → 7.38905609893065 |
 | floor ( *numeric_input* ) → *integer_output* <br /> floor ( *double_precision_input* ) → *integer_output* | Returns the nearest integer less than or equal to the argument. | floor(1.23559) → 1 <br /> floor(-1.23559) → -2 |
+| ln ( *double_precision_input* ) → *double_precision_output* <br /> ln ( *numeric_input* ) → *numeric_output*| Returns the natural logarithmic value of the input. | ln(10) → 2.302585092994046 |
+| log10 ( *double_precision_input* ) → *double_precision_output* <br /> log10 ( *numeric_input* ) → *numeric_output*| Returns the log base 10 value of the input value. log() can also be used and accepts the same input types. | log10(25) → 1.3979400086720377 |
 | pow ( *x_double_precision*, *y_double_precision* ) → *double_precision_output* <br /> power ( *x_double_precision*, *y_double_precision* ) → *double_precision_output* | Returns *x_double_precision* raised to the power of *y_double_precision*. | pow(2.0, 3.0) → 8 <br /> power(2.0, 3.0) → 8|
 | round ( *x_numeric*, *y_int* ) → *output_value* | Rounds *x_numeric* to *y_int* decimal places. *y* cannot be negative. | round(1.23559, 2) → 1.24 |
 | round ( *numeric_input* ) → *integer_output* <br /> round ( *double_precision_input* ) → *integer_output* | Rounds to the nearest integer. | round(1.23559) → 1 |
 | translate( *input_string*, *from_string*, *to_string*) → output_string | Replaces each character in the *input_string* that matches a character in the *from_string* with the corresponding character in the *to_string*. | translate('M1X3', '13', 'ae') → MaXe |
+| trunc ( *double_precision_input* ) → *double_precision_output* <br /> trunc ( *numeric_input* ) → *numeric_output*| Truncate the input value to zero decimal places. | trunc(-20.0932) → -20 |
 
 ## Trigonometric functions
 

--- a/docs/sql/functions-operators/sql-function-mathematical.md
+++ b/docs/sql/functions-operators/sql-function-mathematical.md
@@ -17,8 +17,8 @@ title: Mathematical functions and operators
 | / | `operand1 / operand2` <br /> Division (results are truncated for integers). <br /> | 3 / 2 → 1 <br /> 3.0 / 2 → 1.5 <br />  3 / 1.8 → 1.666... |
 | % | `operand1 * operand2` <br /> Remainder (valid for smallint/int/bigint/numeric). <br /> | 3 % 2 → 1 |
 | ^ | `operand1 ^ operand2` <br /> Exponent. <br /> | 2.0 ^ -2 → 0.25 |
-| \|\|/ | `\|\|/operand` <br /> Cube root. <br /> | \|\|/27 → 3 |
-
+| \|\|/ | `\|\|/operand` <br /> Cube root. <br /> | \|\|/ 27 → 3 |
+| @ | `@operand` <br /> Absolute value. <br /> | @ -10 → 10|
 
 ## Mathematical functions
 


### PR DESCRIPTION

## Info
- **Description**: 
Document unary trunc, ln, log10 (log), exp, cbrt (||/) functions under math functions.

- **Preview**: 
[ Paste the preview link to the edited page here. Edit this item after you submit the PR and the preview is ready. ]

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/9991

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/931

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
