### PR TITLE
chore(version): version label upcoming -> dev

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -31,7 +31,7 @@ const config = {
           showLastUpdateTime: true,
           versions: {
             current: {
-              label: "upcoming",
+              label: "1.1.0 (dev)",
               path: "/upcoming",
               badge: false,
               banner: "unreleased",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -31,7 +31,7 @@ const config = {
           showLastUpdateTime: true,
           versions: {
             current: {
-              label: "1.1.0 (dev)",
+              label: "1.1.x (dev)",
               path: "/upcoming",
               badge: false,
               banner: "unreleased",

--- a/src/theme/DocVersionBanner/index.js
+++ b/src/theme/DocVersionBanner/index.js
@@ -15,16 +15,10 @@ export default function DocVersionBannerWrapper(props) {
   return (
     <>
       {shown && (
-        <div
-          className="theme-doc-version-banner alert alert--warning margin-bottom--md"
-          role="alert"
-        >
+        <div className="theme-doc-version-banner alert alert--warning margin-bottom--md" role="alert">
           <div>You are viewing the documentation of an unreleased version of RisingWave.</div>
           <b>
-            <a href={`/docs/current/${location.pathname.split("/").at(-2)}`}>
-              {" "}
-              Switch to the current public release →
-            </a>
+            <a href={`/docs/current/${location.pathname.split("/").at(-2)}`}> Switch to the current public release →</a>
           </b>
         </div>
       )}


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

![image](https://github.com/risingwavelabs/risingwave-docs/assets/54789193/ebec0544-86a2-4019-8d24-e9e2d0638992)


- **Notes**

❗️ you will need to change the label in `docusaurus.config.js`  (line 34, it might be quite confusing since it's named current) every time you upload a new version

![image](https://github.com/risingwavelabs/risingwave-docs/assets/54789193/3ff1afb1-9fcc-4481-87f1-3e0f48ac306b)


- **Related code PR**


- **Related doc issue**
  

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **upcoming** version of the documentation. ]

- **Key points**

  [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
