### PR TITLE
fix: misuse of timestamp vs timestamptz in get-started

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -74,7 +74,7 @@ As RisingWave is a database, you can directly create a table and insert data int
 
 ```sql
 CREATE TABLE website_visits (
-  timestamp timestamp,
+  timestamp timestamp with time zone,
   user_id varchar,
   page_id varchar,
   action varchar
@@ -114,7 +114,7 @@ You can now connect to the topic from RisingWave by running the following comman
 
 ```sql
 CREATE SOURCE IF NOT EXISTS website_visits_stream (
- timestamp timestamp,
+ timestamp timestamp with time zone,
  user_id varchar,
  page_id varchar,
  action varchar
@@ -160,11 +160,11 @@ SELECT * FROM visits_stream_mv;
 ```
 
 ```
- page_id | total_visits | unique_visitors |   last_visit_time
----------+--------------+-----------------+---------------------
- page2   |            2 |               2 | 2023-06-13 10:08:00
- page1   |            2 |               2 | 2023-06-13 10:07:00
- page3   |            1 |               1 | 2023-06-13 10:09:00
+ page_id | total_visits | unique_visitors |      last_visit_time
+---------+--------------+-----------------+---------------------------
+ page2   |            2 |               2 | 2023-06-13 10:08:00+00:00
+ page1   |            2 |               2 | 2023-06-13 10:07:00+00:00
+ page3   |            1 |               1 | 2023-06-13 10:09:00+00:00
 (3 rows)
 ```
 
@@ -187,11 +187,11 @@ SELECT * FROM visits_stream_mv;
 ```
 
 ```
- page_id | total_visits | unique_visitors |   last_visit_time   
----------+--------------+-----------------+---------------------
- page2   |            3 |               3 | 2023-06-13 10:12:00
- page3   |            3 |               3 | 2023-06-13 10:13:00
- page1   |            4 |               4 | 2023-06-13 10:14:00
+ page_id | total_visits | unique_visitors |      last_visit_time   
+---------+--------------+-----------------+---------------------------
+ page2   |            3 |               3 | 2023-06-13 10:12:00+00:00
+ page3   |            3 |               3 | 2023-06-13 10:13:00+00:00
+ page1   |            4 |               4 | 2023-06-13 10:14:00+00:00
 (3 rows)
 ```
 
@@ -207,9 +207,9 @@ Let's sink all data from `visits_stream_mv` to a Kafka topic:
 CREATE SINK sink1 FROM visits_stream_mv
 WITH (
 connector='kafka',
-type='append-only',
-force_append_only='true',
 properties.bootstrap.server='localhost:9092',
 topic='sink1'
+) FORMAT PLAIN ENCODE JSON (
+force_append_only='true',
 );
 ```

--- a/versioned_docs/version-1.2/get-started.md
+++ b/versioned_docs/version-1.2/get-started.md
@@ -53,7 +53,7 @@ As RisingWave is a database, you can directly create a table and insert data int
 
 ```sql
 CREATE TABLE website_visits (
-  timestamp timestamp,
+  timestamp timestamp with time zone,
   user_id varchar,
   page_id varchar,
   action varchar
@@ -93,7 +93,7 @@ You can now connect to the topic from RisingWave by running the following comman
 
 ```sql
 CREATE SOURCE IF NOT EXISTS website_visits_stream (
- timestamp timestamp,
+ timestamp timestamp with time zone,
  user_id varchar,
  page_id varchar,
  action varchar
@@ -139,11 +139,11 @@ SELECT * FROM visits_stream_mv;
 ```
 
 ```
- page_id | total_visits | unique_visitors |   last_visit_time
----------+--------------+-----------------+---------------------
- page2   |            2 |               2 | 2023-06-13 10:08:00
- page1   |            2 |               2 | 2023-06-13 10:07:00
- page3   |            1 |               1 | 2023-06-13 10:09:00
+ page_id | total_visits | unique_visitors |      last_visit_time
+---------+--------------+-----------------+---------------------------
+ page2   |            2 |               2 | 2023-06-13 10:08:00+00:00
+ page1   |            2 |               2 | 2023-06-13 10:07:00+00:00
+ page3   |            1 |               1 | 2023-06-13 10:09:00+00:00
 (3 rows)
 ```
 
@@ -166,11 +166,11 @@ SELECT * FROM visits_stream_mv;
 ```
 
 ```
- page_id | total_visits | unique_visitors |   last_visit_time   
----------+--------------+-----------------+---------------------
- page2   |            3 |               3 | 2023-06-13 10:12:00
- page3   |            3 |               3 | 2023-06-13 10:13:00
- page1   |            4 |               4 | 2023-06-13 10:14:00
+ page_id | total_visits | unique_visitors |      last_visit_time   
+---------+--------------+-----------------+---------------------------
+ page2   |            3 |               3 | 2023-06-13 10:12:00+00:00
+ page3   |            3 |               3 | 2023-06-13 10:13:00+00:00
+ page1   |            4 |               4 | 2023-06-13 10:14:00+00:00
 (3 rows)
 ```
 

--- a/versioned_docs/version-1.3/get-started.md
+++ b/versioned_docs/version-1.3/get-started.md
@@ -51,7 +51,7 @@ As RisingWave is a database, you can directly create a table and insert data int
 
 ```sql
 CREATE TABLE website_visits (
-  timestamp timestamp,
+  timestamp timestamp with time zone,
   user_id varchar,
   page_id varchar,
   action varchar
@@ -91,7 +91,7 @@ You can now connect to the topic from RisingWave by running the following comman
 
 ```sql
 CREATE SOURCE IF NOT EXISTS website_visits_stream (
- timestamp timestamp,
+ timestamp timestamp with time zone,
  user_id varchar,
  page_id varchar,
  action varchar
@@ -137,11 +137,11 @@ SELECT * FROM visits_stream_mv;
 ```
 
 ```
- page_id | total_visits | unique_visitors |   last_visit_time
----------+--------------+-----------------+---------------------
- page2   |            2 |               2 | 2023-06-13 10:08:00
- page1   |            2 |               2 | 2023-06-13 10:07:00
- page3   |            1 |               1 | 2023-06-13 10:09:00
+ page_id | total_visits | unique_visitors |      last_visit_time
+---------+--------------+-----------------+---------------------------
+ page2   |            2 |               2 | 2023-06-13 10:08:00+00:00
+ page1   |            2 |               2 | 2023-06-13 10:07:00+00:00
+ page3   |            1 |               1 | 2023-06-13 10:09:00+00:00
 (3 rows)
 ```
 
@@ -164,11 +164,11 @@ SELECT * FROM visits_stream_mv;
 ```
 
 ```
- page_id | total_visits | unique_visitors |   last_visit_time   
----------+--------------+-----------------+---------------------
- page2   |            3 |               3 | 2023-06-13 10:12:00
- page3   |            3 |               3 | 2023-06-13 10:13:00
- page1   |            4 |               4 | 2023-06-13 10:14:00
+ page_id | total_visits | unique_visitors |      last_visit_time   
+---------+--------------+-----------------+---------------------------
+ page2   |            3 |               3 | 2023-06-13 10:12:00+00:00
+ page3   |            3 |               3 | 2023-06-13 10:13:00+00:00
+ page1   |            4 |               4 | 2023-06-13 10:14:00+00:00
 (3 rows)
 ```
 
@@ -184,9 +184,9 @@ Let's sink all data from `visits_stream_mv` to a Kafka topic:
 CREATE SINK sink1 FROM visits_stream_mv
 WITH (
 connector='kafka',
-type='append-only',
-force_append_only='true',
 properties.bootstrap.server='localhost:9092',
 topic='sink1'
+) FORMAT PLAIN ENCODE JSON (
+force_append_only='true',
 );
 ```

--- a/versioned_docs/version-1.4/get-started.md
+++ b/versioned_docs/version-1.4/get-started.md
@@ -74,7 +74,7 @@ As RisingWave is a database, you can directly create a table and insert data int
 
 ```sql
 CREATE TABLE website_visits (
-  timestamp timestamp,
+  timestamp timestamp with time zone,
   user_id varchar,
   page_id varchar,
   action varchar
@@ -114,7 +114,7 @@ You can now connect to the topic from RisingWave by running the following comman
 
 ```sql
 CREATE SOURCE IF NOT EXISTS website_visits_stream (
- timestamp timestamp,
+ timestamp timestamp with time zone,
  user_id varchar,
  page_id varchar,
  action varchar
@@ -160,11 +160,11 @@ SELECT * FROM visits_stream_mv;
 ```
 
 ```
- page_id | total_visits | unique_visitors |   last_visit_time
----------+--------------+-----------------+---------------------
- page2   |            2 |               2 | 2023-06-13 10:08:00
- page1   |            2 |               2 | 2023-06-13 10:07:00
- page3   |            1 |               1 | 2023-06-13 10:09:00
+ page_id | total_visits | unique_visitors |      last_visit_time
+---------+--------------+-----------------+---------------------------
+ page2   |            2 |               2 | 2023-06-13 10:08:00+00:00
+ page1   |            2 |               2 | 2023-06-13 10:07:00+00:00
+ page3   |            1 |               1 | 2023-06-13 10:09:00+00:00
 (3 rows)
 ```
 
@@ -187,11 +187,11 @@ SELECT * FROM visits_stream_mv;
 ```
 
 ```
- page_id | total_visits | unique_visitors |   last_visit_time   
----------+--------------+-----------------+---------------------
- page2   |            3 |               3 | 2023-06-13 10:12:00
- page3   |            3 |               3 | 2023-06-13 10:13:00
- page1   |            4 |               4 | 2023-06-13 10:14:00
+ page_id | total_visits | unique_visitors |      last_visit_time   
+---------+--------------+-----------------+---------------------------
+ page2   |            3 |               3 | 2023-06-13 10:12:00+00:00
+ page3   |            3 |               3 | 2023-06-13 10:13:00+00:00
+ page1   |            4 |               4 | 2023-06-13 10:14:00+00:00
 (3 rows)
 ```
 
@@ -207,9 +207,9 @@ Let's sink all data from `visits_stream_mv` to a Kafka topic:
 CREATE SINK sink1 FROM visits_stream_mv
 WITH (
 connector='kafka',
-type='append-only',
-force_append_only='true',
 properties.bootstrap.server='localhost:9092',
 topic='sink1'
+) FORMAT PLAIN ENCODE JSON (
+force_append_only='true',
 );
 ```


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - https://risingwave-community.slack.com/archives/C03BW71523T/p1697654385120419?thread_ts=1697647468.388009&cid=C03BW71523T

- **Notes**

  - [ Include any supplementary context or references here. ]

- **Related code PR**

  - [ Provide a link to the relevant code PR here, if applicable. ]

- **Related doc issue**
  
  Resolves [ Provide a link to the relevant doc issue here, if applicable. ]

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
