### PR TITLE
Add confluent schema registry for Kafka sink Protobuf

### DIFF
--- a/docs/guides/create-sink-kafka.md
+++ b/docs/guides/create-sink-kafka.md
@@ -123,7 +123,10 @@ When creating an append-only Protobuf sink, the following options can be used fo
 |Field|Notes|
 |-----|-----|
 |message| Required. Message name of the main Message in the schema definition. . |
-|schema.location| Required. The schema location. This can be in either `file://`, `http://`, or `https://` format. |
+|schema.registry| Required. The address of the schema registry. This can be in either `file://`, `http://`, `https://` format, or can come from a Confluent schema registry. |
+|schema.registry.username| Optional. The user name used to access the schema registry. |
+|schema.registry.password| Optional. The password associated with the user name. |
+|schema.registry.name.strategy| Optional. Accepted options include `topic_name_strategy` (default), `record_name_strategy`, and `topic_record_name_strategy`.|
 
 :::note
 The `file://` format is not recommended for production use. If it is used, it needs to be available for both meta and compute nodes.

--- a/docs/guides/create-sink-kafka.md
+++ b/docs/guides/create-sink-kafka.md
@@ -123,7 +123,7 @@ When creating an append-only Protobuf sink, the following options can be used fo
 |Field|Notes|
 |-----|-----|
 |message| Required. Message name of the main Message in the schema definition. . |
-|schema.registry| Required. The address of the schema registry. This can be in either `file://`, `http://`, `https://` format, or can come from a Confluent schema registry. |
+|schema.registry| Required. The address of the schema registry. This can be in either `file://`, `http://`, `https://` format, or a Confluent schema registry. |
 |schema.registry.username| Optional. The user name used to access the schema registry. |
 |schema.registry.password| Optional. The password associated with the user name. |
 |schema.registry.name.strategy| Optional. Accepted options include `topic_name_strategy` (default), `record_name_strategy`, and `topic_record_name_strategy`.|

--- a/docs/guides/create-sink-kafka.md
+++ b/docs/guides/create-sink-kafka.md
@@ -124,8 +124,8 @@ When creating an append-only Protobuf sink, the following options can be used fo
 |Field|Notes|
 |-----|-----|
 |message| Required. Message name of the main Message in the schema definition. . |
-|schema.location| The schema location. This can be in either `file://`, `http://`, `https://` format. |
-|schema.registry| The address of the schema registry. |
+|schema.location| Required if `schema.registry` is not specified. Only one of `schema.location` or `schema.registry` can be defined. The schema location. This can be in either `file://`, `http://`, `https://` format. |
+|schema.registry| Required if `schema.location` is not specified. Only one of `schema.location` or `schema.registry` can be defined. The address of the schema registry. |
 |schema.registry.username| Optional. The user name used to access the schema registry. |
 |schema.registry.password| Optional. The password associated with the user name. |
 |schema.registry.name.strategy| Optional. Accepted options include `topic_name_strategy` (default), `record_name_strategy`, and `topic_record_name_strategy`.|

--- a/docs/guides/create-sink-kafka.md
+++ b/docs/guides/create-sink-kafka.md
@@ -124,7 +124,8 @@ When creating an append-only Protobuf sink, the following options can be used fo
 |Field|Notes|
 |-----|-----|
 |message| Required. Message name of the main Message in the schema definition. . |
-|schema.registry| Required. The address of the schema registry. This can be in either `file://`, `http://`, `https://` format, or a Confluent schema registry. |
+|schema.location| The schema location. This can be in either `file://`, `http://`, `https://` format. |
+|schema.registry| The address of the schema registry. |
 |schema.registry.username| Optional. The user name used to access the schema registry. |
 |schema.registry.password| Optional. The password associated with the user name. |
 |schema.registry.name.strategy| Optional. Accepted options include `topic_name_strategy` (default), `record_name_strategy`, and `topic_record_name_strategy`.|


### PR DESCRIPTION

## Info

- **Description**

  - Add confluent schema registry as option, as well as related parameter, for Kafka sink Protobuf encode option

- **Notes**

  - [ Include any supplementary context or references here. ]

- **Related code PR**

  - https://github.com/risingwavelabs/risingwave/pull/15546

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/1953

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
