### PR TITLE
Add timestamptz to load generator

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -137,6 +137,7 @@ multibyte
 protobuf
 Protobuf
 timestamptz
+timestamptzs
 unary
 zstd
 http

--- a/docs/ingest/ingest-from-datagen.md
+++ b/docs/ingest/ingest-from-datagen.md
@@ -100,7 +100,7 @@ WITH (
 
 The following table shows the data types that can be generated for each load generator type.
 
-|Generator &#92; Data|Number|Timestamp|Timestampz|Varchar|Struct|Array|
+|Generator &#92; Data|Number|Timestamp|Timestamptz|Varchar|Struct|Array|
 |---|---|---|---|---|---|---|
 |**Sequence**|✓|✕|✕|✕|✓|✓|
 |**Random**|✓|✓|✓|✓|✓|✓|
@@ -142,34 +142,19 @@ Specify the following fields for every column in the source you are creating.
 </Tabs>
 
 </TabItem>
-<TabItem value="timestamp" label="Timestamp">
+<TabItem value="timestamp/timestamptz" label="Timestamp and Timestamptz">
 
-The random timestamp generator produces random timestamp earlier than the current date and time or the source creation time.
-
-Specify the following fields for every column in the source you are creating.
-
-|`column_parameter`|Description|Value|Required?|
-|---|---|---|---|
-|`kind`|Generator type|Set to `random`.|False<br/>Default: `random`|
-|`max_past`|Specify the maximum deviation from the baseline timestamp to determine the earliest possible timestamp can be generated. |An [interval](/sql/sql-data-types.md)<br/>Example: `2h 37min`|False<br/>Default: `1 day`|
-|`max_past_mode`|Specify the baseline timestamp. <br/> The range for generated timestamps is [base time - `max_past` , base time]|`absolute` — The base time is set to the execution time of the generator. The base time is fixed for each generation.<br />`relative` —  The base time is the system time obtained each time a new record is generated.|False<br/>Default: `absolute`|
-|`basetime`|If set, the generator will ignore `max_past_mode` and use the specified time as the base time.|A [date and time string](https://docs.rs/chrono/latest/chrono/struct.DateTime.html#method.parse_from_rfc3339)<br/>Example: `2023-04-01T16:39:57-08:00`|False<br/>Default: generator execution time|
-|`seed`|A seed number that initializes the random load generator. The sequence of the generated timestamps is determined by the seed value. If given the same seed number, the generator will produce the same sequence of timestamps.|A positive integer<br/>Example: `3`|False<br/>If not specified, a fixed sequence of timestamps will be generated (if the system time is constant).|
-
-</TabItem>
-<TabItem value="timestampz" label="Timestampz">
-
-The random timestampz generator produces random timestamps with time zone earlier than the current date and time or the source creation time.
+The random timestamp and timestamptz generator produces random timestamps and timestamps with time zone, respectively, earlier than the current date and time or the source creation time.
 
 Specify the following fields for every column in the source you are creating.
 
 |`column_parameter`|Description|Value|Required?|
 |---|---|---|---|
 |`kind`|Generator type|Set to `random`.|False<br/>Default: `random`|
-|`max_past`|Specify the maximum deviation from the baseline timestampz to determine the earliest possible timestampz that can be generated. |An [interval](/sql/sql-data-types.md)<br/>Example: `2h 37min`|False<br/>Default: `1 day`|
-|`max_past_mode`|Specify the baseline timestampz. <br/> The range for generated timestampzs is [base time - `max_past` , base time]|`absolute` — The base time is set to the execution time of the generator. The base time is fixed for each generation.<br />`relative` —  The base time is the system time obtained each time a new record is generated.|False<br/>Default: `absolute`|
+|`max_past`|Specify the maximum deviation from the baseline timestamp or timestamptz to determine the earliest possible timestamp or timestamptz that can be generated. |An [interval](/sql/sql-data-types.md)<br/>Example: `2h 37min`|False<br/>Default: `1 day`|
+|`max_past_mode`|Specify the baseline timestamp or timestamptz. <br/> The range for generated timestamps or timestamptzs is [base time - `max_past` , base time]|`absolute` — The base time is set to the execution time of the generator. The base time is fixed for each generation.<br />`relative` —  The base time is the system time obtained each time a new record is generated.|False<br/>Default: `absolute`|
 |`basetime`|If set, the generator will ignore `max_past_mode` and use the specified time as the base time.|A [date and time string](https://docs.rs/chrono/latest/chrono/struct.DateTime.html#method.parse_from_rfc3339)<br/>Example: `2023-04-01T16:39:57-08:00`|False<br/>Default: generator execution time|
-|`seed`|A seed number that initializes the random load generator. The sequence of the generated timestampzs is determined by the seed value. If given the same seed number, the generator will produce the same sequence of timestampzs.|A positive integer<br/>Example: `3`|False<br/>If not specified, a fixed sequence of timestampzs will be generated (if the system time is constant).|
+|`seed`|A seed number that initializes the random load generator. The sequence of the generated timestamps or timestamptzs is determined by the seed value. If given the same seed number, the generator will produce the same sequence of timestamps or timestamptzs.|A positive integer<br/>Example: `3`|False<br/>If not specified, a fixed sequence of timestamps or timestamptzs will be generated (if the system time is constant).|
 
 </TabItem>
 <TabItem value="varchar" label="Varchar">
@@ -268,7 +253,7 @@ The following statement creates a source `s1` with five columns:
 - `c1` — Random strings with each consists of 16 characters
 
 ```sql
-CREATE TABLE s1 (i1 int [], v1 struct<v2 int, v3 double>, t1 timestamp, z1 timestampz, c1 varchar) 
+CREATE TABLE s1 (i1 int [], v1 struct<v2 int, v3 double>, t1 timestamp, z1 timestamptz, c1 varchar) 
 WITH (
      connector = 'datagen',
   

--- a/docs/ingest/ingest-from-datagen.md
+++ b/docs/ingest/ingest-from-datagen.md
@@ -100,10 +100,10 @@ WITH (
 
 The following table shows the data types that can be generated for each load generator type.
 
-|Generator &#92; Data|Number|Timestamp|Varchar|Struct|Array|
-|---|---|---|---|---|---|
-|**Sequence**|✓|✕|✕|✓|✓|
-|**Random**|✓|✓|✓|✓|✓|
+|Generator &#92; Data|Number|Timestamp|Timestampz|Varchar|Struct|Array|
+|---|---|---|---|---|---|---|
+|**Sequence**|✓|✕|✕|✕|✓|✓|
+|**Random**|✓|✓|✓|✓|✓|✓|
 
 Select the type of data to be generated.
 
@@ -155,6 +155,21 @@ Specify the following fields for every column in the source you are creating.
 |`max_past_mode`|Specify the baseline timestamp. <br/> The range for generated timestamps is [base time - `max_past` , base time]|`absolute` — The base time is set to the execution time of the generator. The base time is fixed for each generation.<br />`relative` —  The base time is the system time obtained each time a new record is generated.|False<br/>Default: `absolute`|
 |`basetime`|If set, the generator will ignore `max_past_mode` and use the specified time as the base time.|A [date and time string](https://docs.rs/chrono/latest/chrono/struct.DateTime.html#method.parse_from_rfc3339)<br/>Example: `2023-04-01T16:39:57-08:00`|False<br/>Default: generator execution time|
 |`seed`|A seed number that initializes the random load generator. The sequence of the generated timestamps is determined by the seed value. If given the same seed number, the generator will produce the same sequence of timestamps.|A positive integer<br/>Example: `3`|False<br/>If not specified, a fixed sequence of timestamps will be generated (if the system time is constant).|
+
+</TabItem>
+<TabItem value="timestampz" label="Timestampz">
+
+The random timestampz generator produces random timestamps with time zone earlier than the current date and time or the source creation time.
+
+Specify the following fields for every column in the source you are creating.
+
+|`column_parameter`|Description|Value|Required?|
+|---|---|---|---|
+|`kind`|Generator type|Set to `random`.|False<br/>Default: `random`|
+|`max_past`|Specify the maximum deviation from the baseline timestampz to determine the earliest possible timestampz that can be generated. |An [interval](/sql/sql-data-types.md)<br/>Example: `2h 37min`|False<br/>Default: `1 day`|
+|`max_past_mode`|Specify the baseline timestampz. <br/> The range for generated timestampzs is [base time - `max_past` , base time]|`absolute` — The base time is set to the execution time of the generator. The base time is fixed for each generation.<br />`relative` —  The base time is the system time obtained each time a new record is generated.|False<br/>Default: `absolute`|
+|`basetime`|If set, the generator will ignore `max_past_mode` and use the specified time as the base time.|A [date and time string](https://docs.rs/chrono/latest/chrono/struct.DateTime.html#method.parse_from_rfc3339)<br/>Example: `2023-04-01T16:39:57-08:00`|False<br/>Default: generator execution time|
+|`seed`|A seed number that initializes the random load generator. The sequence of the generated timestampzs is determined by the seed value. If given the same seed number, the generator will produce the same sequence of timestampzs.|A positive integer<br/>Example: `3`|False<br/>If not specified, a fixed sequence of timestampzs will be generated (if the system time is constant).|
 
 </TabItem>
 <TabItem value="varchar" label="Varchar">
@@ -244,15 +259,16 @@ WITH (
 
 Here is an example of connecting RisingWave to the built-in load generator.
 
-The following statement creates a source `s1` with four columns:
+The following statement creates a source `s1` with five columns:
 
 - `i1` — An array of three integers starting from 1 and incrementing by 1
 - `v1` — Structs that contain random integers `v2` ranging from -10 to 10 and random floating-point numbers `v3` ranging from 15 to 55
-- `t1` — Random timestamps from as early as 10 days prior to the generator execution time
+- `t1` — Random timestamps from as early as 2 hours as 37 minutes prior to the generator execution time
+- `z1` - Random timestamps with timezones from as early as 2 hours as 37 minutes prior to the generator execution time
 - `c1` — Random strings with each consists of 16 characters
 
 ```sql
-CREATE TABLE s1 (i1 int [], v1 struct<v2 int, v3 double>, t1 timestamp, c1 varchar) 
+CREATE TABLE s1 (i1 int [], v1 struct<v2 int, v3 double>, t1 timestamp, z1 timestampz, c1 varchar) 
 WITH (
      connector = 'datagen',
   
@@ -271,9 +287,15 @@ WITH (
      fields.v1.v3.seed = '1',
   
      fields.t1.kind = 'random',
-     fields.t1.max_past = '10 day',
+     fields.t1.max_past = '2h 37min',
+     fields.t1.max_past_mode = 'relative',
      fields.t1.seed = '3',
-  
+
+     fields.z1.kind = 'random',
+     fields.z1.max_past = '2h 37min',
+     fields.z1.max_past_mode = 'relative',
+     fields.z1.seed = '3'
+
      fields.c1.kind = 'random',
      fields.c1.length = '16',
      fields.c1.seed = '3',
@@ -289,28 +311,29 @@ SELECT * FROM s1 ORDER BY i1 LIMIT 20;
 ```
 
 ```
-     i1     |            v1            |             t1             |        c1        
-------------+--------------------------+----------------------------+------------------
- {1,2,3}    | (7,53.96978949033611)    | 2023-02-01 17:42:28.339901 | pGWJLsbmPJZZWpBe
- {4,5,6}    | (5,44.24453663454818)    | 2023-01-30 17:11:59.566901 | FT7BRdifYMrRgIyI
- {7,8,9}    | (3,18.808367835800485)   | 2023-01-26 18:39:41.516901 | 0zsMbNLxQh9yYtHh
- {10,11,12} | (-4,26.893033246334525)  | 2023-01-26 09:05:27.092901 | zujxzBql3QHxENyy
- {13,14,15} | (-3,28.68505963291612)   | 2023-01-30 14:51:26.535901 | aBJTDJpinRv8mLvQ
- {16,17,18} | (4,36.32012760913261)    | 2023-01-30 08:13:46.507901 | HVur4zU3hQFgVh74
- {19,20,21} | (-10,16.212694434604053) | 2023-01-30 06:26:51.796901 | LVLAhd1pQvhXVL8p
- {22,23,24} | (-8,28.388082274426225)  | 2023-01-27 02:53:09.042901 | siFqrkdlCnNZqAUT
- {25,26,27} | (2,40.86763449564268)    | 2023-01-30 22:19:39.033901 | ORjwy3oMNbl1Yi6X
- {28,29,30} | (3,29.179236922708526)   | 2023-02-01 09:08:49.935901 | YIVLnWxHyfsiPHQo
- {31,32,33} | (6,26.03842827701958)    | 2023-01-27 05:21:08.179901 | lpzCxwpoJp9njIAa
- {34,35,36} | (-2,20.2351457847852)    | 2023-01-26 00:47:07.622901 | oW8xmndvmXMRp1Rc
- {37,38,39} | (2,36.51138960926262)    | 2023-01-27 15:44:36.250901 | 0m1Qxn96Xeq42H3Z
- {40,41,42} | (0,34.2997487580596)     | 2023-01-28 01:56:15.457901 | 1jT3TnEEj56YNa7w
- {43,44,45} | (7,39.13577932700749)    | 2023-01-28 07:29:23.068901 | linRToOjph0WlJrd
- {46,47,48} | (7,37.43674199879566)    | 2023-01-28 20:45:34.511901 | beql98l3IIkjomTl
- {49,50,51} | (1,41.62099792202798)    | 2023-01-29 11:16:58.485901 | xHbIYlJismRlIKFw
- {52,53,54} | (9,49.240259695092895)   | 2023-01-23 21:22:26.322901 | TDYNZsSNYMpOpZgC
- {55,56,57} | (6,54.64984398127376)    | 2023-01-27 00:49:55.529901 | jqPQM3oyA2lOXLcn
- {58,59,60} | (-4,54.197350082045176)  | 2023-01-25 03:06:59.474901 | 72cIOHPb7DE8FTme
+     i1     |            v1            |             t1             |                z1                |        c1        
+------------+--------------------------+----------------------------+----------------------------------+------------------
+ {1,2,3}    | (7,53.96978949033611)    | 2023-11-28 13:35:04.967040 | 2023-11-28 21:35:04.967330+00:00 | pGWJLsbmPJZZWpBe
+ {4,5,6}    | (5,44.24453663454818)    | 2023-11-28 14:13:15.264457 | 2023-11-28 22:13:15.264481+00:00 | FT7BRdifYMrRgIyI
+ {7,8,9}    | (3,18.808367835800485)   | 2023-11-28 15:12:41.918935 | 2023-11-28 23:12:41.919590+00:00 | 0zsMbNLxQh9yYtHh
+ {10,11,12} | (-4,26.893033246334525)  | 2023-11-28 14:55:43.193883 | 2023-11-28 22:55:43.193917+00:00 | zujxzBql3QHxENyy
+ {13,14,15} | (-3,28.68505963291612)   | 2023-11-28 13:35:05.967253 | 2023-11-28 21:35:05.967520+00:00 | aBJTDJpinRv8mLvQ
+ {16,17,18} | (4,36.32012760913261)    | 2023-11-28 14:13:16.264624 | 2023-11-28 22:13:16.264646+00:00 | HVur4zU3hQFgVh74
+ {19,20,21} | (-10,16.212694434604053) | 2023-11-28 15:12:42.919339 | 2023-11-28 23:12:42.919465+00:00 | LVLAhd1pQvhXVL8p
+ {22,23,24} | (-8,28.388082274426225)  | 2023-11-28 14:55:44.193726 | 2023-11-28 22:55:44.193787+00:00 | siFqrkdlCnNZqAUT
+ {25,26,27} | (2,40.86763449564268)    | 2023-11-28 15:19:51.600898 | 2023-11-28 23:19:51.600977+00:00 | ORjwy3oMNbl1Yi6X
+ {28,29,30} | (3,29.179236922708526)   | 2023-11-28 15:27:49.755084 | 2023-11-28 23:27:49.755105+00:00 | YIVLnWxHyfsiPHQo
+ {31,32,33} | (6,26.03842827701958)    | 2023-11-28 16:07:02.012019 | 2023-11-29 00:07:02.012133+00:00 | lpzCxwpoJp9njIAa
+ {34,35,36} | (-2,20.2351457847852)    | 2023-11-28 14:23:37.167393 | 2023-11-28 22:23:37.167453+00:00 | oW8xmndvmXMRp1Rc
+ {37,38,39} | (2,36.51138960926262)    | 2023-11-28 15:19:52.600699 | 2023-11-28 23:19:52.600741+00:00 | 0m1Qxn96Xeq42H3Z
+ {40,41,42} | (0,34.2997487580596)     | 2023-11-28 15:27:50.754878 | 2023-11-28 23:27:50.754899+00:00 | 1jT3TnEEj56YNa7w
+ {43,44,45} | (7,39.13577932700749)    | 2023-11-28 16:07:03.011837 | 2023-11-29 00:07:03.011905+00:00 | linRToOjph0WlJrd
+ {46,47,48} | (7,37.43674199879566)    | 2023-11-28 14:23:38.167161 | 2023-11-28 22:23:38.167271+00:00 | beql98l3IIkjomTl
+ {49,50,51} | (1,41.62099792202798)    | 2023-11-28 15:24:46.803776 | 2023-11-28 23:24:46.803844+00:00 | xHbIYlJismRlIKFw
+ {52,53,54} | (9,49.240259695092895)   | 2023-11-28 15:39:22.752067 | 2023-11-28 23:39:22.752115+00:00 | TDYNZsSNYMpOpZgC
+ {55,56,57} | (6,54.64984398127376)    | 2023-11-28 13:32:15.049957 | 2023-11-28 21:32:15.050089+00:00 | jqPQM3oyA2lOXLcn
+ {58,59,60} | (-4,54.197350082045176)  | 2023-11-28 14:07:53.278392 | 2023-11-28 22:07:53.278457+00:00 | 72cIOHPb7DE8FTme
 (20 rows)
 ...
 ```
+


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - Updated load generator to include timestampz data type under WITH options. 

- **Notes**

  - [ Include any supplementary context or references here. ]

- **Related code PR**

  - https://github.com/risingwavelabs/risingwave-docs/issues/1532

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/1532

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
