### PR TITLE
jsonb || operator

### DIFF
--- a/docs/sql/functions-operators/sql-function-json.md
+++ b/docs/sql/functions-operators/sql-function-json.md
@@ -177,7 +177,7 @@ SELECT '{"a":1,"b":2}'::jsonb ->> 'b';
 Concatenates jsonb data type.
 
 ```bash title=Syntax
-(jsonb || jsonb) → varchar
+(jsonb || jsonb) → jsonb
 ```
 
 ```sql title=Example

--- a/docs/sql/functions-operators/sql-function-json.md
+++ b/docs/sql/functions-operators/sql-function-json.md
@@ -172,6 +172,26 @@ SELECT '{"a":1,"b":2}'::jsonb ->> 'b';
 2
 ```
 
+### `(jsonb || jsonb) -> jsonb`
+
+Concatenates jsonb data type.
+
+```bash title=Syntax
+(jsonb || jsonb) → varchar
+```
+
+```sql title=Example
+SELECT '["a", "b"]'::jsonb || '["a", "d"]'::jsonb;  
+SELECT '{"a": "b"}'::jsonb || '{"c": "d"}'::jsonb;
+SELECT '[1, 2]'::jsonb || '3'::jsonb;
+SELECT '{"a": "b"}'::jsonb || '42'::jsonb;
+------RESULT
+["a", "b", "a", "d"]
+{"a": "b", "c": "d"}
+[1, 2, 3]
+[{"a": "b"}, 42]
+```
+
 ## `IS JSON` predicate
 
 This predicate tests whether an expression can be parsed as JSON, optionally of a specified type. It evaluates the JSON structure and returns a boolean result indicating whether the value matches the specified JSON type.


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  Added subsection in json function & operators section. This added subsection allows demonstrates how jsonb data type can be concatenated with another jsonb data type


- **Related code PR**

  [PR#12502](https://github.com/risingwavelabs/risingwave/pull/12502)



<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **upcoming** version of the documentation. ]

- **Key points**

  [ Parts that may need revision or extra consideration. ]

## Before merging

- [x] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
