### PR TITLE
Doc update for system catalogs

### DIFF
--- a/docs/sql/system-catalogs/information-schema.md
+++ b/docs/sql/system-catalogs/information-schema.md
@@ -61,6 +61,8 @@ The `information_schema.columns` view contains information about columns of all 
 |`ordinal_position`|int32| Ordinal position of the column within the table (count starts at 1)|
 |`is_nullable` | varchar| `YES` if the column is possibly nullable; `NO` if it is known not nullable.|
 |`data_type` | varchar| Data type of the column|
+|`is_generated` | varchar| `ALWAYS` if the column has a generated value; `NEVER` if it doesn't.|
+|`generation_expression` | varchar| Expression for generating values when `is_generated` is `ALWAYS`.|
 
 ## How to use the information schema views?
 

--- a/docs/sql/system-catalogs/pg_catalog.md
+++ b/docs/sql/system-catalogs/pg_catalog.md
@@ -22,7 +22,6 @@ RisingWave does not fully support all PostgreSQL system catalog columns.
 | [`pg_attribute`](https://www.postgresql.org/docs/current/catalog-pg-attribute.html) | Contains information about table columns.|
 | [`pg_cast`](https://www.postgresql.org/docs/current/catalog-pg-cast.html) | Contains information about type casts. |
 | [`pg_constraint`](https://www.postgresql.org/docs/current/catalog-pg-constraint.html) | Contains information about constraints defined for database tables. Constraints are used to enforce rules and restrictions on the data that can be stored in a table.|
-| [`pg_inherits`](https://www.postgresql.org/docs/current/catalog-pg-inherits.html)|
 | [`pg_conversion`](https://www.postgresql.org/docs/current/catalog-pg-conversion.html) | Contains information about encoding conversion functions. |
 | [`pg_class`](https://www.postgresql.org/docs/current/catalog-pg-class.html) | Contains information about tables, indexes, sequences, and views. |
 | [`pg_collation`](https://www.postgresql.org/docs/current/catalog-pg-collation.html) | Contains information about collations. |
@@ -36,6 +35,7 @@ RisingWave does not fully support all PostgreSQL system catalog columns.
 | [`pg_namespace`](https://www.postgresql.org/docs/current/catalog-pg-namespace.html) | Contains information about namespaces.|
 | [`pg_opclass`](https://www.postgresql.org/docs/current/catalog-pg-opclass.html) | Contains information about index access method operator classes. |
 | [`pg_operator`](https://www.postgresql.org/docs/current/catalog-pg-operator.html) | Contains information about operators. |
+| [`pg_partitioned_table`](https://www.postgresql.org/docs/current/catalog-pg-partitioned-table.html) | Contains information about how tables are partitioned. |
 | [`pg_proc`](https://www.postgresql.org/docs/current/catalog-pg-proc.html)|Contains information about functions, aggregate functions, and window functions. |
 | [`pg_roles`](https://www.postgresql.org/docs/current/view-pg-roles.html) | Contains information about database roles. |
 | [`pg_settings`](https://www.postgresql.org/docs/current/view-pg-settings.html) | Contains information about run-time parameters of the server.|

--- a/docs/sql/system-catalogs/rw_catalog.md
+++ b/docs/sql/system-catalogs/rw_catalog.md
@@ -81,7 +81,7 @@ SELECT name, initialized_at, created_at FROM rw_sources;
 |Relation Name | Description|
 |---|---|
  rw_actors             | Contains the available actor IDs, their statuses, and the corresponding fragment IDs, and parallel unit IDs. |
-  rw_columns            | Contains information about columns of all relations (except sources) in the database, including their names, positions, data types, and more.|
+  rw_columns            | Contains information about columns of all relations (except sources) in the database, including their names, positions, data types, generation details, and more.|
  rw_connections        | Contains details about the connections available in the database, such as their IDs, names, owners, types, and more.|
  rw_databases          | Contains information about the databases available in the database, such as the IDs, names, and owners.|
  rw_ddl_progress       | Contains the progress of running DDL statements. You can use this relation to view the progress of running DDL statements. For details, see [View statement progress](/manage/view-statement-progress.md).|

--- a/versioned_docs/version-1.7/sql/system-catalogs/information-schema.md
+++ b/versioned_docs/version-1.7/sql/system-catalogs/information-schema.md
@@ -56,11 +56,13 @@ The `information_schema.columns` view contains information about columns of all 
 |---|---|---|
 |`table_catalog`|varchar| Name of the current database.|
 |`table_schema` |varchar| Name of the schema that contains the table, sink, view, or materialized view. The default schema for user-created objects is `public`.|
-|`table_name` | varchar| Name of the table, sink, view, or materialized view|
-|`column_name` | varchar| Name of the column|
-|`ordinal_position`|int32| Ordinal position of the column within the table (count starts at 1)|
+|`table_name` | varchar| Name of the table, sink, view, or materialized view.|
+|`column_name` | varchar| Name of the column.|
+|`ordinal_position`|int32| Ordinal position of the column within the table (count starts at 1).|
 |`is_nullable` | varchar| `YES` if the column is possibly nullable; `NO` if it is known not nullable.|
-|`data_type` | varchar| Data type of the column|
+|`data_type` | varchar| Data type of the column.|
+|`is_generated` | varchar| `ALWAYS` if the column has a generated value; `NEVER` if it doesn't.|
+|`generation_expression` | varchar| Expression for generating values when `is_generated` is `ALWAYS`.|
 
 ## How to use the information schema views?
 

--- a/versioned_docs/version-1.7/sql/system-catalogs/pg_catalog.md
+++ b/versioned_docs/version-1.7/sql/system-catalogs/pg_catalog.md
@@ -22,7 +22,6 @@ RisingWave does not fully support all PostgreSQL system catalog columns.
 | [`pg_attribute`](https://www.postgresql.org/docs/current/catalog-pg-attribute.html) | Contains information about table columns.|
 | [`pg_cast`](https://www.postgresql.org/docs/current/catalog-pg-cast.html) | Contains information about type casts. |
 | [`pg_constraint`](https://www.postgresql.org/docs/current/catalog-pg-constraint.html) | Contains information about constraints defined for database tables. Constraints are used to enforce rules and restrictions on the data that can be stored in a table.|
-| [`pg_inherits`](https://www.postgresql.org/docs/current/catalog-pg-inherits.html)|
 | [`pg_conversion`](https://www.postgresql.org/docs/current/catalog-pg-conversion.html) | Contains information about encoding conversion functions. |
 | [`pg_class`](https://www.postgresql.org/docs/current/catalog-pg-class.html) | Contains information about tables, indexes, sequences, and views. |
 | [`pg_collation`](https://www.postgresql.org/docs/current/catalog-pg-collation.html) | Contains information about collations. |
@@ -36,6 +35,7 @@ RisingWave does not fully support all PostgreSQL system catalog columns.
 | [`pg_namespace`](https://www.postgresql.org/docs/current/catalog-pg-namespace.html) | Contains information about namespaces.|
 | [`pg_opclass`](https://www.postgresql.org/docs/current/catalog-pg-opclass.html) | Contains information about index access method operator classes. |
 | [`pg_operator`](https://www.postgresql.org/docs/current/catalog-pg-operator.html) | Contains information about operators. |
+| [`pg_partitioned_table`](https://www.postgresql.org/docs/current/catalog-pg-partitioned-table.html) | Contains information about how tables are partitioned. |
 | [`pg_proc`](https://www.postgresql.org/docs/current/catalog-pg-proc.html)|Contains information about functions, aggregate functions, and window functions. |
 | [`pg_roles`](https://www.postgresql.org/docs/current/view-pg-roles.html) | Contains information about database roles. |
 | [`pg_settings`](https://www.postgresql.org/docs/current/view-pg-settings.html) | Contains information about run-time parameters of the server.|

--- a/versioned_docs/version-1.7/sql/system-catalogs/rw_catalog.md
+++ b/versioned_docs/version-1.7/sql/system-catalogs/rw_catalog.md
@@ -81,7 +81,7 @@ SELECT name, initialized_at, created_at FROM rw_sources;
 |Relation Name | Description|
 |---|---|
  rw_actors             | Contains the available actor IDs, their statuses, and the corresponding fragment IDs, and parallel unit IDs. |
-  rw_columns            | Contains information about columns of all relations (except sources) in the database, including their names, positions, data types, and more.|
+  rw_columns            | Contains information about columns of all relations (except sources) in the database, including their names, positions, data types, generation details, and more.|
  rw_connections        | Contains details about the connections available in the database, such as their IDs, names, owners, types, and more.|
  rw_databases          | Contains information about the databases available in the database, such as the IDs, names, and owners.|
  rw_ddl_progress       | Contains the progress of running DDL statements. You can use this relation to view the progress of running DDL statements. For details, see [View statement progress](/manage/view-statement-progress.md).|


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  -  In Information schema, add description for `is_generated` and `generation_expression`.
  -  In PG catalog, add `pg_partitioned_table` (Delete `pg_inherits` as it appears twice in the doc).
  -  In RW catalog, add generation info for `rw_columns`.

- **Note**

  - Since v1.7

- **Related code PR**

  - https://github.com/risingwavelabs/risingwave/pull/15151

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/1876

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
