### PR TITLE
 Add data type mapping between RW and ClickHouse

### DIFF
--- a/docs/guides/sink-to-clickhouse.md
+++ b/docs/guides/sink-to-clickhouse.md
@@ -170,14 +170,15 @@ WITH (
     clickhouse.table='demo_test'
 );
 ```
+
 ## Data type mapping
 
 |RisingWave Data Type  | ClickHouse Data Type |
 |--------------------- |--------------------- |
 |bool                  | Bool                 |
-|smallint              | UInt16/Int16         |
-|int                   | UInt32/Int32         |
-|bigint                | UInt64/Int64         |
+|smallint              | UInt16 or Int16      |
+|int                   | UInt32 or Int32      |
+|bigint                | UInt64 or Int64      |
 |real(float32)         | Float32              |
 |float(float64)        | Float64              |
 |decimal               | Decimal              |
@@ -186,4 +187,10 @@ WITH (
 |timestamptz           | DateTime64           |
 |struct                | Nested               |
 |list                  | Array                |
-|serial                | UInt64/Int64         |
+|serial                | UInt64 or Int64      |
+
+:::note
+
+In ClickHouse, the `Nested` data type doesn't support multiple levels of nesting. Therefore, when sinking RisingWave's `struct` data to ClickHouse, you need to flatten or restructure the nested data to align with ClickHouse's requirement.
+
+:::

--- a/docs/guides/sink-to-clickhouse.md
+++ b/docs/guides/sink-to-clickhouse.md
@@ -172,11 +172,11 @@ WITH (
 ```
 ## Data type mapping
 
-|RisingWave Data Type | ClickHouse Data Type|
-|----------------------|----------------------|
+|RisingWave Data Type  | ClickHouse Data Type |
+|--------------------- |--------------------- |
 |bool                  | Bool                 |
 |smallint              | UInt16/Int16         |
-|integer               | UInt32/Int32         |
+|int                   | UInt32/Int32         |
 |bigint                | UInt64/Int64         |
 |real(float32)         | Float32              |
 |float(float64)        | Float64              |

--- a/docs/guides/sink-to-clickhouse.md
+++ b/docs/guides/sink-to-clickhouse.md
@@ -170,3 +170,20 @@ WITH (
     clickhouse.table='demo_test'
 );
 ```
+## Data type mapping
+
+|RisingWave Data Type | ClickHouse Data Type|
+|-----|-----|
+|bool | bool |
+|smallint | UInt16/Int16 |
+|integer |UInt32/Int32|
+|bigint |UInt64/Int64|
+|real(float32) |Float32|
+|float(float64)|Float64|
+|decimal |Decimal|
+|date |Date32|
+|varchar |String|
+|timestamptz|DateTime64|
+|struct | Nested|
+|list |Array |
+|serial| UInt64/Int64|

--- a/docs/guides/sink-to-clickhouse.md
+++ b/docs/guides/sink-to-clickhouse.md
@@ -173,17 +173,17 @@ WITH (
 ## Data type mapping
 
 |RisingWave Data Type | ClickHouse Data Type|
-|-----|-----|
-|bool | bool |
-|smallint | UInt16/Int16 |
-|integer |UInt32/Int32|
-|bigint |UInt64/Int64|
-|real(float32) |Float32|
-|float(float64)|Float64|
-|decimal |Decimal|
-|date |Date32|
-|varchar |String|
-|timestamptz|DateTime64|
-|struct | Nested|
-|list |Array |
-|serial| UInt64/Int64|
+|----------------------|----------------------|
+|bool                  | Bool                 |
+|smallint              | UInt16/Int16         |
+|integer               | UInt32/Int32         |
+|bigint                | UInt64/Int64         |
+|real(float32)         | Float32              |
+|float(float64)        | Float64              |
+|decimal               | Decimal              |
+|date                  | Date32               |
+|varchar               | String               |
+|timestamptz           | DateTime64           |
+|struct                | Nested               |
+|list                  | Array                |
+|serial                | UInt64/Int64         |


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  -  Add data type mapping table between RisingWave and ClickHouse

- **Related code PR**
https://github.com/risingwavelabs/risingwave/pull/13672

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/1570

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
