### PR TITLE
Document PrivateLink support for Kafka sink

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -93,6 +93,7 @@ runtime
 disaggregated
 PrivateLink
 VPCs
+VPC
 DataSet
 FlinkSQL
 LSM

--- a/docs/create-source/create-source-kafka.md
+++ b/docs/create-source/create-source-kafka.md
@@ -284,7 +284,7 @@ To learn about compatibility types for Schema Registry and the changes allowed, 
 
 ## Create source with AWS PrivateLink connection
 
-If your Kafka source service is located in a different VPC from RisingWave, use AWS PrivateLink to establish a secure and direct connection. For details on how to set up an AWS PrivateLink connection, see [Create an AWS PrivateLink connection](/guides/aws-privatelink-setup.md).
+If your Kafka source service is located in a different VPC from RisingWave, use AWS PrivateLink to establish a secure and direct connection. For details on how to set up an AWS PrivateLink connection, see [Create an AWS PrivateLink connection](../sql/commands/sql-create-connection.md#create-an-aws-privatelink-connection).
 
 To create a Kafka source with a PrivateLink connection, in the WITH section of your `CREATE SOURCE` or `CREATE TABLE` statement, specify the following parameters.
 

--- a/docs/guides/aws-privatelink-setup.md
+++ b/docs/guides/aws-privatelink-setup.md
@@ -5,7 +5,7 @@ description: How to create an AWS PrivateLink connection.
 slug: /aws-privatelink-setup
 ---
 
-If you are using a cloud-hosted source, such as AWS MSK, there might be connectivity issues when your source service is located in a different VPC from where you have deployed RisingWave. To establish a secure, direct connection between these two different VPCs and allow RisingWave to read consumer messages from the broker, use the [AWS PrivateLink](https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-share-your-services.html) service.
+If you are using a cloud-hosted source or sink, such as AWS MSK, there might be connectivity issues when your service is located in a different VPC from where you have deployed RisingWave. To establish a secure, direct connection between these two different VPCs and allow RisingWave to read consumer messages from the broker or send messages to the broker, use the [AWS PrivateLink](https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-share-your-services.html) service.
 
 :::caution Experimental feature
 The support for AWS PrivateLink connection is a beta feature and is subject to change in future versions. There is no guarantee that this feature will be maintained.
@@ -32,7 +32,8 @@ Follow the steps below to create an AWS PrivateLink connection.
     );
     ```
 
-7. Finally, use the `CREATE SOURCE` command to create a Kafka source with PrivateLink connection. For more details on the syntax, see the [Ingest data from Kafka](/create-source/create-source-kafka.md) topic. Here is an example of connecting to a Kafka source through AWS PrivateLink.
+7. Create a source or sink with AWS PrivateLink connection.
+    - Use the `CREATE SOURCE` command to create a Kafka source with PrivateLink connection. For more details on the syntax, see the [Ingest data from Kafka](/create-source/create-source-kafka.md) topic. Here is an example of connecting to a Kafka source through AWS PrivateLink.
 
     ```sql
     CREATE SOURCE tcp_metrics_rw (
@@ -48,4 +49,19 @@ Follow the steps below to create an AWS PrivateLink connection.
     privatelink.targets = '[{"port": 8001}, {"port": 8002}]',
     scan.startup.mode = 'earliest'
     ) ROW FORMAT JSON;
+    ```
+
+     - Use the `CREATE SINK` command to create a Kafka sink with PrivateLink connection. For more details on the syntax, see the [Sink to Kafka](create-sink-kafka.md) topic. Here is an example of sinking to Kafka with an AWS PrivateLink.
+
+    ```sql
+    CREATE SINK sink2 FROM mv2
+    WITH (
+    connector='kafka',
+    type='append-only',
+    properties.bootstrap.server='b-1.xxx.amazonaws.com:9092,b-2.test.xxx.amazonaws.com:9092',
+    topic='msk_topic',
+    force_append_only='true',
+    connection.name = 'connection1',
+    privatelink.targets = '[{"port": 8001}, {"port": 8002}]'
+    );
     ```

--- a/docs/guides/create-sink-kafka.md
+++ b/docs/guides/create-sink-kafka.md
@@ -95,6 +95,32 @@ WITH (
 
 ```
 
