### PR TITLE
Enhance Array Page with Operators

### DIFF
--- a/docs/sql/functions-operators/sql-function-array.md
+++ b/docs/sql/functions-operators/sql-function-array.md
@@ -438,7 +438,7 @@ array[2,3] <@ array[1,2,3] → t
 
 ### `array || anycompatible → array`
 
-Appends *any_compatible* to the end of the input array. This operation achieves the same result as using `array_append`.
+Appends *any_compatible* to the end of *array*. This operation achieves the same result as using `array_append`.
 
 ```bash title=Example
 array[66] || 123 → {66, 123}
@@ -458,7 +458,7 @@ array[66] || array[123] → {66, 123}
 
 ### `anycompatible || array → array`
 
-Prepends *any_compatible* to the beginning of the input array. This operation achieves the same result as using `array_prepend`.
+Prepends *any_compatible* to the beginning of *array*. This operation achieves the same result as using `array_prepend`.
 
 ```bash title=Example
 123 || array[66] → {123, 66}

--- a/docs/sql/functions-operators/sql-function-array.md
+++ b/docs/sql/functions-operators/sql-function-array.md
@@ -1,11 +1,13 @@
 ---
 id: sql-function-array
 slug: /sql-function-array
-title: Array functions
+title: Array functions and operators
 ---
 <head>
   <link rel="canonical" href="https://docs.risingwave.com/docs/current/sql-function-array/" />
 </head>
+
+## Array functions
 
 ### `array_append`
 
@@ -419,4 +421,56 @@ unnest(Array[Array[1,3,4,5],Array[2,3]]) →
 5
 2
 3
+```
+
+## Array operators
+
+### `array @> array -> boolean`
+
+This operator checks if the left array contains all elements of the right array.
+
+```bash title=Example
+SELECT array[1,2,3] @> array[2,3];
+------RESULT
+t
+```
+
+### `array <@ array -> boolean`
+
+This operator checks if the left array is contained by the right array
+
+```bash title=Example
+SELECT array[2,3] <@ array[1,2,3];
+------RESULT
+t
+```
+
+### `array_append`
+
+Appends *any_compatible* to the end of the input array. 
+
+```bash title=Example
+array[66] || 123 → {66, 123}
+```
+
+---
+
+### `array_cat`
+
+Concatenates two arrays with the same data type. 
+
+If the one of the input arrays is a 2-dimensional array, the other array will be appended within the first array as the last element if it is the second argument. The other array will be prepended within the first array as the first element if it is the first argument.
+
+```bash title=Example
+array[66] || array[123] → {66, 123}
+```
+
+---
+
+### `array_prepend`
+
+Prepends *any_compatible* to the beginning of the input array.
+
+```bash title=Example
+123 || array[66] → {123, 66}
 ```

--- a/docs/sql/functions-operators/sql-function-array.md
+++ b/docs/sql/functions-operators/sql-function-array.md
@@ -19,8 +19,6 @@ array_append ( array, any_compatible ) → array
 
 ```bash title=Example
 array_append(array[66], 123) → {66, 123}
-
-array[66] || 123 → {66, 123}
 ```
 
 ---
@@ -37,8 +35,6 @@ array_cat ( array, array ) → array
 
 ```bash title=Example
 array_cat(array[66], array[123]) → {66, 123}
-
-array[66] || array[123] → {66, 123}
 
 array_cat(array[array[66]], array[233]) → {{66}, {233}}
 
@@ -220,7 +216,6 @@ array_prepend ( any_compatible, array ) → array
 ```bash title=Example
 array_prepend(123, array[66]) → {123, 66}
 
-123 || array[66] → {123, 66}
 ```
 
 ---
@@ -445,9 +440,9 @@ SELECT array[2,3] <@ array[1,2,3];
 t
 ```
 
-### `array_append`
+### `array || anycompatible → array`
 
-Appends *any_compatible* to the end of the input array. 
+Appends *any_compatible* to the end of the input array. This is equal to array_append.
 
 ```bash title=Example
 array[66] || 123 → {66, 123}
@@ -456,10 +451,9 @@ array[66] || 123 → {66, 123}
 ---
 
 ### `array_cat`
+array || array → array
 
 Concatenates two arrays with the same data type. 
-
-If the one of the input arrays is a 2-dimensional array, the other array will be appended within the first array as the last element if it is the second argument. The other array will be prepended within the first array as the first element if it is the first argument.
 
 ```bash title=Example
 array[66] || array[123] → {66, 123}
@@ -468,6 +462,8 @@ array[66] || array[123] → {66, 123}
 ---
 
 ### `array_prepend`
+
+anycompatible || array → array
 
 Prepends *any_compatible* to the beginning of the input array.
 

--- a/docs/sql/functions-operators/sql-function-array.md
+++ b/docs/sql/functions-operators/sql-function-array.md
@@ -437,7 +437,7 @@ t
 
 ### `array <@ array -> boolean`
 
-This operator checks if the left array is contained by the right array
+This operator checks if the left array is contained by the right array.
 
 ```bash title=Example
 SELECT array[2,3] <@ array[1,2,3];

