### PR TITLE
add more details about sink decouple

### DIFF
--- a/docs/data-delivery.md
+++ b/docs/data-delivery.md
@@ -96,6 +96,30 @@ To disable sink decoupling, set `sink_decouple` as `false` or `disable`, regardl
 SET sink_decouple = false;
 ```
 
+Sink decouple is enabled by default for the following sinks if the sink is append-only.
+
+- [Kafka](/guides/create-sink-kafka.md)
+- [Pulsar](/guides/sink-to-pulsar.md)
+- [Kinesis](/guides/sink-to-iceberg.md)
+- [Clickhouse](/guides/sink-to-clickhouse.md)
+- [Nats](/guides/sink-to-nats.md)
+- JDBC
+  - [MySQL](/guides/sink-to-mysql.md)
+  - [PostgreSQL](/guides/sink-to-postgres.md)
+  - [TiDB](/guides/sink-to-tidb.md)
+  - [CockroachDB](/guides/sink-to-cockroach.md)
+
+An internal system table `rw_sink_decouple` is provided to query whether a created sink has enabled sink decouple or not.
+```
+dev=> select sink_id, is_decouple from rw_sink_decouple;
+ sink_id | is_decouple 
+---------+-------------
+       2 | f
+       5 | t
+(2 rows)
+
+```
+
 ## Upsert sinks and primary keys
 
 For each sink, you can specify the data format. All sinks supports the `upsert` and `append-only` formats while Kafka also supports the `debezium` format. When creating an `upsert` sink, note whether or not you need to specify the primary key in the following situations.


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - Provide the list of sinks that enable sink decouple by default.
  - Provide the internal system `rw_sink_decouple` to query whether a sink has enabled sink decouple or not.

- **Notes**

  - [ Include any supplementary context or references here. ]

- **Related code PR**

  - [ Provide a link to the relevant code PR here, if applicable. ]

- **Related doc issue**
  
  Resolves [ Provide a link to the relevant doc issue here, if applicable. ]

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
