### PR TITLE
Remove the type restrictions of jsonb_agg and jsonb_object_agg functions

### DIFF
--- a/docs/sql/functions-operators/sql-function-aggregate.md
+++ b/docs/sql/functions-operators/sql-function-aggregate.md
@@ -94,7 +94,7 @@ The input can be of any supported data type.
 Aggregates values, including nulls, as a JSON array. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```bash title=Syntax
-jsonb_agg ( expression ) -> jsonb    
+jsonb_agg ( any_element ) -> jsonb    
 ```
 
 ---  
@@ -104,10 +104,8 @@ jsonb_agg ( expression ) -> jsonb
 Aggregates name/value pairs as a JSON object.
 
 ```bash title=Syntax
-jsonb_object_agg ( key , value ) -> jsonb   
+jsonb_object_agg ( key "any" , value "any" ) -> jsonb   
 ```
-
-`key`: varchar only.
 
 ---  
 

--- a/docs/sql/functions-operators/sql-function-aggregate.md
+++ b/docs/sql/functions-operators/sql-function-aggregate.md
@@ -104,7 +104,7 @@ jsonb_agg ( any_element ) -> jsonb
 Aggregates name/value pairs as a JSON object.
 
 ```bash title=Syntax
-jsonb_object_agg ( key "any" , value "any" ) -> jsonb   
+jsonb_object_agg ( key "string" , value "any" ) -> jsonb   
 ```
 
 ---  

--- a/docs/sql/functions-operators/sql-function-aggregate.md
+++ b/docs/sql/functions-operators/sql-function-aggregate.md
@@ -97,8 +97,6 @@ Aggregates values, including nulls, as a JSON array. The `ORDER BY` clause is op
 jsonb_agg ( expression ) -> jsonb    
 ```
 
-Currently, input types include boolean, smallint, int, bigint, real, double precision, varchar and jsonb.
-
 ---  
 
 ### `jsonb_object_agg`
@@ -110,8 +108,6 @@ jsonb_object_agg ( key , value ) -> jsonb
 ```
 
 `key`: varchar only.
-
-`value`: Currently supports null, boolean, smallint, int, bigint, real, double precision, varchar, and jsonb.
 
 ---  
 


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - Support more types as the parameters of jsonb_agg and jsonb_object_agg, so remove the type restriction part of these two functions.

- **Related code PR**

  https://github.com/risingwavelabs/risingwave/pull/13299

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/1491

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
