### PR TITLE
fix the syntax document of 'is not true' and '%'

### DIFF
--- a/docs/sql/functions-operators/sql-function-comparison.md
+++ b/docs/sql/functions-operators/sql-function-comparison.md
@@ -30,7 +30,7 @@ title: Comparison functions and operators
 | IN() | `operand IN (value,...)` <br /> Whether a value is equal to any of the values you specify. <br /> TRUE if the operand is equal to one of the specified expressions/values. NULL if the operand is null or if the operand is not in the specified expressions/values that contain a null. | 1 IN (0,1,2,3) → t <br /> 'a' IN ('ab','b','c','d') → f <br /> null IN (null, 3, 0.5*2, min(v1)) → NULL <br /> 99 IN (null, 3, 2) → NULL |
 | NOT IN() | `operand NOT IN (value,...)` <br /> Whether a value is not equal to any of the values you specify. <br /> TRUE if the operand is not equal to any specified expressions/values. | 1 NOT IN (0,1,2,3) → f |
 | IS TRUE | `boolean IS TRUE` <br /> Whether a boolean expression is true. <br /> | true IS TRUE → t <br /> null::boolean IS TRUE → f |
-| IS NOT TRUE | `boolean IS TRUE` <br /> Whether a boolean expression is false or unknown. <br /> | true IS NOT TRUE → f <br /> null::boolean IS NOT TRUE → t |
+| IS NOT TRUE | `boolean IS NOT TRUE` <br /> Whether a boolean expression is false or unknown. <br /> | true IS NOT TRUE → f <br /> null::boolean IS NOT TRUE → t |
 | IS FALSE | `boolean IS FALSE` <br /> Whether a boolean expression is false. <br /> | true IS FALSE → f <br /> null::boolean IS FALSE → f |
 | IS NOT FALSE | `boolean IS NOT FALSE` <br /> Whether a boolean expression is true or unknown. <br /> | true IS NOT FALSE → t <br /> null::boolean IS NOT FALSE → t |
 | IS NULL | `value IS NULL` <br /> Whether a value is null. <br /> | 1 IS NULL → f |

--- a/docs/sql/functions-operators/sql-function-mathematical.md
+++ b/docs/sql/functions-operators/sql-function-mathematical.md
@@ -15,7 +15,7 @@ title: Mathematical functions and operators
 | - | `- operand` <br /> Negation. <br /> | - (-1) → 1 |
 | * | `operand1 * operand2` <br /> Multiplication. <br /> | 2 * 3 → 6 |
 | / | `operand1 / operand2` <br /> Division (results are truncated for integers). <br /> | 3 / 2 → 1 <br /> 3.0 / 2 → 1.5 <br />  3 / 1.8 → 1.666... |
-| % | `operand1 * operand2` <br /> Remainder (valid for smallint/int/bigint/numeric). <br /> | 3 % 2 → 1 |
+| % | `operand1 % operand2` <br /> Remainder (valid for smallint/int/bigint/numeric). <br /> | 3 % 2 → 1 |
 | ^ | `operand1 ^ operand2` <br /> Exponent. <br /> | 2.0 ^ -2 → 0.25 |
 | \|\|/ | `\|\|/operand` <br /> Cube root. <br /> | \|\|/ 27 → 3 |
 | @ | `@operand` <br /> Absolute value. <br /> | @ -10 → 10|

--- a/versioned_docs/version-1.0.0/sql/functions-operators/sql-function-comparison.md
+++ b/versioned_docs/version-1.0.0/sql/functions-operators/sql-function-comparison.md
@@ -30,7 +30,7 @@ title: Comparison functions and operators
 | IN() | `operand IN (value,...)` <br /> Whether a value is equal to any of the values you specify. <br /> TRUE if the operand is equal to one of the specified expressions/values. NULL if the operand is null or if the operand is not in the specified expressions/values that contain a null. | 1 IN (0,1,2,3) → t <br /> 'a' IN ('ab','b','c','d') → f <br /> null IN (null, 3, 0.5*2, min(v1)) → NULL <br /> 99 IN (null, 3, 2) → NULL |
 | NOT IN() | `operand NOT IN (value,...)` <br /> Whether a value is not equal to any of the values you specify. <br /> TRUE if the operand is not equal to any specified expressions/values. | 1 NOT IN (0,1,2,3) → f |
 | IS TRUE | `boolean IS TRUE` <br /> Whether a boolean expression is true. <br /> | true IS TRUE → t <br /> null::boolean IS TRUE → f |
-| IS NOT TRUE | `boolean IS TRUE` <br /> Whether a boolean expression is false or unknown. <br /> | true IS NOT TRUE → f <br /> null::boolean IS NOT TRUE → t |
+| IS NOT TRUE | `boolean IS NOT TRUE` <br /> Whether a boolean expression is false or unknown. <br /> | true IS NOT TRUE → f <br /> null::boolean IS NOT TRUE → t |
 | IS FALSE | `boolean IS FALSE` <br /> Whether a boolean expression is false. <br /> | true IS FALSE → f <br /> null::boolean IS FALSE → f |
 | IS NOT FALSE | `boolean IS NOT FALSE` <br /> Whether a boolean expression is true or unknown. <br /> | true IS NOT FALSE → t <br /> null::boolean IS NOT FALSE → t |
 | IS NULL | `value IS NULL` <br /> Whether a value is null. <br /> | 1 IS NULL → f |


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  [ What's changed? Which parts of the docs are affected? ]

Will fix https://github.com/risingwavelabs/risingwave-docs/pull/1084

- **Notes**

  [ Include any supplementary context or references here. ]

- **Related code PR**

  [ Provide a link to the relevant code PR here, if applicable. ]

- **Related doc issue**
  
  Resolves [ Provide a link to the relevant doc issue here, if applicable. ]

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **upcoming** version of the documentation. ]

- **Key points**

  [ Parts that may need revision or extra consideration. ]

## Before merging

- [x] I have checked the doc site preview, and the updated parts look good.

- [x] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
