### PR TITLE
Add more details to clickhouse.url docs

### DIFF
--- a/docs/guides/sink-to-clickhouse.md
+++ b/docs/guides/sink-to-clickhouse.md
@@ -44,7 +44,7 @@ WITH (
 | --------------------- | ---------------------------------------------------------------------- |
 | `type`                | Required. Specify if the sink should be `upsert` or `append-only`. If creating an `upsert` sink, see the [Overview](data-delivery.md) on when to define the primary key and [Upsert sinks](#upsert-sinks) on limitations.|
 | `primary_key`          | Optional. A string of a list of column names, separated by commas, that specifies the primary key of the ClickHouse sink.|
-| `clickhouse.url`        | Required. Address of the ClickHouse server that you want to sink data to. Format: `ip:port`.|
+| `clickhouse.url`        | Required. Address of the ClickHouse server that you want to sink data to. Format: `http://ip:port`. The default port is `8123`.|
 | `clickhouse.user`       | Required. User name for accessing the ClickHouse server. |
 | `clickhouse.password`   | Required. Password for accessing the ClickHouse server.|
 | `clickhouse.database`  | Required. Name of the ClickHouse database that you want to sink data to.|

--- a/versioned_docs/version-1.6/guides/sink-to-clickhouse.md
+++ b/versioned_docs/version-1.6/guides/sink-to-clickhouse.md
@@ -44,7 +44,7 @@ WITH (
 | --------------------- | ---------------------------------------------------------------------- |
 | `type`                | Required. Specify if the sink should be `upsert` or `append-only`. If creating an `upsert` sink, see the [Overview](data-delivery.md) on when to define the primary key and [Upsert sinks](#upsert-sinks) on limitations.|
 | `primary_key`          | Optional. A string of a list of column names, separated by commas, that specifies the primary key of the ClickHouse sink.|
-| `clickhouse.url`        | Required. Address of the ClickHouse server that you want to sink data to. Format: `http://ip:port`. The default port ist `8123`.|
+| `clickhouse.url`        | Required. Address of the ClickHouse server that you want to sink data to. Format: `http://ip:port`. The default port is `8123`.|
 | `clickhouse.user`       | Required. User name for accessing the ClickHouse server. |
 | `clickhouse.password`   | Required. Password for accessing the ClickHouse server.|
 | `clickhouse.database`  | Required. Name of the ClickHouse database that you want to sink data to.|

--- a/versioned_docs/version-1.6/guides/sink-to-clickhouse.md
+++ b/versioned_docs/version-1.6/guides/sink-to-clickhouse.md
@@ -44,7 +44,7 @@ WITH (
 | --------------------- | ---------------------------------------------------------------------- |
 | `type`                | Required. Specify if the sink should be `upsert` or `append-only`. If creating an `upsert` sink, see the [Overview](data-delivery.md) on when to define the primary key and [Upsert sinks](#upsert-sinks) on limitations.|
 | `primary_key`          | Optional. A string of a list of column names, separated by commas, that specifies the primary key of the ClickHouse sink.|
-| `clickhouse.url`        | Required. Address of the ClickHouse server that you want to sink data to. Format: `ip:port`.|
+| `clickhouse.url`        | Required. Address of the ClickHouse server that you want to sink data to. Format: `http://ip:port`. The default port ist `8123`.|
 | `clickhouse.user`       | Required. User name for accessing the ClickHouse server. |
 | `clickhouse.password`   | Required. Password for accessing the ClickHouse server.|
 | `clickhouse.database`  | Required. Name of the ClickHouse database that you want to sink data to.|


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**
  Adds some simple extra details to the clickhouse.url docs to make it easier to get started.

- **Notes**
  I've just set this up & had to ask on stack as I didn't understand the `ip:port` to mean as part of an url.

- **Related code PR**
  None

- **Related doc issue**
  None
## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
