### PR TITLE
remove `properties.group.id` in kafka example

### DIFF
--- a/docs/create-source/create-source-kafka.md
+++ b/docs/create-source/create-source-kafka.md
@@ -403,8 +403,7 @@ WITH (
   privatelink.endpoint='10.148.0.4',
   privatelink.targets='[{"port": 9094}, {"port": 9095}, {"port": 9096}]',
   properties.bootstrap.server='broker1-endpoint,broker2-endpoint,broker3-endpoint',
-  scan.startup.mode='latest',
-  properties.group.id='test_group'
+  scan.startup.mode='latest'
 ) FORMAT PLAIN ENCODE JSON;
 ```
 


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - Remove deprecated `properties.group.id` in kafka source example

- **Notes**

  - [ Include any supplementary context or references here. ]

- **Related code PR**

  - https://github.com/risingwavelabs/risingwave/pull/9487#issuecomment-1535775663

- **Related doc issue**
  
  Resolves [ Provide a link to the relevant doc issue here, if applicable. ]

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
