### PR TITLE
Fix bug in datatype mapping between RW and Cassandra

### DIFF
--- a/docs/guides/sink-to-cassandra.md
+++ b/docs/guides/sink-to-cassandra.md
@@ -66,7 +66,7 @@ The Cassandra sink in RisingWave provides at-least-once delivery semantics. Even
 |smallint | smallint |
 |integer |int|
 |bigint |bigint|
-|numeric |double|
+|numeric |decimal|
 |real |float|
 |double precision |double|
 |character varying (varchar) |text|

--- a/versioned_docs/version-1.3/guides/sink-to-cassandra.md
+++ b/versioned_docs/version-1.3/guides/sink-to-cassandra.md
@@ -66,7 +66,7 @@ The Cassandra sink in RisingWave provides at-least-once delivery semantics. Even
 |smallint | smallint |
 |integer |int|
 |bigint |bigint|
-|numeric |double|
+|numeric |decimal|
 |real |float|
 |double precision |double|
 |character varying (varchar) |text|

--- a/versioned_docs/version-1.4/guides/sink-to-cassandra.md
+++ b/versioned_docs/version-1.4/guides/sink-to-cassandra.md
@@ -66,7 +66,7 @@ The Cassandra sink in RisingWave provides at-least-once delivery semantics. Even
 |smallint | smallint |
 |integer |int|
 |bigint |bigint|
-|numeric |double|
+|numeric |decimal|
 |real |float|
 |double precision |double|
 |character varying (varchar) |text|

--- a/versioned_docs/version-1.5/guides/sink-to-cassandra.md
+++ b/versioned_docs/version-1.5/guides/sink-to-cassandra.md
@@ -66,7 +66,7 @@ The Cassandra sink in RisingWave provides at-least-once delivery semantics. Even
 |smallint | smallint |
 |integer |int|
 |bigint |bigint|
-|numeric |double|
+|numeric |decimal|
 |real |float|
 |double precision |double|
 |character varying (varchar) |text|

--- a/versioned_docs/version-1.6/guides/sink-to-cassandra.md
+++ b/versioned_docs/version-1.6/guides/sink-to-cassandra.md
@@ -66,7 +66,7 @@ The Cassandra sink in RisingWave provides at-least-once delivery semantics. Even
 |smallint | smallint |
 |integer |int|
 |bigint |bigint|
-|numeric |double|
+|numeric |decimal|
 |real |float|
 |double precision |double|
 |character varying (varchar) |text|

--- a/versioned_docs/version-1.7/guides/sink-to-cassandra.md
+++ b/versioned_docs/version-1.7/guides/sink-to-cassandra.md
@@ -66,7 +66,7 @@ The Cassandra sink in RisingWave provides at-least-once delivery semantics. Even
 |smallint | smallint |
 |integer |int|
 |bigint |bigint|
-|numeric |double|
+|numeric |decimal|
 |real |float|
 |double precision |double|
 |character varying (varchar) |text|


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - `numeric` is mapped to  `decimal`

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/1941
<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
