### PR TITLE
chore: remove `properties.group.id` in demo sql

### DIFF
--- a/versioned_docs/version-1.3/create-source/create-source-kafka.md
+++ b/versioned_docs/version-1.3/create-source/create-source-kafka.md
@@ -403,7 +403,6 @@ WITH (
   privatelink.targets='[{"port": 9094}, {"port": 9095}, {"port": 9096}]',
   properties.bootstrap.server='broker1-endpoint,broker2-endpoint,broker3-endpoint',
   scan.startup.mode='latest',
-  properties.group.id='test_group'
 ) FORMAT PLAIN ENCODE JSON;
 ```
 


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - [ What's changed? Which parts of the docs are affected? ]
  - we've removed the `group.id` in the properties table but left usage in demo sql

- **Notes**

  - [ Include any supplementary context or references here. ]

- **Related code PR**

  - [ Provide a link to the relevant code PR here, if applicable. ]

- **Related doc issue**
  
  Resolves [ Provide a link to the relevant doc issue here, if applicable. ]

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
