### PR TITLE
fix the command to create Rust UDF

### DIFF
--- a/docs/sql/udf/udf-rust.md
+++ b/docs/sql/udf/udf-rust.md
@@ -93,31 +93,17 @@ In RisingWave, use the [`CREATE FUNCTION`](/sql/commands/sql-create-function.md)
 
 There are two ways to load the WASM module:
 
-1. The WASM binary can be embedded in the SQL statement using base64 encoding. You can use the following shell script to encode the binary and generate the SQL statement:
-
-    ```shell
-    encoded=$(base64 -i udf.wasm)
-    sql="CREATE FUNCTION gcd(int, int) RETURNS int LANGUAGE wasm USING BASE64 '$encoded';"
-    echo "$sql" > create_function.sql
-    ```
-
-   When created successfully, the WASM binary will be automatically uploaded to the object store.
-
-2. The WASM binary can be loaded from the object store.
+1. Embed the WASM binary into SQL with base64 encoding. You can use the following command in psql:
 
     ```sql
-    CREATE FUNCTION gcd(int, int) RETURNS int
-    LANGUAGE wasm USING LINK 's3://bucket/path/to/udf.wasm';
-
-    CREATE FUNCTION series(int) RETURNS TABLE (x int)
-    LANGUAGE wasm USING LINK 's3://bucket/path/to/udf.wasm';
+    \set wasm_binary `base64 -i path/to/udf.wasm`
+    CREATE FUNCTION gcd(int, int) RETURNS int LANGUAGE wasm USING BASE64 :'wasm_binary';
     ```
 
-    Alternatively, if you run RisingWave locally, you can use the local file system:
+2. Load the WASM binary from the local file system of the frontend.
 
     ```sql
-    CREATE FUNCTION gcd(int, int) RETURNS int
-    LANGUAGE wasm USING LINK 'fs://path/to/udf.wasm';
+    CREATE FUNCTION gcd(int, int) RETURNS int LANGUAGE wasm USING LINK 'fs://path/to/udf.wasm';
     ```
 
 ## 5. Use your functions in RisingWave

--- a/versioned_docs/version-1.7/sql/udf/udf-rust.md
+++ b/versioned_docs/version-1.7/sql/udf/udf-rust.md
@@ -93,31 +93,17 @@ In RisingWave, use the [`CREATE FUNCTION`](/sql/commands/sql-create-function.md)
 
 There are two ways to load the WASM module:
 
-1. The WASM binary can be embedded in the SQL statement using base64 encoding. You can use the following shell script to encode the binary and generate the SQL statement:
-
-    ```shell
-    encoded=$(base64 -i udf.wasm)
-    sql="CREATE FUNCTION gcd(int, int) RETURNS int LANGUAGE wasm USING BASE64 '$encoded';"
-    echo "$sql" > create_function.sql
-    ```
-
-   When created successfully, the WASM binary will be automatically uploaded to the object store.
-
-2. The WASM binary can be loaded from the object store.
+1. Embed the WASM binary into SQL with base64 encoding. You can use the following command in psql:
 
     ```sql
-    CREATE FUNCTION gcd(int, int) RETURNS int
-    LANGUAGE wasm USING LINK 's3://bucket/path/to/udf.wasm';
-
-    CREATE FUNCTION series(int) RETURNS TABLE (x int)
-    LANGUAGE wasm USING LINK 's3://bucket/path/to/udf.wasm';
+    \set wasm_binary `base64 -i path/to/udf.wasm`
+    CREATE FUNCTION gcd(int, int) RETURNS int LANGUAGE wasm USING BASE64 :'wasm_binary';
     ```
 
-    Alternatively, if you run RisingWave locally, you can use the local file system:
+2. Load the WASM binary from the local file system of the frontend.
 
     ```sql
-    CREATE FUNCTION gcd(int, int) RETURNS int
-    LANGUAGE wasm USING LINK 'fs://path/to/udf.wasm';
+    CREATE FUNCTION gcd(int, int) RETURNS int LANGUAGE wasm USING LINK 'fs://path/to/udf.wasm';
     ```
 
 ## 5. Use your functions in RisingWave


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - We've changed the behavior of creating Rust UDFs in 1.7. But the documentation was not updated in time.
    - WASM binaries are no longer stored in the object store, but in meta store.
    - Loading WASM from object store (`s3://`) is deprecated. Now we only support loading from local file system (`fs://`).
    - Update the command to embed WASM binaries in psql.

- **Notes**

  - [ Include any supplementary context or references here. ]

- **Related code PR**

  - https://github.com/risingwavelabs/risingwave/pull/15269

- **Related doc issue**
  
  Resolves [ Provide a link to the relevant doc issue here, if applicable. ]

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
