### PR TITLE
Doc supported protobuf data types

### DIFF
--- a/docs/ingest/ingest-from-kafka.md
+++ b/docs/ingest/ingest-from-kafka.md
@@ -136,7 +136,7 @@ For tables with primary key constraints, if a new data record with an existing k
 
 |Field|Notes|
 |---|---|
-|*data_format*| Data format. Supported formats: , `DEBEZIUM`, `MAXWELL`, `CANAL`, `UPSERT`, `PLAIN`. |
+|*data_format*| Data format. Supported formats: `DEBEZIUM`, `MAXWELL`, `CANAL`, `UPSERT`, `PLAIN`. |
 |*data_encode*| Data encode. Supported encodes: `JSON`, `AVRO`, `PROTOBUF`, `CSV`. |
 |*message* | Message name of the main Message in schema definition. Required for Protobuf. |
 |*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. For Avro and Protobuf data, you must specify either a schema location or a schema registry but not both.|

--- a/docs/sql/commands/sql-create-source.md
+++ b/docs/sql/commands/sql-create-source.md
@@ -252,7 +252,7 @@ ENCODE JSON [ (
 
 ### Protobuf
 
-For data in Protobuf format, you must specify a message and a schema location. The schema location can be an actual Web location that is in `http://...`, `https://...`, or `S3://...` format. For Kafka data in Protobuf, instead of providing a schema location, you can provide a Confluent Schema Registry that RisingWave can get the schema from. For more details about using Schema Registry for Kafka data, see [Read schema from Schema Registry](/ingest/ingest-from-kafka.md#read-schemas-from-schema-registry).
+For data in protobuf format, you must specify a message and a schema location. The schema location can be an actual Web location that is in `http://...`, `https://...`, or `S3://...` format. For Kafka data in protobuf, instead of providing a schema location, you can provide a Confluent Schema Registry that RisingWave can get the schema from. For more details about using Schema Registry for Kafka data, see [Read schema from Schema Registry](/ingest/ingest-from-kafka.md#read-schemas-from-schema-registry).
 
 `schema.registry` can accept multiple addresses. RisingWave will send requests to all URLs and return the first successful result.
 
@@ -285,6 +285,8 @@ ENCODE PROTOBUF (
    [key.message = 'test_key']
 )
 ```
+
+For more information on supported protobuf types, refer to [Supported protobuf types](/docs/sql/data-types/protobuf-types.md).
 
 ### Bytes
 

--- a/docs/sql/data-types/protobuf-types.md
+++ b/docs/sql/data-types/protobuf-types.md
@@ -1,0 +1,61 @@
+---
+id: protobuf-types
+slug: /protobuf-types
+description: An overview of the supported protobuf types and their corresponding RisingWave types.
+title: Supported protobuf types
+---
+<head>
+  <link rel="canonical" href="https://docs.risingwave.com/docs/current/protobuf-types/" />
+</head>
+
+RisingWave supports a variety of protobuf data types, which are converted to equivalent types in RisingWave. This page provides an overview of the supported protobuf types and their corresponding RisingWave types.
+
+## Conversion
+
+RisingWave converts [well-known types](https://protobuf.dev/reference/protobuf/google.protobuf/) from the protobuf library to specific types in RisngWave. The conversion is as follows:
+
+Protobuf type | RisingWave type
+-- | --
+any | 
+double | double precision
+float | real
+int32 | int
+int64 | bigint
+uint32 | bigint
+uint64 | decimal
+sint32 | int
+sint64 | bigint
+fixed32 | bigint
+fixed64 | decimal
+sfixed32 | int
+sfixed64 | bigint
+bool | boolean
+string | varchar
+bytes | bytea
+enum | varchar
+message | struct. See details in [Nested messages](#nested-messages).
+repeated | array
+map | Not supported
+google.protobuf.Struct | Not supported
+google.protobuf.Timestamp | `struct<seconds bigint, nanos int>`
+google.protobuf.Duration | `struct<seconds bigint, nanos int>`
+google.protobuf.Any | `struct<type_url varchar, value bytea>`
+google.protobuf.Int32Value | `struct<value int>`
+google.protobuf.StringValue | `struct<value varchar>`
+
+### Nested messages
+
+The nested fields are transformed into columns within a struct type. For example, a Protobuf message with the following structure:
+
+```
+message NestedMessage {
+  int32 id = 1;
+  string name = 2;
+}
+```
+
+Will be converted to `struct<id int, name varchar>` in RisingWave.
+
+## Related topics
+
+- [CREATE SOURCE](/docs/sql/commands/sql-create-source.md)

--- a/sidebars.js
+++ b/sidebars.js
@@ -613,6 +613,11 @@ const sidebars = {
                   id: "sql/data-types/data-type-rw_int256",
                   label: "rw_int256",
                 },
+                {
+                  type: "doc",
+                  id: "sql/data-types/protobuf-types",
+                  label: "Supported protobuf types",
+                },
               ],
             },
             {

--- a/versioned_docs/version-1.0.0/create-source/create-source-kafka.md
+++ b/versioned_docs/version-1.0.0/create-source/create-source-kafka.md
@@ -135,7 +135,7 @@ For materialized sources with primary key constraints, if a new data record with
 
 |Field|Notes|
 |---|---|
-|*data_format*| Data format. Supported formats: , `DEBEZIUM`, `MAXWELL`, `CANAL`, `UPSERT`, `PLAIN`. |
+|*data_format*| Data format. Supported formats: `DEBEZIUM`, `MAXWELL`, `CANAL`, `UPSERT`, `PLAIN`. |
 |*data_encode*| Data encode. Supported encodes: `JSON`, `AVRO`, `PROTOBUF`, `CSV`.|
 |*message* | Message name of the main Message in schema definition. Required for Protobuf.|
 |*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. For Avro and Protobuf data, you must specify either a schema location or a schema registry but not both.|

--- a/versioned_docs/version-1.1/create-source/create-source-kafka.md
+++ b/versioned_docs/version-1.1/create-source/create-source-kafka.md
@@ -135,7 +135,7 @@ For materialized sources with primary key constraints, if a new data record with
 
 |Field|Notes|
 |---|---|
-|*data_format*| Data format. Supported formats: , `DEBEZIUM`, `MAXWELL`, `CANAL`, `UPSERT`, `PLAIN`. |
+|*data_format*| Data format. Supported formats: `DEBEZIUM`, `MAXWELL`, `CANAL`, `UPSERT`, `PLAIN`. |
 |*data_encode*| Data encode. Supported encodes: `JSON`, `AVRO`, `PROTOBUF`, `CSV`.|
 |*message* | Message name of the main Message in schema definition. Required for Protobuf.|
 |*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. For Avro and Protobuf data, you must specify either a schema location or a schema registry but not both.|

--- a/versioned_docs/version-1.2/create-source/create-source-kafka.md
+++ b/versioned_docs/version-1.2/create-source/create-source-kafka.md
@@ -136,7 +136,7 @@ For materialized sources with primary key constraints, if a new data record with
 
 |Field|Notes|
 |---|---|
-|*data_format*| Data format. Supported formats: , `DEBEZIUM`, `MAXWELL`, `CANAL`, `UPSERT`, `PLAIN`. |
+|*data_format*| Data format. Supported formats: `DEBEZIUM`, `MAXWELL`, `CANAL`, `UPSERT`, `PLAIN`. |
 |*data_encode*| Data encode. Supported encodes: `JSON`, `AVRO`, `PROTOBUF`, `CSV`. |
 |*message* | Message name of the main Message in schema definition. Required for Protobuf. |
 |*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. For Avro and Protobuf data, you must specify either a schema location or a schema registry but not both.|

--- a/versioned_docs/version-1.3/create-source/create-source-kafka.md
+++ b/versioned_docs/version-1.3/create-source/create-source-kafka.md
@@ -136,7 +136,7 @@ For tables with primary key constraints, if a new data record with an existing k
 
 |Field|Notes|
 |---|---|
-|*data_format*| Data format. Supported formats: , `DEBEZIUM`, `MAXWELL`, `CANAL`, `UPSERT`, `PLAIN`. |
+|*data_format*| Data format. Supported formats: `DEBEZIUM`, `MAXWELL`, `CANAL`, `UPSERT`, `PLAIN`. |
 |*data_encode*| Data encode. Supported encodes: `JSON`, `AVRO`, `PROTOBUF`, `CSV`. |
 |*message* | Message name of the main Message in schema definition. Required for Protobuf. |
 |*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. For Avro and Protobuf data, you must specify either a schema location or a schema registry but not both.|


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - Add a page for the protobuf-rw data types conversion table under SQL - Data types
  - Add a link to the page in CREATE SOURCE - Protobuf

- **Related code PR**

  - https://github.com/risingwavelabs/risingwave/pull/12291

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/1454
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/1307

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - @neverchanje, @xzhseh Can you please provide info on the equivalent data type in RW for the `any` field in protobuf?

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
