### PR TITLE
fix order of include clauses

### DIFF
--- a/docs/ingest/ingest-from-gcs.md
+++ b/docs/ingest/ingest-from-gcs.md
@@ -12,11 +12,11 @@ Use the SQL statement below to connect RisingWave to a Google Cloud Storage sour
 ```sql
 CREATE SOURCE [ IF NOT EXISTS ] source_name 
 schema_definition
+[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 WITH (
    connector = 'gcs',
    connector_parameter = 'value', ...
 )
-[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 FORMAT data_format ENCODE data_encode (
    without_header = 'true' | 'false',
    delimiter = 'delimiter'

--- a/docs/ingest/ingest-from-kafka.md
+++ b/docs/ingest/ingest-from-kafka.md
@@ -27,11 +27,11 @@ RisingWave Cloud provides an intuitive guided setup for creating a Kafka source.
 ```sql
 CREATE {TABLE | SOURCE} [ IF NOT EXISTS ] source_name 
 [ schema_definition ]
+[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 WITH (
    connector='kafka',
    connector_parameter='value', ...
 )
-[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 FORMAT data_format ENCODE data_encode (
    message = 'message',
    schema.location = 'location' | schema.registry = 'schema_registry_url'

--- a/docs/ingest/ingest-from-kinesis.md
+++ b/docs/ingest/ingest-from-kinesis.md
@@ -17,11 +17,11 @@ When creating a source, you can choose to persist the data from the source in Ri
 ```sql
 CREATE {TABLE | SOURCE} [ IF NOT EXISTS ] source_name 
 [ schema_definition ]
+[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 WITH (
    connector='kinesis',
    connector_parameter='value', ...
 )
-[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 FORMAT data_format ENCODE data_encode (
    message = 'message',
    schema.location = 'location'

--- a/docs/ingest/ingest-from-pulsar.md
+++ b/docs/ingest/ingest-from-pulsar.md
@@ -21,11 +21,11 @@ When creating a source, you can choose to persist the data from the source in Ri
 ```sql
 CREATE {TABLE | SOURCE} [ IF NOT EXISTS ] source_name 
 [ schema_definition ]
+[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 WITH (
    connector='pulsar',
    connector_parameter='value', ...
 )
-[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 FORMAT data_format ENCODE data_encode (
    message = 'message',
    schema.location = 'location' | schema.registry = 'schema_registry_url'

--- a/docs/ingest/ingest-from-s3.md
+++ b/docs/ingest/ingest-from-s3.md
@@ -17,11 +17,11 @@ The S3 connector does not guarantee the sequential reading of files or complete 
 ```sql
 CREATE SOURCE [ IF NOT EXISTS ] source_name 
 schema_definition
+[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 WITH (
    connector={ 's3' | 's3_v2' },
    connector_parameter='value', ...
 )
-[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 FORMAT data_format ENCODE data_encode (
    without_header = 'true' | 'false',
    delimiter = 'delimiter'

--- a/versioned_docs/version-1.7/ingest/ingest-from-gcs.md
+++ b/versioned_docs/version-1.7/ingest/ingest-from-gcs.md
@@ -12,11 +12,11 @@ Use the SQL statement below to connect RisingWave to a Google Cloud Storage sour
 ```sql
 CREATE SOURCE [ IF NOT EXISTS ] source_name 
 schema_definition
+[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 WITH (
    connector = 'gcs',
    connector_parameter = 'value', ...
 )
-[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 FORMAT data_format ENCODE data_encode (
    without_header = 'true' | 'false',
    delimiter = 'delimiter'

--- a/versioned_docs/version-1.7/ingest/ingest-from-kafka.md
+++ b/versioned_docs/version-1.7/ingest/ingest-from-kafka.md
@@ -27,11 +27,11 @@ RisingWave Cloud provides an intuitive guided setup for creating a Kafka source.
 ```sql
 CREATE {TABLE | SOURCE} [ IF NOT EXISTS ] source_name 
 [ schema_definition ]
+[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 WITH (
    connector='kafka',
    connector_parameter='value', ...
 )
-[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 FORMAT data_format ENCODE data_encode (
    message = 'message',
    schema.location = 'location' | schema.registry = 'schema_registry_url'

--- a/versioned_docs/version-1.7/ingest/ingest-from-kinesis.md
+++ b/versioned_docs/version-1.7/ingest/ingest-from-kinesis.md
@@ -17,11 +17,11 @@ When creating a source, you can choose to persist the data from the source in Ri
 ```sql
 CREATE {TABLE | SOURCE} [ IF NOT EXISTS ] source_name 
 [ schema_definition ]
+[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 WITH (
    connector='kinesis',
    connector_parameter='value', ...
 )
-[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 FORMAT data_format ENCODE data_encode (
    message = 'message',
    schema.location = 'location'

--- a/versioned_docs/version-1.7/ingest/ingest-from-pulsar.md
+++ b/versioned_docs/version-1.7/ingest/ingest-from-pulsar.md
@@ -21,11 +21,11 @@ When creating a source, you can choose to persist the data from the source in Ri
 ```sql
 CREATE {TABLE | SOURCE} [ IF NOT EXISTS ] source_name 
 [ schema_definition ]
+[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 WITH (
    connector='pulsar',
    connector_parameter='value', ...
 )
-[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 FORMAT data_format ENCODE data_encode (
    message = 'message',
    schema.location = 'location' | schema.registry = 'schema_registry_url'

--- a/versioned_docs/version-1.7/ingest/ingest-from-s3.md
+++ b/versioned_docs/version-1.7/ingest/ingest-from-s3.md
@@ -17,11 +17,11 @@ The S3 connector does not guarantee the sequential reading of files or complete 
 ```sql
 CREATE SOURCE [ IF NOT EXISTS ] source_name 
 schema_definition
+[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 WITH (
    connector={ 's3' | 's3_v2' },
    connector_parameter='value', ...
 )
-[INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 FORMAT data_format ENCODE data_encode (
    without_header = 'true' | 'false',
    delimiter = 'delimiter'


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - The `INCLUDE` clause should be put BEFORE the `WITH` clause. Wrong order will result in a parse error.

- **Notes**

  - [ Include any supplementary context or references here. ]

- **Related code PR**

  - [ Provide a link to the relevant code PR here, if applicable. ]

- **Related doc issue**
  
  Resolves [ Provide a link to the relevant doc issue here, if applicable. ]

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
