### PR TITLE
fix: Caused by an incorrect hreflang link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,7 +5,7 @@
 const config = {
   title: "RisingWave",
   tagline: "Get started with RisingWave",
-  url: "https://www.risingwave-labs.com",
+  url: "https://docs.risingwave.com",
   baseUrl: "/",
   trailingSlash: true,
   onBrokenLinks: "warn",


### PR DESCRIPTION
The issue is not conducive to SEO.
<img width="1273" alt="image" src="https://github.com/risingwavelabs/risingwave-docs/assets/116697357/93415702-acf8-47c4-abab-e6194c12d1cb">

<img width="703" alt="image" src="https://github.com/risingwavelabs/risingwave-docs/assets/116697357/503f8a71-9b89-4a57-b7e2-b5c3104a5323">

fixed:
<img width="704" alt="image" src="https://github.com/risingwavelabs/risingwave-docs/assets/116697357/8c316770-1e9c-4adc-95c3-07d395b5ae3b">

