### PR TITLE
Update MySQL CDC Source Type Mapping

### DIFF
--- a/docs/guides/ingest-from-mysql-cdc.md
+++ b/docs/guides/ingest-from-mysql-cdc.md
@@ -259,7 +259,7 @@ RisingWave data types marked with an asterisk indicates that while there is no c
 | TIMESTAMP[(M)] | TIMESTAMPTZ |
 | DATE | DATE |
 | TIME[(M)] | TIME |
-| DATETIME[(fsp)] Optional fractional seconds precision (fsp: 0-6). Default precision is 0 when omitted.| TIMESTAMP |
+| DATETIME[(fsp)] <br /> Optional fractional seconds precision (fsp: 0-6). If omitted, the default precision is 0.| TIMESTAMP |
 | NUMERIC[(M[,D])] | NUMERIC |
 | DECIMAL[(M[,D])] | NUMERIC |
 | GEOMETRY, LINESTRING, POLYGON, <br />MULTIPOINT, MULTILINESTRING, <br />MULTIPOLYGON, GEOMETRYCOLLECTION | STRUCT |

--- a/docs/guides/ingest-from-mysql-cdc.md
+++ b/docs/guides/ingest-from-mysql-cdc.md
@@ -268,7 +268,7 @@ Please be aware that the range of specific values varies among MySQL types and R
 
 | MySQL type | RisingWave type | MySQL range | RisingWave range |
 | --- | --- | --- | --- |
-| TIME | DATE | `-838:59:59.000000` to `838:59:59.000000` | `00:00:00` to `23:59:59` |
+| TIME | TIME | `-838:59:59.000000` to `838:59:59.000000` | `00:00:00` to `23:59:59` |
 | DATE | DATE | `1000-01-01` to `9999-12-31` | `0001-01-01` to `9999-12-31` |
 | DATETIME | TIMESTAMP | `1000-01-01 00:00:00.000000` to `9999-12-31 23:59:59.49999` | `1973-03-03 09:46:40` to `5138-11-16 09:46:40` |
 | TIMESTAMP | TIMESTAMPTZ | `1970-01-01 00:00:01.000000` to `2038-01-19 03:14:07.499999` | `0001-01-01 00:00:00` to `9999-12-31 23:59:59` |

--- a/docs/guides/ingest-from-mysql-cdc.md
+++ b/docs/guides/ingest-from-mysql-cdc.md
@@ -256,11 +256,19 @@ RisingWave data types marked with an asterisk indicates that while there is no c
 | ENUM | CHARACTER VARYING* |
 | SET | No support |
 | YEAR[(2\|4)] | INTEGER |
-| TIMESTAMP[(M)] | TIMESTAMP WITH TIME ZONE |
+| TIMESTAMP[(M)] | TIMESTAMPTZ |
 | DATE | DATE |
-| TIME[(M)] | TIME WITHOUT TIME ZONE |
-| DATETIME, DATETIME(0), DATETIME(1), DATETIME(2), DATETIME(3) | TIMESTAMP WITHOUT TIME ZONE |
-| DATETIME(4), DATETIME(5), DATETIME(6) | TIMESTAMP WITHOUT TIME ZONE |
+| TIME[(M)] | TIME |
+| DATETIME[(fsp)] Optional fractional seconds precision (fsp: 0-6). Default precision is 0 when omitted.| TIMESTAMP |
 | NUMERIC[(M[,D])] | NUMERIC |
 | DECIMAL[(M[,D])] | NUMERIC |
 | GEOMETRY, LINESTRING, POLYGON, <br />MULTIPOINT, MULTILINESTRING, <br />MULTIPOLYGON, GEOMETRYCOLLECTION | STRUCT |
+
+Please be aware that the range of specific values varies among MySQL types and RisingWave types. Refer to the table below for detailed information.
+
+| MySQL type | RisingWave type | MySQL range | RisingWave range |
+| --- | --- | --- | --- |
+| TIME | DATE | `-838:59:59.000000` to `838:59:59.000000` | `00:00:00` to `23:59:59` |
+| DATE | DATE | `1000-01-01` to `9999-12-31` | `0001-01-01` to `9999-12-31` |
+| DATETIME | TIMESTAMP | `1000-01-01 00:00:00.000000` to `9999-12-31 23:59:59.49999` | `1973-03-03 09:46:40` to `5138-11-16 09:46:40` |
+| TIMESTAMP | TIMESTAMPTZ | `1970-01-01 00:00:01.000000` to `2038-01-19 03:14:07.499999` | `0001-01-01 00:00:00` to `9999-12-31 23:59:59` |


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

1.  Add a new table to specify the different ranges of data types supported by MySQL and RisingWave.

2. For RisingWave type column of Data type mapping table, update the following names:
    - `TIMESTAMP WITH TIME ZONE` --> `TIMESTAMPTZ`
    - `TIME WITHOUT TIME ZONE` --> `TIME`
    - `TIMESTAMP WITHOUT TIME ZONE` --> `TIMESTAMP`

3.  For MySQL type column of Data type mapping table, merge the original two lines of `DATETIME` into one line, and clarify the value range of `fsp`.



- **Related code PR**

     https://github.com/risingwavelabs/risingwave/pull/13546

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/1548

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
