### PR TITLE
Support expression and NULL as direct arguments

### DIFF
--- a/docs/sql/functions-operators/sql-function-aggregate.md
+++ b/docs/sql/functions-operators/sql-function-aggregate.md
@@ -199,10 +199,6 @@ var_samp ( expression ) -> output_value
 
 ## Ordered-set aggregate functions
 
-:::note
-At present, ordered-set aggregate functions support only constant fraction arguments.
-:::
-
 ### `mode`
 
 Computes the mode, which is the most frequent value of the aggregated argument. If there are multiple equally-frequent values, it arbitrarily chooses the first one.
@@ -225,18 +221,21 @@ SELECT mode() WITHIN GROUP (ORDER BY column1) FROM table1;
 
 Computes the continuous percentile, which is a value corresponding to the specified fraction within the ordered set of aggregated argument values. It can interpolate between adjacent input items if needed.
 
-```bash title=Syntax
-percentile_cont ( fraction double precision ) WITHIN GROUP ( ORDER BY sort_expression double precision ) -> double precision
+```sql title=Syntax
+percentile_cont ( fraction_or_expression ) WITHIN GROUP ( ORDER BY sort_expression double precision ) -> double precision
 ```
 
-`fraction`: The fraction value representing the desired percentile. It should be between 0 and 1.
+`fraction_or_expression`: Represents the desired percentile. This can be either a fraction value (e.g., 0.5) or a fraction expression (e.g., 0.2 + 0.3) that represents the desired percentile. It should be between 0 and 1.
 
-This example calculates the median (50th percentile) of the values in `column1` from `table1`.
+The examples below calculate the median (50th percentile) of the values in `column1` from `table1`.
 
-```sql title=Example
+```sql title=Example 1
 SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
 
+```sql title=Example 2
+SELECT percentile_cont(0.2 + 0.3) WITHIN GROUP (ORDER BY column1) FROM table1;
+```
 ---  
 
 ### `percentile_disc`

--- a/docs/sql/functions-operators/sql-function-aggregate.md
+++ b/docs/sql/functions-operators/sql-function-aggregate.md
@@ -239,6 +239,8 @@ SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY column1) FROM table1;
 
 If NULL is provided, the function will not calculate a specific percentile and return NULL instead.
 
+---  
+
 ### `percentile_disc`
 
 Computes the discrete percentile, which is the first value within the ordered set of aggregated argument values whose position in the ordering equals or exceeds the specified fraction.

--- a/docs/sql/functions-operators/sql-function-aggregate.md
+++ b/docs/sql/functions-operators/sql-function-aggregate.md
@@ -222,21 +222,26 @@ SELECT mode() WITHIN GROUP (ORDER BY column1) FROM table1;
 Computes the continuous percentile, which is a value corresponding to the specified fraction within the ordered set of aggregated argument values. It can interpolate between adjacent input items if needed.
 
 ```sql title=Syntax
-percentile_cont ( fraction_or_expression ) WITHIN GROUP ( ORDER BY sort_expression double precision ) -> double precision
+percentile_cont ( fraction_or_expression ) WITHIN GROUP ( ORDER BY sort_expression ) -> fraction or NULL
 ```
 
-`fraction_or_expression`: Represents the desired percentile. This can be either a fraction value (e.g., 0.5) or a fraction expression (e.g., 0.2 + 0.3) that represents the desired percentile. It should be between 0 and 1.
+`fraction_or_expression`: Represents the desired percentile. This can be a fraction value (e.g., 0.5) or a fraction expression (e.g., 0.2 + 0.3) or NULL. The fraction or expression should be between 0 and 1.
 
 The examples below calculate the median (50th percentile) of the values in `column1` from `table1`.
 
-```sql title=Example 1
+```sql title=Example
 SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
 
-```sql title=Example 2
+```sql title=Example
 SELECT percentile_cont(0.2 + 0.3) WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
----  
+
+If NULL is provided, the function will not calculate a specific percentile and return NULL instead.
+
+```sql title=Example
+SELECT percentile_cont(0.3 + NULL) WITHIN GROUP (ORDER BY column1) FROM table1; -> NULL
+```
 
 ### `percentile_disc`
 

--- a/docs/sql/functions-operators/sql-function-aggregate.md
+++ b/docs/sql/functions-operators/sql-function-aggregate.md
@@ -199,6 +199,10 @@ var_samp ( expression ) -> output_value
 
 ## Ordered-set aggregate functions
 
+:::note
+At present, ordered-set aggregate functions support only constant fraction arguments.
+:::
+
 ### `mode`
 
 Computes the mode, which is the most frequent value of the aggregated argument. If there are multiple equally-frequent values, it arbitrarily chooses the first one.
@@ -222,26 +226,18 @@ SELECT mode() WITHIN GROUP (ORDER BY column1) FROM table1;
 Computes the continuous percentile, which is a value corresponding to the specified fraction within the ordered set of aggregated argument values. It can interpolate between adjacent input items if needed.
 
 ```sql title=Syntax
-percentile_cont ( fraction_or_expression ) WITHIN GROUP ( ORDER BY sort_expression ) -> fraction or NULL
+percentile_cont ( fraction double precision ) WITHIN GROUP ( ORDER BY sort_expression double precision ) -> double precision
 ```
 
-`fraction_or_expression`: Represents the desired percentile. This can be a fraction value (e.g., 0.5) or a fraction expression (e.g., 0.2 + 0.3) or NULL. The fraction or expression should be between 0 and 1.
+`fraction`: The fraction value representing the desired percentile. It should be between 0 and 1.
 
-The examples below calculate the median (50th percentile) of the values in `column1` from `table1`.
+This example calculates the median (50th percentile) of the values in `column1` from `table1`.
 
 ```sql title=Example
 SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
 
-```sql title=Example
-SELECT percentile_cont(0.2 + 0.3) WITHIN GROUP (ORDER BY column1) FROM table1;
-```
-
 If NULL is provided, the function will not calculate a specific percentile and return NULL instead.
-
-```sql title=Example
-SELECT percentile_cont(0.3 + NULL) WITHIN GROUP (ORDER BY column1) FROM table1; -> NULL
-```
 
 ### `percentile_disc`
 
@@ -260,6 +256,8 @@ This example calculates the 75th percentile of the values in `column1` from `tab
 ```sql title=Example
 SELECT percentile_disc(0.75) WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
+
+If NULL is provided, the function will not calculate a specific percentile and return NULL instead.
 
 ## Grouping operation functions
 


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

     Ordered-set aggregate functions now support fraction expressions and NULL as direct arguments. Previously only fraction values were supported.

- **Related code PR**

  https://github.com/risingwavelabs/risingwave/pull/14080

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/1722

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
