### PR TITLE
Remove `FORMAT ... ENCODE ...` syntax in NATS sink

### DIFF
--- a/docs/guides/sink-to-nats.md
+++ b/docs/guides/sink-to-nats.md
@@ -39,8 +39,7 @@ WITH (
    password='<your password>'
    jwt=`<your jwt>`,
    nkey=`<your nkey>`
-)
-FORMAT PLAIN ENCODE JSON;
+);
 ```
 
 After the sink is created, RisingWave will continuously sink data to the NATS subject in append-only mode.

--- a/docs/sql/commands/sql-create-sink.md
+++ b/docs/sql/commands/sql-create-sink.md
@@ -26,7 +26,7 @@ WITH (
 ) ] ];
 ```
 :::note
-The optional `FORMAT data_format ENCODE data_encode` syntax is only used for Kafka, Kinesis, and Pulsar sinks. 
+The optional `FORMAT data_format ENCODE data_encode` syntax is only used for Kafka, Kinesis, Pulsar, and Redis sinks.
 :::
 
 

--- a/versioned_docs/version-1.7/guides/sink-to-nats.md
+++ b/versioned_docs/version-1.7/guides/sink-to-nats.md
@@ -39,8 +39,7 @@ WITH (
    password='<your password>'
    jwt=`<your jwt>`,
    nkey=`<your nkey>`
-)
-FORMAT PLAIN ENCODE JSON;
+);
 ```
 
 After the sink is created, RisingWave will continuously sink data to the NATS subject in append-only mode.

--- a/versioned_docs/version-1.7/sql/commands/sql-create-sink.md
+++ b/versioned_docs/version-1.7/sql/commands/sql-create-sink.md
@@ -26,7 +26,7 @@ WITH (
 ) ] ];
 ```
 :::note
-The optional `FORMAT data_format ENCODE data_encode` syntax is only used for Kafka, Kinesis, and Pulsar sinks. 
+The optional `FORMAT data_format ENCODE data_encode` syntax is only used for Kafka, Kinesis, Pulsar, and Redis sinks.
 :::
 
 


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - Confirmed with Xiangjin: only Kafka / Kinesis / Pulsar / Redis sinks support `FORMAT ... ENCODE ...` syntax
  - Did a global search and removed this syntax in other sinks. It only appears once in the NATS sink.

- **Related code PR**

  - https://github.com/risingwavelabs/risingwave/issues/15276

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/1891

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
