### PR TITLE
Hide the single-table MySQL/PG cdc source and use the shared source instead.

### DIFF
--- a/docs/guides/ingest-from-mysql-cdc.md
+++ b/docs/guides/ingest-from-mysql-cdc.md
@@ -153,7 +153,16 @@ To ensure all data changes are captured, you must create a table and specify pri
 
 ### Syntax
 
-Syntax for creating a CDC table. Note that a primary key is required.
+Syntax for creating a CDC source.
+
+```sql
+CREATE SOURCE [ IF NOT EXISTS ] source_name WITH (
+   connector='mysql-cdc',
+   <field>=<value>, ...
+);
+```
+
+Syntax for creating a CDC table. Note that a primary key is required and must be consistent with the upstream table.
 
 ```sql
 CREATE TABLE [ IF NOT EXISTS ] table_name (
@@ -164,16 +173,7 @@ WITH (
    connector='mysql-cdc',
    connector_parameter='value', ...
 )
-[ FORMAT DEBEZIUM ENCODE JSON ];
-```
-
-Syntax for creating a CDC source.
-
-```sql
-CREATE SOURCE [ IF NOT EXISTS ] source_name WITH (
-   connector='mysql-cdc',
-   <field>=<value>, ...
-);
+FROM source TABLE table_name;
 ```
 
 ### Connector parameters
