### PR TITLE
Add two system views into catalogs

### DIFF
--- a/docs/sql/system-catalogs/rw_catalog.md
+++ b/docs/sql/system-catalogs/rw_catalog.md
@@ -87,7 +87,7 @@ SELECT name, initialized_at, created_at FROM rw_sources;
  rw_ddl_progress       | Contains the progress of running DDL statements. You can use this relation to view the progress of running DDL statements. For details, see [View statement progress](/manage/view-statement-progress.md).|
  rw_description        | Contains optional descriptions (comments) for each database object. Descriptions can be added with the [`COMMENT ON`](/sql/commands/sql-comment-on.md) command and viewed with `DESCRIBE` or `SHOW COLUMNS FROM` command.|
  rw_event_logs         | Contains information about events, including event IDs, timestamps, event types, and additional information if available. |
- rw_fragment_parallelism          | Contains information about the parallelism configuration on the fragment level, including fragment IDs, parallelism, and more. |
+ rw_fragment_parallelism          | Contains information about the parallelism configuration at the fragment level, including fragment IDs, parallelism, and more. |
  rw_fragments          | Contains low-level information about fragments in the database, including fragment IDs, table IDs, and more. |
  rw_functions          | Contains information about functions in the database, including their IDs, names, schema identifiers, types, argument and return data types, programming language, and more. |
  rw_hummock_branched_objects         | Contains information about branched objects of Hummock (the storage engine in RisingWave), including object IDs, corresponding SST IDs, and compaction group IDs. |

--- a/docs/sql/system-catalogs/rw_catalog.md
+++ b/docs/sql/system-catalogs/rw_catalog.md
@@ -87,6 +87,7 @@ SELECT name, initialized_at, created_at FROM rw_sources;
  rw_ddl_progress       | Contains the progress of running DDL statements. You can use this relation to view the progress of running DDL statements. For details, see [View statement progress](/manage/view-statement-progress.md).|
  rw_description        | Contains optional descriptions (comments) for each database object. Descriptions can be added with the [`COMMENT ON`](/sql/commands/sql-comment-on.md) command and viewed with `DESCRIBE` or `SHOW COLUMNS FROM` command.|
  rw_event_logs         | Contains information about events, including event IDs, timestamps, event types, and additional information if available. |
+ rw_fragment_parallelism          | Contains information about the fragment parallelism configuration, including fragment IDs, parallelism, and more. |
  rw_fragments          | Contains low-level information about fragments in the database, including fragment IDs, table IDs, and more. |
  rw_functions          | Contains information about functions in the database, including their IDs, names, schema identifiers, types, argument and return data types, programming language, and more. |
  rw_hummock_branched_objects         | Contains information about branched objects of Hummock (the storage engine in RisingWave), including object IDs, corresponding SST IDs, and compaction group IDs. |
@@ -109,6 +110,7 @@ SELECT name, initialized_at, created_at FROM rw_sources;
  rw_schemas            | Contains information about schemas that are available in the database, including their names, unique IDs, owner IDs, and more. |
  rw_sinks              | Contains information about sinks that are available in the database, including their unique IDs, names, schema IDs, owner IDs, connector types, sink types, connection IDs, definitions, and more.|
  rw_sources            | Contains information about sources that are available in the database, including their unique IDs, names, schema IDs, owner IDs, connector types, column definitions, row formats, append-only flags, connection IDs, and more.|
+ rw_streaming_parallelism            | Contains information about the streaming parallelism configuration for streaming jobs, including their IDs, names, relation types, and parallelism.|
  rw_system_tables      | Contains information about system tables in the database, including their unique IDs, names, schema IDs, owners, and more. |
  rw_table_fragments    | Contains information about table fragments in the database, including their parent table IDs, fragment statuses, and primary keys.|
  rw_table_stats        | Contains statistical information about tables, including their unique IDs, total key count, total key size, and total value size in bytes.|

--- a/docs/sql/system-catalogs/rw_catalog.md
+++ b/docs/sql/system-catalogs/rw_catalog.md
@@ -87,7 +87,7 @@ SELECT name, initialized_at, created_at FROM rw_sources;
  rw_ddl_progress       | Contains the progress of running DDL statements. You can use this relation to view the progress of running DDL statements. For details, see [View statement progress](/manage/view-statement-progress.md).|
  rw_description        | Contains optional descriptions (comments) for each database object. Descriptions can be added with the [`COMMENT ON`](/sql/commands/sql-comment-on.md) command and viewed with `DESCRIBE` or `SHOW COLUMNS FROM` command.|
  rw_event_logs         | Contains information about events, including event IDs, timestamps, event types, and additional information if available. |
- rw_fragment_parallelism          | Contains information about the fragment parallelism configuration, including fragment IDs, parallelism, and more. |
+ rw_fragment_parallelism          | Contains information about the parallelism configuration on the fragment level, including fragment IDs, parallelism, and more. |
  rw_fragments          | Contains low-level information about fragments in the database, including fragment IDs, table IDs, and more. |
  rw_functions          | Contains information about functions in the database, including their IDs, names, schema identifiers, types, argument and return data types, programming language, and more. |
  rw_hummock_branched_objects         | Contains information about branched objects of Hummock (the storage engine in RisingWave), including object IDs, corresponding SST IDs, and compaction group IDs. |


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - Add `rw_fragment_parallelism` & `rw_streaming_parallelism` system views into RW catalogs

- **Related code PR**

  - https://github.com/risingwavelabs/risingwave/pull/14789

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/1807

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
