### PR TITLE
Doc `IS JSON` predicate

### DIFF
--- a/docs/sql/functions-operators/sql-function-json.md
+++ b/docs/sql/functions-operators/sql-function-json.md
@@ -171,3 +171,38 @@ SELECT '{"a":1,"b":2}'::jsonb ->> 'b';
 ------RESULT
 2
 ```
+
+## `IS JSON` predicate
+
+This predicate tests whether an expression can be parsed as JSON, optionally of a specified type. It evaluates the JSON structure and returns a boolean result indicating whether the value matches the specified JSON type.
+
+#### Syntax
+
+```sql
+expression IS [ NOT ] JSON [ VALUE | ARRAY | OBJECT | SCALAR ] → bool
+```
+
+If SCALAR, ARRAY, or OBJECT is specified, the test is whether or not the JSON is of that particular type.
+
+#### Example
+
+```sql
+SELECT js,
+  js IS JSON "json?",
+  js IS JSON SCALAR "scalar?",
+  js IS JSON OBJECT "object?",
+  js IS JSON ARRAY "array?"
+FROM (VALUES
+      ('123'), ('"abc"'), ('{"a": "b"}'), ('[1,2]'),('abc')) foo(js);
+```
+```
+------RESULT
+
+ js         | json? | scalar? | object? | array?
+------------+-------+---------+---------+---------
+ 123        | t     | t       | f       | f
+ "abc"      | t     | t       | f       | f
+ {"a": "b"} | t     | f       | t       | f
+ [1,2]      | t     | f       | f       | t
+ abc        | f     | f       | f       | f
+```


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

 Add `IS JSON` predicate in JSON functions.

- **Related code PR**

  https://github.com/risingwavelabs/risingwave/pull/11831

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/1199

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **upcoming** version of the documentation. ]

- **Key points**

  [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
