### PR TITLE
Creating new Avro sources requires schema registry

### DIFF
--- a/docs/concepts/key-concepts.md
+++ b/docs/concepts/key-concepts.md
@@ -7,7 +7,7 @@ slug: /key-concepts
   <link rel="canonical" href="https://docs.risingwave.com/docs/current/key-concepts/" />
 </head>
 
-This page explains key concepts and terms that are used throughout the documentation. In the first part, we present terms closely related to RisingWave. In the second part, we include a broader range of terms in a glossary. 
+This page explains key concepts and terms that are used throughout the documentation. In the first part, we present terms closely related to RisingWave. In the second part, we include a broader range of terms in a glossary.
 
 ## Key concepts of RisingWave
 
@@ -90,7 +90,7 @@ A view is a virtual relation that acts as an actual relation. It is not a part o
 
 ### Avro
 
-Avro is an open-source data serialization system that facilitates data exchange between systems, programming languages, and processing frameworks. Avro has a JSON-like data model, but it can be represented as either JSON or in a compact binary form. RisingWave can decode Avro data. You need to specify the schema by providing either a schema location or a schema registry URL (only for Kafka topics).
+Avro is an open-source data serialization system that facilitates data exchange between systems, programming languages, and processing frameworks. Avro has a JSON-like data model, but it can be represented as either JSON or in a compact binary form. RisingWave can decode Avro data. You need to specify the schema by providing a schema registry URL (only for Kafka topics).
 
 ### Connection
 

--- a/docs/ingest/ingest-from-kafka.md
+++ b/docs/ingest/ingest-from-kafka.md
@@ -79,8 +79,8 @@ For tables with primary key constraints, if a new data record with an existing k
 |*data_format*| Data format. Supported formats: `DEBEZIUM`, `MAXWELL`, `CANAL`, `UPSERT`, `PLAIN`. |
 |*data_encode*| Data encode. Supported encodes: `JSON`, `AVRO`, `PROTOBUF`, `CSV`. |
 |*message* | Message name of the main Message in schema definition. Required for Protobuf. |
-|*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. For Protobuf data, you must specify either a schema location or a schema registry but not both. For Avro data, it's not supported.|
-|*schema.registry*| Confluent Schema Registry URL. Example: `http://127.0.0.1:8081`. For Protobuf data, you must specify either a schema location or a Confluent Schema Registry but not both; for Avro data, you must specify a Confluent Schema Registry.|
+|*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. This option is not supported for Avro data. For Protobuf data, you must specify either a schema location or a schema registry but not both.|
+|*schema.registry*| Confluent Schema Registry URL. Example: `http://127.0.0.1:8081`. For Avro data, you must specify a Confluent Schema Registry. For Protobuf data, you must specify either a schema location or a Confluent Schema Registry but not both.|
 |*schema.registry.username*|Conditional. User name for the schema registry. It must be specified with `schema.registry.password`.|
 |*schema.registry.password*|Conditional. Password for the schema registry. It must be specified with `schema.registry.username`.|
 |*schema.registry.name.strategy*|Optional. Accepts `topic_name_strategy` (default), `record_name_strategy`, `topic_record_name_strategy`. If it is set to either `record_name_strategy` or `topic_record_name_strategy`, the `message` parameter must also be set. It can only be specified with *schema.registry*. |

--- a/docs/ingest/ingest-from-kafka.md
+++ b/docs/ingest/ingest-from-kafka.md
@@ -79,8 +79,8 @@ For tables with primary key constraints, if a new data record with an existing k
 |*data_format*| Data format. Supported formats: `DEBEZIUM`, `MAXWELL`, `CANAL`, `UPSERT`, `PLAIN`. |
 |*data_encode*| Data encode. Supported encodes: `JSON`, `AVRO`, `PROTOBUF`, `CSV`. |
 |*message* | Message name of the main Message in schema definition. Required for Protobuf. |
-|*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. For Avro and Protobuf data, you must specify either a schema location or a schema registry but not both.|
-|*schema.registry*| Confluent Schema Registry URL. Example: `http://127.0.0.1:8081`. For Avro or Protobuf data, you must specify either a schema location or a Confluent Schema Registry but not both.|
+|*location*| Web location of the schema file in `http://...`, `https://...`, or `S3://...` format. For Protobuf data, you must specify either a schema location or a schema registry but not both. For Avro data, it's not supported.|
+|*schema.registry*| Confluent Schema Registry URL. Example: `http://127.0.0.1:8081`. For Protobuf data, you must specify either a schema location or a Confluent Schema Registry but not both; for Avro data, you must specify a Confluent Schema Registry.|
 |*schema.registry.username*|Conditional. User name for the schema registry. It must be specified with `schema.registry.password`.|
 |*schema.registry.password*|Conditional. Password for the schema registry. It must be specified with `schema.registry.username`.|
 |*schema.registry.name.strategy*|Optional. Accepts `topic_name_strategy` (default), `record_name_strategy`, `topic_record_name_strategy`. If it is set to either `record_name_strategy` or `topic_record_name_strategy`, the `message` parameter must also be set. It can only be specified with *schema.registry*. |

--- a/docs/ingest/ingest-from-kafka.md
+++ b/docs/ingest/ingest-from-kafka.md
@@ -275,7 +275,7 @@ WHERE _rw_kafka_timestamp > now() - interval '10 minute';
 
 ## Read schemas from locations
 
-RisingWave supports reading schemas from a Web location in `http://...`, `https://...`, or `S3://...` format, or a Confluent Schema Registry for Kafka data in Avro or Protobuf format.
+RisingWave supports reading schemas from a Web location in `http://...`, `https://...`, or `S3://...` format, or a Confluent Schema Registry for Kafka data in Protobuf format. For Avro, only Confluent Schema Registry is supported for reading schemas.
 
 For Protobuf, if a schema location is specified, the schema file must be a `FileDescriptorSet`, which can be compiled from a `.proto` file with a command like this:
 

--- a/docs/ingest/supported-sources-and-formats.md
+++ b/docs/ingest/supported-sources-and-formats.md
@@ -42,7 +42,7 @@ When creating a source, you need to specify the data and encoding formats in the
 
 ### Avro
 
-For data in Avro format, you must specify a message and a schema file location. The schema file location can be an actual Web location that is in `http://...`, `https://...`, or `S3://...` format. For Kafka data in Avro, instead of a schema file location, you can provide a Confluent Schema Registry that RisingWave can get the schema from. For more details about using Schema Registry for Kafka data, see [Read schema from Schema Registry](/ingest/ingest-from-kafka.md#read-schemas-from-schema-registry).
+For data in Avro format, you must specify a message and a schema registry. For Kafka data in Avro, you need to provide a Confluent Schema Registry that RisingWave can get the schema from. For more details about using Schema Registry for Kafka data, see [Read schema from Schema Registry](/ingest/ingest-from-kafka.md#read-schemas-from-schema-registry).
 
 `schema.registry` can accept multiple addresses. RisingWave will send requests to all URLs and return the first successful result.
 
@@ -66,7 +66,7 @@ Syntax:
 FORMAT PLAIN
 ENCODE AVRO (
    message = 'main_message',
-   schema.location = 'location' | schema.registry = 'schema_registry_url [, ...]',
+   schema.registry = 'schema_registry_url [, ...]',
    [schema.registry.name.strategy = 'topic_name_strategy'],
    [key.message = 'test_key']
 )


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - Creating new Avro sources must specify a schema registry, the `schema.location` is not an option.

- **Related code PR**

  - https://github.com/risingwavelabs/risingwave/pull/15256

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/1902

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
