### PR TITLE
1569-document-deprecate-nologinlogin-options-in-create-user

### DIFF
--- a/docs/sql/commands/sql-create-user.md
+++ b/docs/sql/commands/sql-create-user.md
@@ -28,8 +28,6 @@ If you do not want password authentication for the user, omit the PASSWORD optio
 | `NOCREATEDB`| Denies the user the permission to create databases. `NOCREATEDB` is the default value.|
 | `CREATEUSER`| Grants the user the permission to create new users and/or alter and drop existing users. `NOCREATEUSER` is the default value. |
 | `NOCREATEUSER` | Denies the user the ability to create new users and/or alter and drop existing users. `NOCREATEUSER` is the default value. |
-| `LOGIN` | Grants the user the ability to log in when establishing connection with RisingWave. `LOGIN` is the default value. |
-| `NOLOGIN` | Denies the user the ability to log in when establishing connection with RisingWave. `LOGIN` is the default value. |
 
 ## Examples
 


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - [ Delete the following two rows in create user: ]
  
LOGIN | Grants the user the ability to log in when establishing connection with RisingWave. LOGIN is the default value.
-- | --
NOLOGIN | Denies the user the ability to log in when establishing connection with RisingWave. LOGIN is the default value.



- **Notes**

  - [ Include any supplementary context or references here. ]

- **Related code PR**

  - [ https://github.com/risingwavelabs/risingwave/issues/13522 ]

- **Related doc issue**
  
  Resolves [ https://github.com/risingwavelabs/risingwave-docs/issues/1569#event-11092054173 ]

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
