### PR TITLE
fix: source cannot have PK defined

### DIFF
--- a/docs/sql/commands/sql-create-source.md
+++ b/docs/sql/commands/sql-create-source.md
@@ -19,7 +19,6 @@ Regardless of whether the data is persisted in RisingWave, you can create materi
 CREATE SOURCE [ IF NOT EXISTS ] source_name (
     col_name data_type [ AS generation_expression ],
     ...
-   [ PRIMARY KEY (col_name, ... ) ]
    [ watermark_clause ]
 )
 [ WITH (
@@ -33,9 +32,7 @@ CREATE SOURCE [ IF NOT EXISTS ] source_name (
 
 ## Notes
 
-For sources with primary key constraints, if you insert a new data record with an existing key, the new record will overwrite the existing record.
-
-A [generated column](/sql/query-syntax/query-syntax-generated-columns.md) that is defined with non-deterministic functions cannot be specified as part of the primary key. For example, if `A1` is defined as `current_timestamp()`, then it cannot be part of the primary key.
+A [generated column](/sql/query-syntax/query-syntax-generated-columns.md) is defined with non-deterministic functions. When the data is ingested, the function will be evaluated to generated the value of this field.
 
 Names and unquoted identifiers are case-insensitive. Therefore, you must double-quote any of these fields for them to be case-sensitive.
 
@@ -56,8 +53,6 @@ To know when a data record is loaded to RisingWave, you can define a column that
 ## Supported sources
 
 Click a connector name to see the SQL syntax, options, and sample statement of connecting RisingWave to the connector.
-
-Data formats denoted with an M only support materialized sources, which require a primary key to be specified. Otherwise, both materialized and non-materialized sources are supported.
 
 | Connector | Version | Format |
 |---------|---------|---------|

--- a/docs/sql/commands/sql-create-table.md
+++ b/docs/sql/commands/sql-create-table.md
@@ -35,7 +35,9 @@ CREATE TABLE [ IF NOT EXISTS ] table_name (
 
 ## Notes
 
-For tables with primary key constraints, if you insert a new data record with an existing key, the new record will overwrite the existing record. A generated column cannot be defined as a primary key.
+For tables with primary key constraints, if you insert a new data record with an existing key, the new record will overwrite the existing record.
+
+A [generated column](/sql/query-syntax/query-syntax-generated-columns.md) that is defined with non-deterministic functions cannot be specified as part of the primary key. For example, if `A1` is defined as `current_timestamp()`, then it cannot be part of the primary key.
 
 Names and unquoted identifiers are case-insensitive. Therefore, you must double-quote any of these fields for them to be case-sensitive.
 

--- a/versioned_docs/version-1.3/sql/commands/sql-create-source.md
+++ b/versioned_docs/version-1.3/sql/commands/sql-create-source.md
@@ -19,7 +19,6 @@ Regardless of whether the data is persisted in RisingWave, you can create materi
 CREATE SOURCE [ IF NOT EXISTS ] source_name (
     col_name data_type [ AS generation_expression ],
     ...
-   [ PRIMARY KEY (col_name, ... ) ]
    [ watermark_clause ]
 )
 [ WITH (
@@ -33,9 +32,7 @@ CREATE SOURCE [ IF NOT EXISTS ] source_name (
 
 ## Notes
 
-For sources with primary key constraints, if you insert a new data record with an existing key, the new record will overwrite the existing record.
-
-A [generated column](/sql/query-syntax/query-syntax-generated-columns.md) that is defined with non-deterministic functions cannot be specified as part of the primary key. For example, if `A1` is defined as `current_timestamp()`, then it cannot be part of the primary key.
+A [generated column](/sql/query-syntax/query-syntax-generated-columns.md) is defined with non-deterministic functions. When the data is ingested, the function will be evaluated to generated the value of this field.
 
 Names and unquoted identifiers are case-insensitive. Therefore, you must double-quote any of these fields for them to be case-sensitive.
 
@@ -56,8 +53,6 @@ To know when a data record is loaded to RisingWave, you can define a column that
 ## Supported sources
 
 Click a connector name to see the SQL syntax, options, and sample statement of connecting RisingWave to the connector.
-
-Data formats denoted with an M only support materialized sources, which require a primary key to be specified. Otherwise, both materialized and non-materialized sources are supported.
 
 | Connector | Version | Format |
 |---------|---------|---------|

--- a/versioned_docs/version-1.3/sql/commands/sql-create-table.md
+++ b/versioned_docs/version-1.3/sql/commands/sql-create-table.md
@@ -35,7 +35,9 @@ CREATE TABLE [ IF NOT EXISTS ] table_name (
 
 ## Notes
 
-For tables with primary key constraints, if you insert a new data record with an existing key, the new record will overwrite the existing record. A generated column cannot be defined as a primary key.
+For tables with primary key constraints, if you insert a new data record with an existing key, the new record will overwrite the existing record.
+
+A [generated column](/sql/query-syntax/query-syntax-generated-columns.md) that is defined with non-deterministic functions cannot be specified as part of the primary key. For example, if `A1` is defined as `current_timestamp()`, then it cannot be part of the primary key.
 
 Names and unquoted identifiers are case-insensitive. Therefore, you must double-quote any of these fields for them to be case-sensitive.
 


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

Sources cannot have PK defined. These docs were introduced by the concept "materialized source", which has been deprecated and substituted by "table".

I fixed all the historical version as well, because it's not specific to any RisingWave version.

I also found lots of occurrence of "materialized source". Let's clean them later. #1467

- **Notes**

  - [ Include any supplementary context or references here. ]

- **Related code PR**

  - [ Provide a link to the relevant code PR here, if applicable. ]

- **Related doc issue**
  
  Resolves [ Provide a link to the relevant doc issue here, if applicable. ]

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
