### PR TITLE
fix: use the correct endpoint for cos s3-compatible yaml

### DIFF
--- a/docs/deploy/risingwave-kubernetes.md
+++ b/docs/deploy/risingwave-kubernetes.md
@@ -284,7 +284,7 @@ spec:
     s3:
       # Endpoint of the S3 compatible object storage.
       #
-      # Here we use Tencent Cloud Object Store (COS) in ap-guanzhou as an example.
+      # Here we use Tencent Cloud Object Store (COS) in ap-guangzhou as an example.
       endpoint: cos.ap-guangzhou.myqcloud.com
       
       # Region of the S3 compatible bucket.

--- a/docs/deploy/risingwave-kubernetes.md
+++ b/docs/deploy/risingwave-kubernetes.md
@@ -282,10 +282,10 @@ spec:
     
     # Declaration of the S3 compatible state store backend.
     s3:
-      # Endpoint of the S3 compatible object storage. Two variables are supported:
-      # - ${BUCKET}: name of the S3 bucket.
-      # - ${REGION}: name of the region.
-      endpoint: ${BUCKET}.cos.${REGION}.myqcloud.com
+      # Endpoint of the S3 compatible object storage.
+      #
+      # Here we use Tencent Cloud Object Store (COS) in ap-guanzhou as an example.
+      endpoint: cos.ap-guangzhou.myqcloud.com
       
       # Region of the S3 compatible bucket.
       region: ap-guangzhou

--- a/versioned_docs/version-1.4/deploy/risingwave-kubernetes.md
+++ b/versioned_docs/version-1.4/deploy/risingwave-kubernetes.md
@@ -283,7 +283,7 @@ spec:
     s3:
       # Endpoint of the S3 compatible object storage.
       #
-      # Here we use Tencent Cloud Object Store (COS) in ap-guanzhou as an example.
+      # Here we use Tencent Cloud Object Store (COS) in ap-guangzhou as an example.
       endpoint: cos.ap-guangzhou.myqcloud.com
       
       # Region of the S3 compatible bucket.

--- a/versioned_docs/version-1.4/deploy/risingwave-kubernetes.md
+++ b/versioned_docs/version-1.4/deploy/risingwave-kubernetes.md
@@ -281,10 +281,10 @@ spec:
     
     # Declaration of the S3 compatible state store backend.
     s3:
-      # Endpoint of the S3 compatible object storage. Two variables are supported:
-      # - ${BUCKET}: name of the S3 bucket.
-      # - ${REGION}: name of the region.
-      endpoint: ${BUCKET}.cos.${REGION}.myqcloud.com
+      # Endpoint of the S3 compatible object storage.
+      #
+      # Here we use Tencent Cloud Object Store (COS) in ap-guanzhou as an example.
+      endpoint: cos.ap-guangzhou.myqcloud.com
       
       # Region of the S3 compatible bucket.
       region: ap-guangzhou

--- a/versioned_docs/version-1.5/deploy/risingwave-kubernetes.md
+++ b/versioned_docs/version-1.5/deploy/risingwave-kubernetes.md
@@ -283,7 +283,7 @@ spec:
     s3:
       # Endpoint of the S3 compatible object storage.
       #
-      # Here we use Tencent Cloud Object Store (COS) in ap-guanzhou as an example.
+      # Here we use Tencent Cloud Object Store (COS) in ap-guangzhou as an example.
       endpoint: cos.ap-guangzhou.myqcloud.com
       
       # Region of the S3 compatible bucket.

--- a/versioned_docs/version-1.5/deploy/risingwave-kubernetes.md
+++ b/versioned_docs/version-1.5/deploy/risingwave-kubernetes.md
@@ -281,10 +281,10 @@ spec:
     
     # Declaration of the S3 compatible state store backend.
     s3:
-      # Endpoint of the S3 compatible object storage. Two variables are supported:
-      # - ${BUCKET}: name of the S3 bucket.
-      # - ${REGION}: name of the region.
-      endpoint: ${BUCKET}.cos.${REGION}.myqcloud.com
+      # Endpoint of the S3 compatible object storage.
+      #
+      # Here we use Tencent Cloud Object Store (COS) in ap-guanzhou as an example.
+      endpoint: cos.ap-guangzhou.myqcloud.com
       
       # Region of the S3 compatible bucket.
       region: ap-guangzhou

--- a/versioned_docs/version-1.6/deploy/risingwave-kubernetes.md
+++ b/versioned_docs/version-1.6/deploy/risingwave-kubernetes.md
@@ -284,7 +284,7 @@ spec:
     s3:
       # Endpoint of the S3 compatible object storage.
       #
-      # Here we use Tencent Cloud Object Store (COS) in ap-guanzhou as an example.
+      # Here we use Tencent Cloud Object Store (COS) in ap-guangzhou as an example.
       endpoint: cos.ap-guangzhou.myqcloud.com
       
       # Region of the S3 compatible bucket.

--- a/versioned_docs/version-1.6/deploy/risingwave-kubernetes.md
+++ b/versioned_docs/version-1.6/deploy/risingwave-kubernetes.md
@@ -282,10 +282,10 @@ spec:
     
     # Declaration of the S3 compatible state store backend.
     s3:
-      # Endpoint of the S3 compatible object storage. Two variables are supported:
-      # - ${BUCKET}: name of the S3 bucket.
-      # - ${REGION}: name of the region.
-      endpoint: ${BUCKET}.cos.${REGION}.myqcloud.com
+      # Endpoint of the S3 compatible object storage.
+      #
+      # Here we use Tencent Cloud Object Store (COS) in ap-guanzhou as an example.
+      endpoint: cos.ap-guangzhou.myqcloud.com
       
       # Region of the S3 compatible bucket.
       region: ap-guangzhou

--- a/versioned_docs/version-1.7/deploy/risingwave-kubernetes.md
+++ b/versioned_docs/version-1.7/deploy/risingwave-kubernetes.md
@@ -284,7 +284,7 @@ spec:
     s3:
       # Endpoint of the S3 compatible object storage.
       #
-      # Here we use Tencent Cloud Object Store (COS) in ap-guanzhou as an example.
+      # Here we use Tencent Cloud Object Store (COS) in ap-guangzhou as an example.
       endpoint: cos.ap-guangzhou.myqcloud.com
       
       # Region of the S3 compatible bucket.

--- a/versioned_docs/version-1.7/deploy/risingwave-kubernetes.md
+++ b/versioned_docs/version-1.7/deploy/risingwave-kubernetes.md
@@ -282,10 +282,10 @@ spec:
     
     # Declaration of the S3 compatible state store backend.
     s3:
-      # Endpoint of the S3 compatible object storage. Two variables are supported:
-      # - ${BUCKET}: name of the S3 bucket.
-      # - ${REGION}: name of the region.
-      endpoint: ${BUCKET}.cos.${REGION}.myqcloud.com
+      # Endpoint of the S3 compatible object storage.
+      #
+      # Here we use Tencent Cloud Object Store (COS) in ap-guanzhou as an example.
+      endpoint: cos.ap-guangzhou.myqcloud.com
       
       # Region of the S3 compatible bucket.
       region: ap-guangzhou


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - deployment with s3-compatible object store (cos) yaml is updated to use path style endpoint instead of virual hosted style endpoint.

- **Notes**

  - This issue is found by a user

- **Related code PR**

  - [ Provide a link to the relevant code PR here, if applicable. ]

- **Related doc issue**
  
  Resolves [ Provide a link to the relevant doc issue here, if applicable. ]

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