--- a/docs/sql/functions-operators/sql-function-array.md
+++ b/docs/sql/functions-operators/sql-function-array.md
@@ -11,7 +11,7 @@ title: Array functions and operators
 
 ### `array_append`
 
-Appends *any_compatible* to the end of the input array. The `||` operator can also be used.
+Appends *any_compatible* to the end of the input array.
 
 ```bash title=Syntax
 array_append ( array, any_compatible ) → array
@@ -25,7 +25,7 @@ array_append(array[66], 123) → {66, 123}
 
 ### `array_cat`
 
-Concatenates two arrays with the same data type. The `||` operator can also be used.
+Concatenates two arrays with the same data type.
 
 If the one of the input arrays is a 2-dimensional array, the other array will be appended within the first array as the last element if it is the second argument. The other array will be prepended within the first array as the first element if it is the first argument.
 
@@ -207,7 +207,7 @@ array_positions(array[1,2,3,4,5,6,1,2,3,4,5,6], 4) → {4, 10}
 
 ### `array_prepend`
 
-Prepends *any_compatible* to the beginning of the input array. The `||` operator can also be used.
+Prepends *any_compatible* to the beginning of the input array.
 
 ```bash title=Syntax
 array_prepend ( any_compatible, array ) → array
@@ -425,9 +425,7 @@ unnest(Array[Array[1,3,4,5],Array[2,3]]) →
 This operator checks if the left array contains all elements of the right array.
 
 ```bash title=Example
-SELECT array[1,2,3] @> array[2,3];
-------RESULT
-t
+array[1,2,3] @> array[2,3] → t
 ```
 
 ### `array <@ array -> boolean`
@@ -435,14 +433,12 @@ t
 This operator checks if the left array is contained by the right array.
 
 ```bash title=Example
-SELECT array[2,3] <@ array[1,2,3];
-------RESULT
-t
+array[2,3] <@ array[1,2,3] → t
 ```
 
 ### `array || anycompatible → array`
 
-Appends *any_compatible* to the end of the input array. This is equal to `array_append`.
+Appends *any_compatible* to the end of the input array. This operation achieves the same result as using `array_append`.
 
 ```bash title=Example
 array[66] || 123 → {66, 123}
@@ -452,7 +448,7 @@ array[66] || 123 → {66, 123}
 
 ### `array || array → array`
 
-Concatenates two arrays with the same data type. This is equal to `array_cat`.
+Concatenates two arrays with the same data type. This operation achieves the same result as using `array_cat`.
 
 ```bash title=Example
 array[66] || array[123] → {66, 123}
@@ -462,7 +458,7 @@ array[66] || array[123] → {66, 123}
 
 ### `anycompatible || array → array`
 
-Prepends *any_compatible* to the beginning of the input array. This is equal to `array_prepend`.
+Prepends *any_compatible* to the beginning of the input array. This operation achieves the same result as using `array_prepend`.
 
 ```bash title=Example
 123 || array[66] → {123, 66}

--- a/docs/sql/functions-operators/sql-function-array.md
+++ b/docs/sql/functions-operators/sql-function-array.md
@@ -442,7 +442,7 @@ t
 
 ### `array || anycompatible → array`
 
-Appends *any_compatible* to the end of the input array. This is equal to array_append.
+Appends *any_compatible* to the end of the input array. This is equal to `array_append`.
 
 ```bash title=Example
 array[66] || 123 → {66, 123}
@@ -450,10 +450,9 @@ array[66] || 123 → {66, 123}
 
 ---
 
-### `array_cat`
-array || array → array
+### `array || array → array`
 
-Concatenates two arrays with the same data type. 
+Concatenates two arrays with the same data type. This is equal to `array_cat`.
 
 ```bash title=Example
 array[66] || array[123] → {66, 123}
@@ -461,11 +460,9 @@ array[66] || array[123] → {66, 123}
 
 ---
 
-### `array_prepend`
+### `anycompatible || array → array`
 
-anycompatible || array → array
-
-Prepends *any_compatible* to the beginning of the input array.
+Prepends *any_compatible* to the beginning of the input array. This is equal to `array_prepend`.
 
 ```bash title=Example
 123 || array[66] → {123, 66}


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

1. Split the Array functions page into two sections: Array functions and Array operators.

2. In the Array operators section, add the following operators:
   - `@>` 
   - `<@`

3. For the following functions:
   - `array_append`
   - `array_cat`
   - `array_prepend`

   Add their corresponding operators to the Array operators section.

- **Related code PR**

  https://github.com/risingwavelabs/risingwave/pull/13253

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/1484
<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