+## Create source with AWS PrivateLink connection
+
+If your Kafka sink service is located in a different VPC from RisingWave, use AWS PrivateLink to establish a secure and direct connection. For details on how to set up an AWS PrivateLink connection, see see [Create an AWS PrivateLink connection](../sql/commands/sql-create-connection.md#create-an-aws-privatelink-connection).
+
+To create a Kafka sink with a PrivateLink connection, in the WITH section of your `CREATE SINK` statement, specify the following parameters.
+
+|Parameter| Notes|
+|---|---|
+|`connection.name`| The name of the connection, which comes from the connection created using the `CREATE CONNECTION` statement.|
+|`privatelink.targets`| The PrivateLink targets that correspond to the Kafka brokers. The targets should be in JSON format. Note that each target listed corresponds to each broker specified in the `properties.bootstrap.server` field. If the order is incorrect, there will be connectivity issues. |
+
+Here is an example of creating a Kafka sink using a PrivateLink connection. Notice that `{"port": 8001}` corresponds to the broker `ip1:9092`, and `{"port": 8002}` corresponds to the broker `ip2:9092`.
+
+```sql
+CREATE SINK sink2 FROM mv2
+WITH (
+   connector='kafka',
+   type='append-only',
+   properties.bootstrap.server='b-1.xxx.amazonaws.com:9092,b-2.test.xxx.amazonaws.com:9092',
+   topic='msk_topic',
+   force_append_only='true',
+   connection.name = 'connection1',
+   privatelink.targets = '[{"port": 8001}, {"port": 8002}]'
+);
+```
+
 ## TLS/SSL encryption and SASL authentication
 
 RisingWave can sink data to Kafka that is encrypted with [Transport Layer Security (TLS)](https://en.wikipedia.org/wiki/Transport_Layer_Security) and/or authenticated with SASL.

--- a/docs/guides/create-sink-kafka.md
+++ b/docs/guides/create-sink-kafka.md
@@ -95,7 +95,7 @@ WITH (
 
 ```
 
-## Create source with AWS PrivateLink connection
+## Create sink with AWS PrivateLink connection
 
 If your Kafka sink service is located in a different VPC from RisingWave, use AWS PrivateLink to establish a secure and direct connection. For details on how to set up an AWS PrivateLink connection, see see [Create an AWS PrivateLink connection](../sql/commands/sql-create-connection.md#create-an-aws-privatelink-connection).
 

--- a/docs/key-concepts.md
+++ b/docs/key-concepts.md
@@ -82,6 +82,10 @@ The central metadata management service. It also acts as a failure detector that
 
 Avro is an open-source data serialization system that facilitates data exchange between systems, programming languages, and processing frameworks. Avro has a JSON-like data model, but it can be represented as either JSON or in a compact binary form. RisingWave can decode Avro data. You need to specify the schema by providing either a schema location or a schema registry URL (only for Kafka topics).
 
+### Connection
+
+A connection allows access to services located outside of your VPC. AWS PrivateLink provides a network connection used to create a private connection between VPCs, private networks, and other services. In RisingWave, the [`CREATE CONNECTION`](sql/commands/sql-create-connection.md) command establishes a connection between RisingWave and an external service. Then, a source or sink can be created to receive or send messages.
+
 ### Change data capture (CDC)
 
 Change data capture refers to the process of identifying and capturing changes as they are made in a database or source application, then delivering those changes in real time to a downstream process, system, or data lake. RisingWave supports ingesting CDC events in Debezium JSON or [Maxwell](https://maxwells-daemon.io/) JSON from Kafka topics.

--- a/docs/sql/commands/sql-create-connection.md
+++ b/docs/sql/commands/sql-create-connection.md
@@ -70,7 +70,7 @@ CREATE CONNECTION connection_name with (
 If you are using a cloud-hosted source or sink, such as AWS MSK, there might be connectivity issues when your service is located in a different VPC from where you have deployed RisingWave. To establish a secure, direct connection between these two different VPCs and allow RisingWave to read consumer messages from the broker or send messages to the broker, use the [AWS PrivateLink](https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-share-your-services.html) service.
 
 :::caution Experimental feature
-The support for AWS PrivateLink connection is a beta feature and is subject to change in future versions. There is no guarantee that this feature will be maintained.
+The support for AWS PrivateLink connection is a beta feature and the syntax for `CREATE CONNECTION` is subject to change in future versions.
 :::
 
 Follow the steps below to create an AWS PrivateLink connection.

--- a/docs/sql/commands/sql-create-connection.md
+++ b/docs/sql/commands/sql-create-connection.md
@@ -7,7 +7,6 @@ slug: /sql-create-connection
 
 Use the `CREATE CONNECTION` command to create an AWS PrivateLink connection for a Kafka source connector. This is necessary in order to be able to consume messages from a Kafka service located in a different VPC from the RisingWave cluster in the cloud.
 
-For details on how to connect to a Kafka broker, see the [Ingest data from Kafka](/create-source/create-source-kafka.md) topic.
 
 ## Syntax
 
@@ -38,3 +37,66 @@ CREATE CONNECTION connection_name with (
     service.name = 'com.amazonaws.xyz.us-east-1.abc-xyz-0000'
 );
 ```
+
+## Create an AWS PrivateLink connection
+
+If you are using a cloud-hosted source or sink, such as AWS MSK, there might be connectivity issues when your service is located in a different VPC from where you have deployed RisingWave. To establish a secure, direct connection between these two different VPCs and allow RisingWave to read consumer messages from the broker or send messages to the broker, use the [AWS PrivateLink](https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-share-your-services.html) service.
+
+:::caution Experimental feature
+The support for AWS PrivateLink connection is a beta feature and is subject to change in future versions. There is no guarantee that this feature will be maintained.
+:::
+
+Follow the steps below to create an AWS PrivateLink connection.
+
+1. Create a [target group](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-target-group.html) for each broker. Set the **target type** as **IP addresses** and the **protocol** as **TCP**. Ensure that the VPC of the target group is the same as your cloud-hosted source.
+
+2. Create a [Network Load Balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-network-load-balancer.html). Ensure that it is enabled in the same subnets your broker sources are in and the Cross-zone load balancing is also enabled. 
+
+3. Create a [TCP listener](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-listener.html) for each MSK broker that corresponds to the target groups created. Ensure the ports are unique.
+
+4. Complete the [health check](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html) for each target group.
+
+5. Create a [VPC endpoint service](https://docs.aws.amazon.com/vpc/latest/privatelink/create-endpoint-service.html) associated with the Networkd Load Balancer created. Be sure to add the AWS principal of the account that will access the endpoint service to allow the service consumer to connect. See [Manage permissions](https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#add-remove-permissions) for more details.
+
+6. Use the `CREATE CONNECTION` command in RisingWave to create an AWS PrivateLink connection referencing the endpoint service created. Here is an example of creating an AWS PrivateLink connection.
+    ```sql
+    CREATE CONNECTION connection_name WITH (
+        type = 'privatelink',
+        provider = 'aws',
+        service.name = 'com.amazonaws.xyz.us-east-1.abc-xyz-0000'
+    );
+    ```
+
+7. Create a source or sink with AWS PrivateLink connection.
+    - Use the `CREATE SOURCE` command to create a Kafka source with PrivateLink connection. For more details on the syntax, see the [Ingest data from Kafka](/create-source/create-source-kafka.md) topic. Here is an example of connecting to a Kafka source through AWS PrivateLink.
+
+    ```sql
+    CREATE SOURCE tcp_metrics_rw (
+    device_id VARCHAR,
+    metric_name VARCHAR,
+    report_time TIMESTAMP,
+    metric_value DOUBLE PRECISION
+    ) WITH (
+    connector = 'kafka',
+    topic = 'tcp_metrics',
+    properties.bootstrap.server = 'ip1:9092, ip2:9092',
+    connection.name = 'my_connection',
+    privatelink.targets = '[{"port": 8001}, {"port": 8002}]',
+    scan.startup.mode = 'earliest'
+    ) ROW FORMAT JSON;
+    ```
+
+     - Use the `CREATE SINK` command to create a Kafka sink with PrivateLink connection. For more details on the syntax, see the [Sink to Kafka](create-sink-kafka.md) topic. Here is an example of sinking to Kafka with an AWS PrivateLink.
+
+    ```sql
+    CREATE SINK sink2 FROM mv2
+    WITH (
+    connector='kafka',
+    type='append-only',
+    properties.bootstrap.server='b-1.xxx.amazonaws.com:9092,b-2.test.xxx.amazonaws.com:9092',
+    topic='msk_topic',
+    force_append_only='true',
+    connection.name = 'connection1',
+    privatelink.targets = '[{"port": 8001}, {"port": 8002}]'
+    );
+    ```

--- a/sidebars.js
+++ b/sidebars.js
@@ -217,19 +217,6 @@ const sidebars = {
               id: 'data-ingestion',
             },
             {
-              type: 'category',
-              label: 'Connections',
-              collapsible: true,
-              collapsed: true,
-              items: [
-                {
-                  type: 'doc',
-                  label: 'AWS PrivateLink',
-                  id: 'guides/aws-privatelink-setup',
-                },
-              ]
-            },
-            {
               type: 'doc',
               label: 'Apache Kafka',
               id: 'create-source/create-source-kafka',


### PR DESCRIPTION

## Info
- **Description**: 
Document PrivateLink support for Kafka sink. Move AWS PrivateLink guide to CREATE CONNECTION command, remove PrivateLink guide from sidebar. Add 'Connection' to Key concepts page.

- **Preview**: 
[ Paste the preview link to the edited page here. Edit this item after you submit the PR and the preview is ready. ]

- **Related code PR**: 
https://github.com/risingwavelabs/risingwave/pull/9263

- **Related doc issue**: 
Resolves https://github.com/risingwavelabs/risingwave-docs/issues/916

- **Notes**: 
[ Any additional information? ]

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
