### PR TITLE
Doc s3_v2 connector

### DIFF
--- a/docs/ingest/ingest-from-s3.md
+++ b/docs/ingest/ingest-from-s3.md
@@ -122,6 +122,12 @@ Empty cells in CSV files will be parsed to `NULL`.
 
 ### `s3_v2` connector
 
+:::caution BETA FEATURE
+
+The `s3_v2` connector is currently in Beta. Please use with caution as stability issues may still occur. Its functionality may evolve based on feedback. Please report any issues encountered to our team.
+
+:::
+
 The `s3` connector treats files as splits, resulting in poor scalability and potential timeouts when dealing with a large number of files.
 
 The `s3_v2` connector is designed to address the scalability and performance limitations of the `s3` connector by implementing a more efficient listing and fetching mechanism. If you want to explore the technical details of this new approach, refer to [the design document](https://github.com/risingwavelabs/rfcs/blob/main/rfcs/0076-refined-s3-source.md).

--- a/docs/ingest/ingest-from-s3.md
+++ b/docs/ingest/ingest-from-s3.md
@@ -16,7 +16,7 @@ Use the SQL statement below to connect RisingWave to an Amazon S3 source.
 CREATE SOURCE [ IF NOT EXISTS ] source_name 
 schema_definition
 WITH (
-   connector='s3',
+   connector={ 's3' | 's3_v2' },
    connector_parameter='value', ...
 )
 FORMAT data_format ENCODE data_encode (
@@ -62,14 +62,19 @@ export const svg = rr.Diagram(
                     rr.Sequence(
                         rr.Terminal('connector'),
                         rr.Terminal('='),
-                        rr.NonTerminal('s3', 'skip'),
+                        rr.Choice(1,
+                            rr.Terminal('\'s3\''),
+                            rr.Terminal('\'s3_v2\'')
+                        ),
                         rr.Terminal(','),
                     ),
                     rr.OneOrMore(
                         rr.Sequence(
                             rr.NonTerminal('connector_parameter', 'skip'),
                             rr.Terminal('='),
+                            rr.Terminal('\''),
                             rr.NonTerminal('value', 'skip'),
+                            rr.Terminal('\''),
                             rr.Terminal(','),
                         ),
                     ),
@@ -96,6 +101,7 @@ export const svg = rr.Diagram(
 
 |Field|Notes|
 |---|---|
+|connector|Required. Select between the `s3` and `s3_v2` (recommended) connector. [Learn more about `s3_v2`](#s3_v2-connector).|
 |s3.region_name |Required. The service region.|
 |s3.bucket_name |Required. The name of the bucket the data source is stored in. |
 |s3.credentials.access|Required. This field indicates the access key ID of AWS. |
@@ -113,6 +119,12 @@ Empty cells in CSV files will be parsed to `NULL`.
 |*data_encode*| Supported data encodes: `CSV`, `JSON`. |
 |*without_header*| Whether the first line is header. Accepted values: `'true'`, `'false'`. Default: `'true'`.|
 |*delimiter*| How RisingWave splits contents. For `JSON` encode, the delimiter is `\n`. |
+
+### `s3_v2` connector
+
+The `s3` connector treats files as splits, resulting in poor scalability and potential timeouts when dealing with a large number of files.
+
+The `s3_v2` connector is designed to address the scalability and performance limitations of the `s3` connector by implementing a more efficient listing and fetching mechanism. If you want to explore the technical details of this new approach, refer to [the design doc](https://github.com/risingwavelabs/rfcs/blob/main/rfcs/0076-refined-s3-source.md).
 
 ## Example
 
@@ -132,7 +144,7 @@ CREATE TABLE s(
     primary key(id)
 ) 
 WITH (
-    connector = 's3',
+    connector = 's3_v2',
     s3.region_name = 'ap-southeast-2',
     s3.bucket_name = 'example-s3-source',
     s3.credentials.access = 'xxxxx',
@@ -154,7 +166,7 @@ CREATE TABLE s3(
     mark int,
 )
 WITH (
-    connector = 's3',
+    connector = 's3_v2',
     match_pattern = '%Ring%*.ndjson',
     s3.region_name = 'ap-southeast-2',
     s3.bucket_name = 'example-s3-source',

--- a/docs/ingest/ingest-from-s3.md
+++ b/docs/ingest/ingest-from-s3.md
@@ -124,7 +124,7 @@ Empty cells in CSV files will be parsed to `NULL`.
 
 The `s3` connector treats files as splits, resulting in poor scalability and potential timeouts when dealing with a large number of files.
 
-The `s3_v2` connector is designed to address the scalability and performance limitations of the `s3` connector by implementing a more efficient listing and fetching mechanism. If you want to explore the technical details of this new approach, refer to [the design doc](https://github.com/risingwavelabs/rfcs/blob/main/rfcs/0076-refined-s3-source.md).
+The `s3_v2` connector is designed to address the scalability and performance limitations of the `s3` connector by implementing a more efficient listing and fetching mechanism. If you want to explore the technical details of this new approach, refer to [the design document](https://github.com/risingwavelabs/rfcs/blob/main/rfcs/0076-refined-s3-source.md).
 
 ## Example
 


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - Update the "Ingest data from S3 buckets" page to introduce `s3_v2`.
  - Since `s3_v2` shares the same parameters with `s3`, there's no need to add a separate page for `s3_v2`.

- **Related code PR**

  - https://github.com/risingwavelabs/risingwave/pull/12595

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/1378

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
