### PR TITLE
Move the code for schema.registry.username and password 

### DIFF
--- a/docs/ingest/ingest-from-kafka.md
+++ b/docs/ingest/ingest-from-kafka.md
@@ -198,12 +198,12 @@ CREATE TABLE IF NOT EXISTS source_abc
 WITH (
    connector='kafka',
    properties.bootstrap.server='localhost:9092',
-   topic='test_topic',
-   schema.registry.username='your_schema_registry_username',
-   schema.registry.password='your_schema_registry_password'
+   topic='test_topic'
 )
 FORMAT UPSERT ENCODE AVRO (
-   schema.registry = 'http://127.0.0.1:8081'
+   schema.registry = 'http://127.0.0.1:8081',
+   schema.registry.username='your_schema_registry_username',
+   schema.registry.password='your_schema_registry_password'
 );
 ```
 

--- a/versioned_docs/version-1.6/ingest/ingest-from-kafka.md
+++ b/versioned_docs/version-1.6/ingest/ingest-from-kafka.md
@@ -198,12 +198,12 @@ CREATE TABLE IF NOT EXISTS source_abc
 WITH (
    connector='kafka',
    properties.bootstrap.server='localhost:9092',
-   topic='test_topic',
-   schema.registry.username='your_schema_registry_username',
-   schema.registry.password='your_schema_registry_password'
+   topic='test_topic'
 )
 FORMAT UPSERT ENCODE AVRO (
-   schema.registry = 'http://127.0.0.1:8081'
+   schema.registry = 'http://127.0.0.1:8081',
+   schema.registry.username='your_schema_registry_username',
+   schema.registry.password='your_schema_registry_password'
 );
 ```
 


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  Move `schema.registry.username` and `schema.registry.password` under `schema.registry`, in both v1.6 and v1.7.

- **Related code PR**

  - [ Provide a link to the relevant code PR here, if applicable. ]

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/1788

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
