### PR TITLE
Doc background MV job persistency

### DIFF
--- a/docs/sql/commands/sql-set-background-ddl.md
+++ b/docs/sql/commands/sql-set-background-ddl.md
@@ -10,8 +10,6 @@ slug: /sql-set-background-ddl
 
 :::caution Experimental feature
 The `SET BACKGROUND_DDL` command is currently an experimental feature. Its functionality is subject to change. We cannot guarantee its continued support in future releases, and it may be discontinued without notice. You may use this feature at your own risk.
-
-Currently, if the cluster crashes while a background DDL operation is still running, recovery is not supported.
 :::
 
 Use the `SET BACKGROUND_DDL` command to run Data Definition Language (DDL) operations, such as creating materialized views in the background.
@@ -22,13 +20,19 @@ Use the `SET BACKGROUND_DDL` command to run Data Definition Language (DDL) opera
 SET BACKGROUND_DDL = { true | false };
 ```
 
-- When `BACKGROUND_DDL` is set to true, any subsequent DDL operations will be executed in the background, allowing you to proceed with other tasks. 
+- When `BACKGROUND_DDL` is set to true, any subsequent DDL operations will be executed in the background, allowing you to proceed with other tasks.
 
-- When `BACKGROUND_DDL` is set to false (or not set at all), the DDL operations will execute as normal.
+- When `BACKGROUND_DDL` is set to false (or not set at all), the DDL operations will execute  in the foreground.
 
 ## Supported DDL operations
 
 - [CREATE MATERIALIZED VIEW](/sql/commands/sql-create-mv.md)
+
+## Persistence
+
+For materialized views created in the background, their table definitions are persisted, even if errors occur during checkpointing. Their table definitions and fragments will only be dropped if the job is cancelled.
+
+For materialized views created in the foreground, their table and fragments will be cleaned up if checkpointing fails or when the streaming job restarts from the beginning.
 
 ## Background management
 

--- a/docs/sql/commands/sql-set-background-ddl.md
+++ b/docs/sql/commands/sql-set-background-ddl.md
@@ -30,7 +30,7 @@ SET BACKGROUND_DDL = { true | false };
 
 ## Persistence
 
-For materialized views created in the background, their table definitions are persisted, even if errors occur during checkpointing. Their table definitions and fragments will only be dropped if the job is cancelled.
+For materialized views created in the background, their table definitions are persisted, even if errors occur during checkpointing. This allows the materialized view jobs to be recovered from where they left off before the failure. Their table definitions and fragments will only be dropped if the job is cancelled.
 
 For materialized views created in the foreground, their table and fragments will be cleaned up if checkpointing fails or when the streaming job restarts from the beginning.
 

--- a/docs/sql/commands/sql-set-background-ddl.md
+++ b/docs/sql/commands/sql-set-background-ddl.md
@@ -30,10 +30,11 @@ SET BACKGROUND_DDL = { true | false };
 
 ## Persistence
 
-For materialized views created in the background, their table definitions persist, even if errors occur during checkpointing. This allows the materialized view jobs to be recovered from where they left off before the failure. Their table definitions and fragments will only be dropped if the job is canceled.
+For materialized views being created in the background, their table definitions persist while they are being created, even if errors occur during checkpointing. This allows the materialized view jobs to be recovered from where they left off before the failure. Their table definitions and fragments will only be dropped if the job is canceled.
 
-For materialized views created in the foreground, their table and fragments will be cleaned up if checkpointing fails or when the streaming job restarts from the beginning.
+For materialized views being created in the foreground, their table and fragments will be cleaned up if checkpointing fails, if the cluster is restarted, or if the stream job is cancelled.
 
+The key difference is during the **creating phase** of a materialized view. After a materialized view is created (i.e. backfilling has completed), both foreground and background materialized views are functionally the same.
 ## Background management
 
 ### Monitor progress

--- a/docs/sql/commands/sql-set-background-ddl.md
+++ b/docs/sql/commands/sql-set-background-ddl.md
@@ -30,7 +30,7 @@ SET BACKGROUND_DDL = { true | false };
 
 ## Persistence
 
-For materialized views created in the background, their table definitions are persisted, even if errors occur during checkpointing. This allows the materialized view jobs to be recovered from where they left off before the failure. Their table definitions and fragments will only be dropped if the job is cancelled.
+For materialized views created in the background, their table definitions persist, even if errors occur during checkpointing. This allows the materialized view jobs to be recovered from where they left off before the failure. Their table definitions and fragments will only be dropped if the job is canceled.
 
 For materialized views created in the foreground, their table and fragments will be cleaned up if checkpointing fails or when the streaming job restarts from the beginning.
 


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - Updated the SET BACKGROUND_DDL page to introduce the persistence of MV jobs in the background.

- **Related code PR**

  - https://github.com/risingwavelabs/risingwave/pull/12167

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/1414

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  Please review the description: 
  ```
  ## Persistence
  
  For materialized views created in the background, their table definitions persist, even if errors occur during checkpointing. This allows the materialized view jobs to be recovered from where they left off before the failure. Their table definitions and fragments will only be dropped if the job is canceled.
  
  For materialized views created in the foreground, their table and fragments will be cleaned up if checkpointing fails or when the streaming job restarts from the beginning.
  ```

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
