### PR TITLE
chore: Change the logo link.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -148,6 +148,7 @@ const config = {
         logo: {
           alt: "RisingWave Logo",
           src: "img/logo-title.png",
+          href: "https://www.risingwave.com/", 
         },
         items: [
           {

--- a/src/components/LinkGroup/index.js
+++ b/src/components/LinkGroup/index.js
@@ -85,7 +85,7 @@ export default function LinkGroup(props) {
     <div className={styles.container}>
       <div className={styles.flexBox}>
         <LinkItem
-          link="https://www.risingwave-labs.com"
+          link="https://www.risingwave.com/"
           focusing={rwFocus}
           setFocus={setRWFocus}
           label="RisingWave Labs"


### PR DESCRIPTION
- Modify the logo link to redirect to the official website.
<img width="651" alt="image" src="https://github.com/risingwavelabs/risingwave-docs/assets/116697357/6cdd6aa0-9574-4828-8927-ee2851a555c6">