### PR TITLE
Adding release note for 0.19.1

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -7,6 +7,22 @@ slug: /release-notes
 
 This page summarizes changes in each version of RisingWave, including new features and important bug fixes.
 
+## v0.19.1
+
+This version was released on June 8, 2023.
+
+### Main changes
+
+Bug fixes and improvements. See [all changes](https://github.com/risingwavelabs/risingwave/compare/v0.19.0...v0.19.1).
+
+### Assets
+
+- Run this version from Docker:<br/>
+    `docker run -it --pull=always -p 4566:4566 -p 5691:5691 risingwavelabs/risingwave:v0.19.1 playground`
+- [Prebuilt library for Linux](https://github.com/risingwavelabs/risingwave/releases/download/v0.19.1/risingwave-v0.19.1-x86_64-unknown-linux.tar.gz)
+- [Source code (zip)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.19.1.zip)
+- [Source code (tar.gz)](https://github.com/risingwavelabs/risingwave/archive/refs/tags/v0.19.1.tar.gz)
+
 ## v0.19.0
 
 This version was released on June 1, 2023.


### PR DESCRIPTION
<!--Edit the Info section when creating this pull request.-->

## Info

If we're not creating a dedicated doc version for patches, at least we can mention them in the Release Notes.

<!--You DON'T need to edit the following sections when creating this pull request.-->

## Before merging
  - [ ] (For version-specific PR) I have selected the corresponding software version in **Milestone** and linked the related doc issue to this PR in **Development**.
  - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`bernscode`, `CharlieSYH`, `emile-00`, & `hengm3467`). 
  - [ ] I have checked the doc site preview, and the updated parts look good. <details><summary>How?</summary>Scroll down and open this link: <img width="916" alt="image" src="https://user-images.githubusercontent.com/100549427/199641563-82967cd0-2c5c-4f40-bcdb-5ac80f03ffd8.png">
</details>
