### PR TITLE
move schema registry related options into format encode parts in 1.4, 1.5, and dev.

### DIFF
--- a/docs/ingest/ingest-from-kafka.md
+++ b/docs/ingest/ingest-from-kafka.md
@@ -128,8 +128,6 @@ For tables with primary key constraints, if a new data record with an existing k
 |scan.startup.mode|Optional. The offset mode that RisingWave will use to consume data. The two supported modes are `earliest` (earliest offset) and `latest` (latest offset). If not specified, the default value `earliest` will be used.|
 |scan.startup.timestamp_millis|Optional. RisingWave will start to consume data from the specified UNIX timestamp (milliseconds). If this field is specified, the value for `scan.startup.mode` will be ignored.|
 |properties.sync.call.timeout | Optional. Specify the timeout. By default, the timeout is 5 seconds.  |
-|schema.registry.username|Conditional. User name for the schema registry. It must be specified with `schema.registry.password`.|
-|schema.registry.password|Conditional. Password for the schema registry. It must be specified with `schema.registry.username`.|
 |properties.client.id|Optional. Client ID associated with the Kafka client. |
 
 ### Other parameters
@@ -140,7 +138,9 @@ For tables with primary key constraints, if a new data record with an existing k
 |*data_encode*| Data encode. Supported encodes: `JSON`, `AVRO`, `PROTOBUF`, `CSV`. |
 |*message* | Message name of the main Message in schema definition. Required for Protobuf. |
 |*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. For Avro and Protobuf data, you must specify either a schema location or a schema registry but not both.|
-|*schema_registry_url*| Confluent Schema Registry URL. Example: `http://127.0.0.1:8081`. For Avro or Protobuf data, you must specify either a schema location or a Confluent Schema Registry but not both.|
+|*schema.registry*| Confluent Schema Registry URL. Example: `http://127.0.0.1:8081`. For Avro or Protobuf data, you must specify either a schema location or a Confluent Schema Registry but not both.|
+|*schema.registry.username*|Conditional. User name for the schema registry. It must be specified with `schema.registry.password`.|
+|*schema.registry.password*|Conditional. Password for the schema registry. It must be specified with `schema.registry.username`.|
 
 ## Additional Kafka parameters
 

--- a/versioned_docs/version-1.4/ingest/ingest-from-kafka.md
+++ b/versioned_docs/version-1.4/ingest/ingest-from-kafka.md
@@ -128,8 +128,6 @@ For tables with primary key constraints, if a new data record with an existing k
 |scan.startup.mode|Optional. The offset mode that RisingWave will use to consume data. The two supported modes are `earliest` (earliest offset) and `latest` (latest offset). If not specified, the default value `earliest` will be used.|
 |scan.startup.timestamp_millis|Optional. RisingWave will start to consume data from the specified UNIX timestamp (milliseconds). If this field is specified, the value for `scan.startup.mode` will be ignored.|
 |properties.sync.call.timeout | Optional. Specify the timeout. By default, the timeout is 5 seconds.  |
-|schema.registry.username|Conditional. User name for the schema registry. It must be specified with `schema.registry.password`.|
-|schema.registry.password|Conditional. Password for the schema registry. It must be specified with `schema.registry.username`.|
 |properties.client.id|Optional. Client ID associated with the Kafka client. |
 
 ### Other parameters
@@ -140,7 +138,9 @@ For tables with primary key constraints, if a new data record with an existing k
 |*data_encode*| Data encode. Supported encodes: `JSON`, `AVRO`, `PROTOBUF`, `CSV`. |
 |*message* | Message name of the main Message in schema definition. Required for Protobuf. |
 |*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. For Avro and Protobuf data, you must specify either a schema location or a schema registry but not both.|
-|*schema_registry_url*| Confluent Schema Registry URL. Example: `http://127.0.0.1:8081`. For Avro or Protobuf data, you must specify either a schema location or a Confluent Schema Registry but not both.|
+|*schema.registry*| Confluent Schema Registry URL. Example: `http://127.0.0.1:8081`. For Avro or Protobuf data, you must specify either a schema location or a Confluent Schema Registry but not both.|
+|*schema.registry.username*|Conditional. User name for the schema registry. It must be specified with `schema.registry.password`.|
+|*schema.registry.password*|Conditional. Password for the schema registry. It must be specified with `schema.registry.username`.|
 
 ## Additional Kafka parameters
 

--- a/versioned_docs/version-1.5/ingest/ingest-from-kafka.md
+++ b/versioned_docs/version-1.5/ingest/ingest-from-kafka.md
@@ -128,8 +128,6 @@ For tables with primary key constraints, if a new data record with an existing k
 |scan.startup.mode|Optional. The offset mode that RisingWave will use to consume data. The two supported modes are `earliest` (earliest offset) and `latest` (latest offset). If not specified, the default value `earliest` will be used.|
 |scan.startup.timestamp_millis|Optional. RisingWave will start to consume data from the specified UNIX timestamp (milliseconds). If this field is specified, the value for `scan.startup.mode` will be ignored.|
 |properties.sync.call.timeout | Optional. Specify the timeout. By default, the timeout is 5 seconds.  |
-|schema.registry.username|Conditional. User name for the schema registry. It must be specified with `schema.registry.password`.|
-|schema.registry.password|Conditional. Password for the schema registry. It must be specified with `schema.registry.username`.|
 |properties.client.id|Optional. Client ID associated with the Kafka client. |
 
 ### Other parameters
@@ -140,7 +138,9 @@ For tables with primary key constraints, if a new data record with an existing k
 |*data_encode*| Data encode. Supported encodes: `JSON`, `AVRO`, `PROTOBUF`, `CSV`. |
 |*message* | Message name of the main Message in schema definition. Required for Protobuf. |
 |*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. For Avro and Protobuf data, you must specify either a schema location or a schema registry but not both.|
-|*schema_registry_url*| Confluent Schema Registry URL. Example: `http://127.0.0.1:8081`. For Avro or Protobuf data, you must specify either a schema location or a Confluent Schema Registry but not both.|
+|*schema.registry*| Confluent Schema Registry URL. Example: `http://127.0.0.1:8081`. For Avro or Protobuf data, you must specify either a schema location or a Confluent Schema Registry but not both.|
+|*schema.registry.username*|Conditional. User name for the schema registry. It must be specified with `schema.registry.password`.|
+|*schema.registry.password*|Conditional. Password for the schema registry. It must be specified with `schema.registry.username`.|
 
 ## Additional Kafka parameters
 


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - Replicate changes of pr(https://github.com/risingwavelabs/risingwave-docs/pull/1627) to 1.5 and dev.
  - Move schema.registry.username and schema.registry.password into format_encode_options, the doc part is not consistent with code impl
  - schema_registry_url have been renamed to schema.registry

- **Notes**

  - [ Include any supplementary context or references here. ]

- **Related code PR**

  - [ Provide a link to the relevant code PR here, if applicable. ]

- **Related doc issue**
  
  Resolves [ Provide a link to the relevant doc issue here, if applicable. ]

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
