### PR TITLE
Update redis-sink data_encode notes

### DIFF
--- a/docs/guides/sink-to-redis.md
+++ b/docs/guides/sink-to-redis.md
@@ -44,7 +44,7 @@ FORMAT data_format ENCODE data_encode [ (
 | Field | Notes |
 | --------------- | ---------------------------------------------------------------------- |
 |data_format| Data format. Allowed formats:<ul><li> `PLAIN`: Output data with insert operations.</li><li> `UPSERT`: Output data as a changelog stream. </li></ul>|
-|data_encode| Data encode. Supported encode:  <ul><li>`JSON`:<ul><li>`date`: number of days since CE.</li></ul><ul><li>`interval`: `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S` format string.</li></ul><ul><li>`time without time zone`: number of milliseconds past the last midnight.</li></ul><ul><li>`timestamp`: number of milliseconds since Epoch.</li></ul></li><li>`TEMPLATE`: convert to the string specified by `redis_key_format`/`redis_value_format`.</li></ul> |
+|data_encode| Data encoding. Supported encodings:  <ul><li>`JSON`:<ul><li>`date`: number of days since the Common Era (CE).</li></ul><ul><li>`interval`: `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S` format string.</li></ul><ul><li>`time without time zone`: number of milliseconds past the last midnight.</li></ul><ul><li>`timestamp`: number of milliseconds since the Epoch.</li></ul></li><li>`TEMPLATE`: converts data to the string specified by `redis_key_format`/`redis_value_format`.</li></ul> |
 |force_append_only| If `true`, forces the sink to be `PLAIN` (also known as `append-only`), even if it cannot be.|
 |redis_key_format| Required if `data_encode` is `TEMPLATE`. Specify the format for the key as a string. |
 |redis_value_format| Required if `data_encode` is `TEMPLATE`. Specify the format for the value as a string. |

--- a/docs/guides/sink-to-redis.md
+++ b/docs/guides/sink-to-redis.md
@@ -7,7 +7,7 @@
 
 This guide describes how to sink data from RisingWave to Redis.
 
-[Redis](https://redis.io) is an open-source, in-memory data structure store, often referred to as a data structure server. RisingWave sinks data to Redis in the form of strings storing key-value pairs in the specified format (`JSON` or `TEMPLATE`), so a primary key must always be provided. 
+[Redis](https://redis.io) is an open-source, in-memory data structure store, often referred to as a data structure server. RisingWave sinks data to Redis in the form of strings storing key-value pairs in the specified format (`JSON` or `TEMPLATE`), so a primary key must always be provided.
 
 You can test out this process on your own device by using the `redis-sink` demo in the [`integration_test directory`](https://github.com/risingwavelabs/risingwave/tree/main/integration_tests) of the RisingWave repository.
 
@@ -39,12 +39,12 @@ FORMAT data_format ENCODE data_encode [ (
 |redis.url | Required. The address of the Redis database. |
 |primary_key| Required. The primary keys of the sink. If necessary, use ',' to delimit the primary key columns. |
 
-## Sink parameters 
+## Sink parameters
 
 | Field | Notes |
 | --------------- | ---------------------------------------------------------------------- |
 |data_format| Data format. Allowed formats:<ul><li> `PLAIN`: Output data with insert operations.</li><li> `UPSERT`: Output data as a changelog stream. </li></ul>|
-|data_encode| Data encode. Supported encode: `JSON`, `TEMPLATE`. |
+|data_encode| Data encode. Supported encode:  <ul><li>`JSON`:<ul><li>`date`: number of days since CE.</li></ul><ul><li>`interval`: `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S` format string.</li></ul><ul><li>`time without time zone`: number of milliseconds past the last midnight.</li></ul><ul><li>`timestamp`: number of milliseconds since Epoch.</li></ul><ul><li>`timestamptz`: `yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'` format string.</li></ul></li><li>`TEMPLATE`: convert to the string specified by `redis_key_format`/`redis_value_format`.</li></ul> |
 |force_append_only| If `true`, forces the sink to be `PLAIN` (also known as `append-only`), even if it cannot be.|
 |redis_key_format| Required if `data_encode` is `TEMPLATE`. Specify the format for the key as a string. |
 |redis_value_format| Required if `data_encode` is `TEMPLATE`. Specify the format for the value as a string. |
@@ -60,7 +60,7 @@ SELECT
     target_id,
     event_timestamp
 FROM
-    source_1; 
+    source_1;
 ```
 
 We can sink data from `bhv_mv` to Redis by creating a sink. Here, `data_encode` is `JSON`.

--- a/docs/guides/sink-to-redis.md
+++ b/docs/guides/sink-to-redis.md
@@ -44,7 +44,7 @@ FORMAT data_format ENCODE data_encode [ (
 | Field | Notes |
 | --------------- | ---------------------------------------------------------------------- |
 |data_format| Data format. Allowed formats:<ul><li> `PLAIN`: Output data with insert operations.</li><li> `UPSERT`: Output data as a changelog stream. </li></ul>|
-|data_encode| Data encode. Supported encode:  <ul><li>`JSON`:<ul><li>`date`: number of days since CE.</li></ul><ul><li>`interval`: `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S` format string.</li></ul><ul><li>`time without time zone`: number of milliseconds past the last midnight.</li></ul><ul><li>`timestamp`: number of milliseconds since Epoch.</li></ul><ul><li>`timestamptz`: `yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'` format string.</li></ul></li><li>`TEMPLATE`: convert to the string specified by `redis_key_format`/`redis_value_format`.</li></ul> |
+|data_encode| Data encode. Supported encode:  <ul><li>`JSON`:<ul><li>`date`: number of days since CE.</li></ul><ul><li>`interval`: `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S` format string.</li></ul><ul><li>`time without time zone`: number of milliseconds past the last midnight.</li></ul><ul><li>`timestamp`: number of milliseconds since Epoch.</li></ul></li><li>`TEMPLATE`: convert to the string specified by `redis_key_format`/`redis_value_format`.</li></ul> |
 |force_append_only| If `true`, forces the sink to be `PLAIN` (also known as `append-only`), even if it cannot be.|
 |redis_key_format| Required if `data_encode` is `TEMPLATE`. Specify the format for the key as a string. |
 |redis_value_format| Required if `data_encode` is `TEMPLATE`. Specify the format for the value as a string. |


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**
Update redis-sink data_encode notes.

| Field | Notes |
| --------------- | ---------------------------------------------------------------------- |
|data_encode| Data encode. Supported encode:<ul><li>`JSON`:<ul><li>`date`: number of days since CE.</li></ul><ul><li>`interval`: `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S` format string.</li></ul><ul><li>`time without time zone`: number of milliseconds past the last midnight.</li></ul><ul><li>`timestamp`: number of milliseconds since Epoch.</li></ul></li><li>`TEMPLATE`: convert to the string specified by `redis_key_format`/`redis_value_format`.</li></ul>|


- **Related code PR**

  - [ Provide a link to the relevant code PR here, if applicable. ]
 
- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/1605


<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

https://pr-1607.d2fbku9n2b6wde.amplifyapp.com/docs/dev/sink-to-redis/#sink-parameters

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
