### PR TITLE
feat: move github icon from mobile sidebar to head

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -521,6 +521,7 @@ table tr:first-child {
 /* custom github icon */
 
 .header-github-link {
+  list-style-type: none;
   width: 2rem;
   height: 2rem;
   border-radius: 50%;

--- a/src/theme/Navbar/ColorModeToggle/index.js
+++ b/src/theme/Navbar/ColorModeToggle/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import {useColorMode, useThemeConfig} from '@docusaurus/theme-common';
+import ColorModeToggle from '@theme/ColorModeToggle';
+import styles from './styles.module.css';
+export default function NavbarColorModeToggle({className}) {
+  const navbarStyle = useThemeConfig().navbar.style;
+  const disabled = useThemeConfig().colorMode.disableSwitch;
+  const {colorMode, setColorMode} = useColorMode();
+  if (disabled) {
+    return null;
+  }
+  return (
+    <ColorModeToggle
+      className={className}
+      buttonClassName={
+        navbarStyle === 'dark' ? styles.darkNavbarColorModeToggle : undefined
+      }
+      value={colorMode}
+      onChange={setColorMode}
+    />
+  );
+}

--- a/src/theme/Navbar/ColorModeToggle/styles.module.css
+++ b/src/theme/Navbar/ColorModeToggle/styles.module.css
@@ -1,0 +1,3 @@
+.darkNavbarColorModeToggle:hover {
+  background: var(--ifm-color-gray-800);
+}

--- a/src/theme/Navbar/Content/index.js
+++ b/src/theme/Navbar/Content/index.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import {useThemeConfig, ErrorCauseBoundary} from '@docusaurus/theme-common';
+import {
+  splitNavbarItems,
+  useNavbarMobileSidebar,
+} from '@docusaurus/theme-common/internal';
+import NavbarItem from '@theme/NavbarItem';
+import NavbarColorModeToggle from '@theme/Navbar/ColorModeToggle';
+import SearchBar from '@theme/SearchBar';
+import NavbarMobileSidebarToggle from '@theme/Navbar/MobileSidebar/Toggle';
+import NavbarLogo from '@theme/Navbar/Logo';
+import NavbarSearch from '@theme/Navbar/Search';
+import styles from './styles.module.css';
+function useNavbarItems() {
+  // TODO temporary casting until ThemeConfig type is improved
+  return useThemeConfig().navbar.items;
+}
+function NavbarItems({items}) {
+  return (
+    <>
+      {items.map((item, i) => (
+        <ErrorCauseBoundary
+          key={i}
+          onError={(error) =>
+            new Error(
+              `A theme navbar item failed to render.
+Please double-check the following navbar item (themeConfig.navbar.items) of your Docusaurus config:
+${JSON.stringify(item, null, 2)}`,
+              {cause: error},
+            )
+          }>
+          <NavbarItem {...item} />
+        </ErrorCauseBoundary>
+      ))}
+    </>
+  );
+}
+function NavbarContentLayout({left, right}) {
+  return (
+    <div className="navbar__inner">
+      <div className="navbar__items">{left}</div>
+      <div className="navbar__items navbar__items--right">{right}</div>
+    </div>
+  );
+}
+export default function NavbarContent() {
+  const mobileSidebar = useNavbarMobileSidebar();
+  const items = useNavbarItems();
+  const [leftItems, rightItems] = splitNavbarItems(items);
+  const searchBarItem = items.find((item) => item.type === 'search');
+  return (
+    <NavbarContentLayout
+      left={
+        // TODO stop hardcoding items?
+        <>
+          {!mobileSidebar.disabled && <NavbarMobileSidebarToggle />}
+          <NavbarLogo />
+          <NavbarItems items={leftItems} />
+        </>
+      }
+      right={
+        // TODO stop hardcoding items?
+        // Ask the user to add the respective navbar items => more flexible
+        <>
+          <NavbarItems items={rightItems} />
+          <NavbarColorModeToggle className={styles.colorModeToggle} />
+          {!searchBarItem && (
+            <NavbarSearch>
+              <SearchBar />
+            </NavbarSearch>
+          )}
+        </>
+      }
+    />
+  );
+}

--- a/src/theme/Navbar/Content/styles.module.css
+++ b/src/theme/Navbar/Content/styles.module.css
@@ -1,0 +1,8 @@
+/*
+Hide color mode toggle in small viewports
+ */
+@media (max-width: 996px) {
+  .colorModeToggle {
+    display: none;
+  }
+}

--- a/src/theme/Navbar/Layout/index.js
+++ b/src/theme/Navbar/Layout/index.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import clsx from 'clsx';
+import {useThemeConfig} from '@docusaurus/theme-common';
+import {
+  useHideableNavbar,
+  useNavbarMobileSidebar,
+} from '@docusaurus/theme-common/internal';
+import {translate} from '@docusaurus/Translate';
+import NavbarMobileSidebar from '@theme/Navbar/MobileSidebar';
+import styles from './styles.module.css';
+function NavbarBackdrop(props) {
+  return (
+    <div
+      role="presentation"
+      {...props}
+      className={clsx('navbar-sidebar__backdrop', props.className)}
+    />
+  );
+}
+export default function NavbarLayout({children}) {
+  const {
+    navbar: {hideOnScroll, style},
+  } = useThemeConfig();
+  const mobileSidebar = useNavbarMobileSidebar();
+  const {navbarRef, isNavbarVisible} = useHideableNavbar(hideOnScroll);
+  return (
+    <nav
+      ref={navbarRef}
+      aria-label={translate({
+        id: 'theme.NavBar.navAriaLabel',
+        message: 'Main',
+        description: 'The ARIA label for the main navigation',
+      })}
+      className={clsx(
+        'navbar',
+        'navbar--fixed-top',
+        hideOnScroll && [
+          styles.navbarHideable,
+          !isNavbarVisible && styles.navbarHidden,
+        ],
+        {
+          'navbar--dark': style === 'dark',
+          'navbar--primary': style === 'primary',
+          'navbar-sidebar--show': mobileSidebar.shown,
+        },
+      )}>
+      {children}
+      <NavbarBackdrop onClick={mobileSidebar.toggle} />
+      <NavbarMobileSidebar />
+    </nav>
+  );
+}

--- a/src/theme/Navbar/Layout/styles.module.css
+++ b/src/theme/Navbar/Layout/styles.module.css
@@ -1,0 +1,7 @@
+.navbarHideable {
+  transition: transform var(--ifm-transition-fast) ease;
+}
+
+.navbarHidden {
+  transform: translate3d(0, calc(-100% - 2px), 0);
+}

--- a/src/theme/Navbar/Logo/index.js
+++ b/src/theme/Navbar/Logo/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import Logo from '@theme/Logo';
+export default function NavbarLogo() {
+  return (
+    <Logo
+      className="navbar__brand"
+      imageClassName="navbar__logo"
+      titleClassName="navbar__title text--truncate"
+    />
+  );
+}

--- a/src/theme/Navbar/MobileSidebar/Header/index.js
+++ b/src/theme/Navbar/MobileSidebar/Header/index.js
@@ -1,0 +1,46 @@
+import React from "react";
+import { useNavbarMobileSidebar } from "@docusaurus/theme-common/internal";
+import { translate } from "@docusaurus/Translate";
+import NavbarColorModeToggle from "@theme/Navbar/ColorModeToggle";
+import IconClose from "@theme/Icon/Close";
+import NavbarLogo from "@theme/Navbar/Logo";
+import { useThemeConfig } from "@docusaurus/theme-common";
+import NavbarItem from "@theme/NavbarItem";
+import styles from "./styles.module.css";
+function useNavbarItems() {
+  // TODO temporary casting until ThemeConfig type is improved
+  return useThemeConfig().navbar.items;
+}
+function CloseButton() {
+  const mobileSidebar = useNavbarMobileSidebar();
+  return (
+    <button
+      type="button"
+      aria-label={translate({
+        id: "theme.docs.sidebar.closeSidebarButtonAriaLabel",
+        message: "Close navigation bar",
+        description: "The ARIA label for close button of mobile sidebar",
+      })}
+      className="clean-btn navbar-sidebar__close"
+      onClick={() => mobileSidebar.toggle()}
+    >
+      <IconClose color="var(--ifm-color-emphasis-600)" />
+    </button>
+  );
+}
+export default function NavbarMobileSidebarHeader() {
+  const items = useNavbarItems().filter((item) => item?.className?.includes("github-link"));
+  const mobileSidebar = useNavbarMobileSidebar();
+  console.log(items[0]);
+  return (
+    <div className="navbar-sidebar__brand">
+      <NavbarLogo />
+      <NavbarColorModeToggle className="margin-right--md" />
+      <div className={styles.githubIcon}>
+        <NavbarItem mobile {...items[0]} onClick={() => mobileSidebar.toggle()} />
+      </div>
+      <div className={styles.githubIcon}></div>
+      <CloseButton />
+    </div>
+  );
+}

--- a/src/theme/Navbar/MobileSidebar/Header/styles.module.css
+++ b/src/theme/Navbar/MobileSidebar/Header/styles.module.css
@@ -1,0 +1,3 @@
+.githubIcon li {
+  list-style: none;
+}

--- a/src/theme/Navbar/MobileSidebar/Layout/index.js
+++ b/src/theme/Navbar/MobileSidebar/Layout/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import clsx from 'clsx';
+import {useNavbarSecondaryMenu} from '@docusaurus/theme-common/internal';
+export default function NavbarMobileSidebarLayout({
+  header,
+  primaryMenu,
+  secondaryMenu,
+}) {
+  const {shown: secondaryMenuShown} = useNavbarSecondaryMenu();
+  return (
+    <div className="navbar-sidebar">
+      {header}
+      <div
+        className={clsx('navbar-sidebar__items', {
+          'navbar-sidebar__items--show-secondary': secondaryMenuShown,
+        })}>
+        <div className="navbar-sidebar__item menu">{primaryMenu}</div>
+        <div className="navbar-sidebar__item menu">{secondaryMenu}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/theme/Navbar/MobileSidebar/PrimaryMenu/index.js
+++ b/src/theme/Navbar/MobileSidebar/PrimaryMenu/index.js
@@ -1,0 +1,22 @@
+import React from "react";
+import { useThemeConfig } from "@docusaurus/theme-common";
+import { useNavbarMobileSidebar } from "@docusaurus/theme-common/internal";
+import NavbarItem from "@theme/NavbarItem";
+function useNavbarItems() {
+  // TODO temporary casting until ThemeConfig type is improved
+  return useThemeConfig().navbar.items;
+}
+// The primary menu displays the navbar items
+export default function NavbarMobilePrimaryMenu() {
+  const mobileSidebar = useNavbarMobileSidebar();
+  // TODO how can the order be defined for mobile?
+  // Should we allow providing a different list of items?
+  const items = useNavbarItems().filter((item) => !item?.className?.includes("github-link"));
+  return (
+    <ul className="menu__list">
+      {items.map((item, i) => (
+        <NavbarItem mobile {...item} onClick={() => mobileSidebar.toggle()} key={i} />
+      ))}
+    </ul>
+  );
+}

--- a/src/theme/Navbar/MobileSidebar/SecondaryMenu/index.js
+++ b/src/theme/Navbar/MobileSidebar/SecondaryMenu/index.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import {useThemeConfig} from '@docusaurus/theme-common';
+import {useNavbarSecondaryMenu} from '@docusaurus/theme-common/internal';
+import Translate from '@docusaurus/Translate';
+function SecondaryMenuBackButton(props) {
+  return (
+    <button {...props} type="button" className="clean-btn navbar-sidebar__back">
+      <Translate
+        id="theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel"
+        description="The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)">
+        ← Back to main menu
+      </Translate>
+    </button>
+  );
+}
+// The secondary menu slides from the right and shows contextual information
+// such as the docs sidebar
+export default function NavbarMobileSidebarSecondaryMenu() {
+  const isPrimaryMenuEmpty = useThemeConfig().navbar.items.length === 0;
+  const secondaryMenu = useNavbarSecondaryMenu();
+  return (
+    <>
+      {/* edge-case: prevent returning to the primaryMenu when it's empty */}
+      {!isPrimaryMenuEmpty && (
+        <SecondaryMenuBackButton onClick={() => secondaryMenu.hide()} />
+      )}
+      {secondaryMenu.content}
+    </>
+  );
+}

--- a/src/theme/Navbar/MobileSidebar/Toggle/index.js
+++ b/src/theme/Navbar/MobileSidebar/Toggle/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import {useNavbarMobileSidebar} from '@docusaurus/theme-common/internal';
+import {translate} from '@docusaurus/Translate';
+import IconMenu from '@theme/Icon/Menu';
+export default function MobileSidebarToggle() {
+  const {toggle, shown} = useNavbarMobileSidebar();
+  return (
+    <button
+      onClick={toggle}
+      aria-label={translate({
+        id: 'theme.docs.sidebar.toggleSidebarButtonAriaLabel',
+        message: 'Toggle navigation bar',
+        description:
+          'The ARIA label for hamburger menu button of mobile navigation',
+      })}
+      aria-expanded={shown}
+      className="navbar__toggle clean-btn"
+      type="button">
+      <IconMenu />
+    </button>
+  );
+}

--- a/src/theme/Navbar/MobileSidebar/index.js
+++ b/src/theme/Navbar/MobileSidebar/index.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import {
+  useLockBodyScroll,
+  useNavbarMobileSidebar,
+} from '@docusaurus/theme-common/internal';
+import NavbarMobileSidebarLayout from '@theme/Navbar/MobileSidebar/Layout';
+import NavbarMobileSidebarHeader from '@theme/Navbar/MobileSidebar/Header';
+import NavbarMobileSidebarPrimaryMenu from '@theme/Navbar/MobileSidebar/PrimaryMenu';
+import NavbarMobileSidebarSecondaryMenu from '@theme/Navbar/MobileSidebar/SecondaryMenu';
+export default function NavbarMobileSidebar() {
+  const mobileSidebar = useNavbarMobileSidebar();
+  useLockBodyScroll(mobileSidebar.shown);
+  if (!mobileSidebar.shouldRender) {
+    return null;
+  }
+  return (
+    <NavbarMobileSidebarLayout
+      header={<NavbarMobileSidebarHeader />}
+      primaryMenu={<NavbarMobileSidebarPrimaryMenu />}
+      secondaryMenu={<NavbarMobileSidebarSecondaryMenu />}
+    />
+  );
+}

--- a/src/theme/Navbar/Search/index.js
+++ b/src/theme/Navbar/Search/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+export default function NavbarSearch({children, className}) {
+  return <div className={clsx(className, styles.searchBox)}>{children}</div>;
+}

--- a/src/theme/Navbar/Search/styles.module.css
+++ b/src/theme/Navbar/Search/styles.module.css
@@ -1,0 +1,13 @@
+@media (max-width: 996px) {
+  .searchBox {
+    position: absolute;
+    right: var(--ifm-navbar-padding-horizontal);
+  }
+}
+
+@media (min-width: 997px) {
+  .searchBox {
+    padding: var(--ifm-navbar-item-padding-vertical)
+      var(--ifm-navbar-item-padding-horizontal);
+  }
+}


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

![image](https://github.com/risingwavelabs/risingwave-docs/assets/54789193/28828707-83a2-44ef-9086-8d42ed342dba)

- move github icon to mobile sidebar header

- **Notes**

  [ Include any supplementary context or references here. ]

- **Related code PR**

  [ Provide a link to the relevant code PR here, if applicable. ]

- **Related doc issue**
  
  Resolves [ Provide a link to the relevant doc issue here, if applicable. ]

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **upcoming** version of the documentation. ]

- **Key points**

  [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