@@ -217,35 +217,6 @@ Data is in Debezium JSON format. [Debezium](https://debezium.io) is a log-based 
 
 ## Examples
 
-### Create a single CDC table 
-
-The following example creates a table in RisingWave that reads CDC data from the `orders` table in MySQL. When connecting to a specific table in MySQL, use the `CREATE TABLE` command.
-
-```sql
-CREATE TABLE orders (
-  order_id int,
-  order_date bigint,
-  customer_name string,
-  price decimal,
-  product_id int,
-  order_status smallint,
-  PRIMARY KEY (order_id)
-) WITH (
-  connector = 'mysql-cdc',
-  hostname = '127.0.0.1',
-  port = '3306',
-  username = 'root',
-  password = '123456',
-  database.name = 'mydb',
-  table.name = 'orders',
-  server.id = '5454'
-);
-```
-
-### Create multiple CDC tables with the same source
-
-RisingWave supports creating a single MySQL source that allows you to read CDC data from multiple tables located in the same database.
-
 Connect to the upstream database by creating a CDC source using the [`CREATE SOURCE`](/sql/commands/sql-create-source.md) command and MySQL CDC parameters. The data format is fixed as `FORMAT PLAIN ENCODE JSON` so it does not need to be specified.
 
 ```sql
@@ -272,7 +243,7 @@ CREATE TABLE t1_rw (
 ) FROM mysql_mydb TABLE 'mydb.t1';
 ```
 
-You can create another CDC table in RisingWave that ingests data from table `t3` in the same database `mydb`.
+You can also create another CDC table in RisingWave that ingests data from table `t3` in the same database `mydb`.
 
 ```sql
 CREATE TABLE t3_rw (

--- a/docs/guides/ingest-from-mysql-cdc.md
+++ b/docs/guides/ingest-from-mysql-cdc.md
@@ -170,8 +170,7 @@ CREATE TABLE [ IF NOT EXISTS ] table_name (
    PRIMARY KEY ( column_name, ... )
 ) 
 WITH (
-   connector='mysql-cdc',
-   connector_parameter='value', ...
+   snapshot='true' 
 )
 FROM source TABLE table_name;
 ```
@@ -190,6 +189,11 @@ All the fields listed below are required. Note that the value of these parameter
 |table.name| Name of the table that you want to ingest data from. |
 |server.id| Required if creating a shared source. A numeric ID of the database client. It must be unique across all database processes that are running in the MySQL cluster. If not specified, RisingWave will generate a random ID.|
 |transactional| Optional. Specify whether you want to enable transactions for the CDC table that you are about to create. By default, the value is `'true'` for shared sources, and `'false'` otherwise. This feature is also supported for shared CDC sources for multi-table transactions. For details, see [Transaction within a CDC table](/concepts/transactions.md#transactions-within-a-cdc-table).|
+
+The following fields are used when creating a CDC table.
+
+|Field|Notes|
+|---|---|
 |snapshot| Optional. If `false`, CDC backfill will be disabled and only upstream events that have occurred after the creation of the table will be consumed. This option can only be applied for tables created from a shared source. |
 
 #### Debezium parameters

--- a/docs/guides/ingest-from-postgres-cdc.md
+++ b/docs/guides/ingest-from-postgres-cdc.md
@@ -172,8 +172,7 @@ CREATE TABLE [ IF NOT EXISTS ] table_name (
    PRIMARY KEY ( column_name, ... )
 ) 
 WITH (
-   connector='postgres-cdc',
-   connector_parameter='value', ...
+    snapshot='true' 
 )
 FROM source TABLE table_name;
 ```
@@ -197,11 +196,17 @@ Unless specified otherwise, the fields listed are required. Note that the value 
 |publication.name| Optional. Name of the publication. By default, the value is `rw_publication`. For more information, see [Multiple CDC source tables](#multiple-cdc-source-tables). |
 |publication.create.enable| Optional. By default, the value is `'true'`. If `publication.name` does not exist and this value is `'true'`, a `publication.name` will be created. If `publication.name` does not exist and this value is `'false'`, an error will be returned. |
 |transactional| Optional. Specify whether you want to enable transactions for the CDC table that you are about to create. By default, the value is `'true'` for shared sources, and `'false'` otherwise. This feature is also supported for shared CDC sources for multi-table transactions. For details, see [Transaction within a CDC table](/concepts/transactions.md#transactions-within-a-cdc-table).|
-|snapshot| Optional. If `false`, CDC backfill will be disabled and only upstream events that have occurred after the creation of the table will be consumed. This option can only be applied for tables created from a shared source. |
 
 :::note
 RisingWave implements CDC via PostgreSQL replication. Inspect the current progress via the [`pg_replication_slots`](https://www.postgresql.org/docs/14/view-pg-replication-slots.html) view. Remove inactive replication slots via [`pg_drop_replication_slot()`](https://www.postgresql.org/docs/current/functions-admin.html#:~:text=pg_drop_replication_slot). RisingWave does not automatically drop inactive replication slots. You must do this manually to prevent WAL files from accumulating in the upstream PostgreSQL database.
 :::
+
+The following fields are used when creating a CDC table.
+
+|Field|Notes|
+|---|---|
+|snapshot| Optional. If `false`, CDC backfill will be disabled and only upstream events that have occurred after the creation of the table will be consumed. This option can only be applied for tables created from a shared source. |
+
 
 #### Debezium parameters
 

--- a/docs/guides/ingest-from-postgres-cdc.md
+++ b/docs/guides/ingest-from-postgres-cdc.md
@@ -155,27 +155,27 @@ To ensure all data changes are captured, you must create a table or source and s
 
 ### Syntax
 
- Syntax for creating a CDC table. Note that a primary key is required.
-
- ```sql
- CREATE TABLE [ IF NOT EXISTS ] table_name (
-    column_name data_type PRIMARY KEY , ...
-    PRIMARY KEY ( column_name, ... )
- ) 
- WITH (
-    connector='postgres-cdc',
-    connector_parameter='value', ...
- )
- [ FORMAT DEBEZIUM ENCODE JSON ];
- ```
-
- Syntax for creating a CDC source.
+Syntax for creating a CDC source.
 
 ```sql
 CREATE SOURCE [ IF NOT EXISTS ] source_name WITH (
    connector='postgres-cdc',
    <field>=<value>, ...
 );
+```
+
+Syntax for creating a CDC table. Note that a primary key is required and must be consistent with the upstream table.
+
+```sql
+CREATE TABLE [ IF NOT EXISTS ] table_name (
+   column_name data_type PRIMARY KEY , ...
+   PRIMARY KEY ( column_name, ... )
+) 
+WITH (
+   connector='postgres-cdc',
+   connector_parameter='value', ...
+)
+FROM source TABLE table_name;
 ```
 
 ### Connector parameters
@@ -226,33 +226,6 @@ Data is in Debezium JSON format. [Debezium](https://debezium.io) is a log-based 
 
 ## Examples
 
-### Create a single CDC table
-
-The following example creates a table in RisingWave that reads CDC data from the `shipments` table in PostgreSQL. The `shipments` table is located in the `public` schema, under the `dev` database. When connecting to a specific table in PostgreSQL, use the `CREATE TABLE` command.
-
-```sql
- CREATE TABLE shipments (
-    shipment_id integer,
-    order_id integer,
-    origin string,
-    destination string,
-    is_arrived boolean,
-    PRIMARY KEY (shipment_id)
-) WITH (
-    connector = 'postgres-cdc',
-    hostname = '127.0.0.1',
-    port = '5432',
-    username = 'postgres',
-    password = 'postgres',
-    database.name = 'dev',
-    schema.name = 'public',
-    table.name = 'shipments'
-);
-```
-### Create multiple CDC tables with the same source
-
-RisingWave supports creating a single PostgreSQL source that allows you to read CDC data from multiple tables located in the same database.
-
 Connect to the upstream database by creating a CDC source using the [`CREATE SOURCE`](/sql/commands/sql-create-source.md) command and PostgreSQL CDC parameters. The data format is fixed as `FORMAT PLAIN ENCODE JSON` so it does not need to be specified.
 
 ```sql
@@ -278,7 +251,7 @@ CREATE TABLE tt3 (
 ) FROM pg_mydb TABLE 'public.tt3';
 ```
 
-You can create another CDC table in RisingWave that ingests data from table `tt4` in the schema `ods`.
+You can also create another CDC table in RisingWave that ingests data from table `tt4` in the schema `ods`.
 
 ```sql
 CREATE TABLE tt4 (

--- a/docs/guides/ingest-from-postgres-cdc.md
+++ b/docs/guides/ingest-from-postgres-cdc.md
@@ -178,6 +178,8 @@ WITH (
 FROM source TABLE table_name;
 ```
 
+To check the progress of backfilling historical data, find the corresponding internal table using the [`SHOW INTERNAL TABLES`](/sql/commands/sql-show-internal-tables.md) command and query from it. 
+
 ### Connector parameters
 
 Unless specified otherwise, the fields listed are required. Note that the value of these parameters should be enclosed in single quotation marks.


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

Hide the single-table MySQL/PG cdc source and use the shared source instead.

Preparing for deprecating the single-table MySQL/PG cdc source.

- **Notes**

  - [ Include any supplementary context or references here. ]

- **Related code PR**

  - [ Provide a link to the relevant code PR here, if applicable. ]

- **Related doc issue**
  
  Resolves [ Provide a link to the relevant doc issue here, if applicable. ]

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
