### PR TITLE
restructure: fold watermark under emit-on-window-close

### DIFF
--- a/docs/transform/emit-on-window-close.md
+++ b/docs/transform/emit-on-window-close.md
@@ -24,8 +24,8 @@ FROM TUMBLE(events, event_time, INTERVAL '1' MINUTE)
 GROUP BY window_start;
 ```
 
-- **Emit on update:** With this policy, the aggregation operator emits a new count(*) result downstream whenever each barrier passes (default interval is 1 second). This updated count is then reflected in the materialized view or outputted to external systems.
-- **Emit on window close:** When the watermark defined on event_time surpasses the end time of a time window, the aggregation operator emits the final immutable aggregation result downstream. This result represents the complete aggregation for the window and is not subject to further changes.
+- **Emit on update:** With this policy, the aggregation operator emits a new `count(*)` result downstream whenever each barrier passes (default interval is 1 second). This updated count is then reflected in the materialized view or outputted to external systems.
+- **Emit on window close:** When the watermark defined on `event_time` surpasses the end time of a time window, the aggregation operator emits the final immutable aggregation result downstream. This result represents the complete aggregation for the window and is not subject to further changes.
 
 RisingWave defaults to the emit-on-update behavior to ensure consistency between materialized views and base tables. This choice aligns with the SQL definition of view and helps maintain coherence across the system.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -326,14 +326,21 @@ const sidebars = {
           label: "Window functions",
         },
         {
-          type: "doc",
-          id: "transform/emit-on-window-close",
+          type: "category",
           label: "Emit on window close",
-        },
-        {
-          type: "doc",
-          id: "transform/watermarks",
-          label: "Watermarks",
+          collapsible: true,
+          collapsed: true,
+          link: {
+            type: "doc",
+            id: "transform/emit-on-window-close",
+          },
+          items: [
+            {
+              type: "doc",
+              id: "transform/watermarks",
+              label: "Watermarks",
+            },
+          ]
         },
         {
           type: "doc",


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

As discussed in Slack channel, our watermark is only designed to be used along with emit-on-window-close.

(And state cleaning, but it’s very difficult for users to understand. Also, in most cases, state cleaning comes with emit-on-window-close together)

I attempted to merge [Watermark](https://docs.risingwave.com/docs/current/watermarks/) and [Emit on window close](https://docs.risingwave.com/docs/current/emit-on-window-close/) into one, but it seems better to just put "Watermark" under "Emit on window close".

- **Notes**

  - [ Include any supplementary context or references here. ]

- **Related code PR**

  - [ Provide a link to the relevant code PR here, if applicable. ]

- **Related doc issue**
  
  Resolves [ Provide a link to the relevant doc issue here, if applicable. ]

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
