### PR TITLE
add `type` field to nats sink

### DIFF
--- a/docs/guides/create-sink-kafka.md
+++ b/docs/guides/create-sink-kafka.md
@@ -69,6 +69,7 @@ When creating a Kafka sink in RisingWave, you can specify the following Kafka-sp
 |message.max.bytes | properties.message.max.bytes | int |
 |message.send.max.retries |properties.message.send.max.retries| int|
 |message.timeout.ms| properties.message.timeout.ms| int |
+|properties.request.required.acks|request.required.acks| int |
 |queue.buffering.max.kbytes |properties.queue.buffering.max.kbytes| int|
 |queue.buffering.max.messages |properties.queue.buffering.max.messages |int|
 |queue.buffering.max.ms |properties.queue.buffering.max.ms |float|

--- a/docs/guides/create-sink-kafka.md
+++ b/docs/guides/create-sink-kafka.md
@@ -69,7 +69,6 @@ When creating a Kafka sink in RisingWave, you can specify the following Kafka-sp
 |message.max.bytes | properties.message.max.bytes | int |
 |message.send.max.retries |properties.message.send.max.retries| int|
 |message.timeout.ms| properties.message.timeout.ms| int |
-|properties.request.required.acks|request.required.acks| int |
 |queue.buffering.max.kbytes |properties.queue.buffering.max.kbytes| int|
 |queue.buffering.max.messages |properties.queue.buffering.max.messages |int|
 |queue.buffering.max.ms |properties.queue.buffering.max.ms |float|

--- a/docs/guides/sink-to-nats.md
+++ b/docs/guides/sink-to-nats.md
@@ -37,8 +37,9 @@ WITH (
    connect_mode=<connect_mode>
    username='<your user name>',
    password='<your password>'
-   jwt=`<your jwt>`,
-   nkey=`<your nkey>`
+   jwt='<your jwt>',
+   nkey='<your nkey>',
+   type='<sink data type>'
 );
 ```
 
@@ -52,7 +53,7 @@ The NATS sink connector in RisingWave provides at-least-once delivery semantics.
 
 :::note
 
-According to the [NATS documentation](https://docs.nats.io/running-a-nats-service/nats_admin/jetstream_admin/naming), stream names must adhere to subject naming rules as well as being friendly to the file system. Here are the recommended guidelines for stream names:
+According to the [NATS documentation](https://docs.nats.io/running-a-nats-service/nats_admin/jetstream_admin/naming), stream names must adhere to subject naming rules as well as be friendly to the file system. Here are the recommended guidelines for stream names:
 
 - Use alphanumeric values.
 - Avoid spaces, tabs, periods (`.`), greater than (`>`) or asterisks (`*`).
@@ -72,3 +73,4 @@ According to the [NATS documentation](https://docs.nats.io/running-a-nats-servic
 |`connect_mode`|Required. Authentication mode for the connection. Allowed values: `plain`: No authentication; `user_and_password`: Use user name and password for authentication. For this option, `username` and `password` must be specified; `credential`: Use JSON Web Token (JWT) and NKeys for authentication. For this option, `jwt` and `nkey` must be specified.  |
 |`jwt` and `nkey`|JWT and NKEY for authentication. For details, see [JWT](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/jwt) and [NKeys](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth).|
 |`username` and `password`| Conditional. The client user name and pasword. Required when `connect_mode` is `user_and_password`.|
+|`type`|Required. Sink data type. Its value should be append-only.|

--- a/docs/guides/sink-to-nats.md
+++ b/docs/guides/sink-to-nats.md
@@ -73,4 +73,4 @@ According to the [NATS documentation](https://docs.nats.io/running-a-nats-servic
 |`connect_mode`|Required. Authentication mode for the connection. Allowed values: `plain`: No authentication; `user_and_password`: Use user name and password for authentication. For this option, `username` and `password` must be specified; `credential`: Use JSON Web Token (JWT) and NKeys for authentication. For this option, `jwt` and `nkey` must be specified.  |
 |`jwt` and `nkey`|JWT and NKEY for authentication. For details, see [JWT](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/jwt) and [NKeys](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth).|
 |`username` and `password`| Conditional. The client user name and pasword. Required when `connect_mode` is `user_and_password`.|
-|`type`|Required. Sink data type. Its value should be append-only.|
+|`type`|Required. Sink data type. Its value should be `append-only`.|

--- a/versioned_docs/version-1.6/guides/sink-to-nats.md
+++ b/versioned_docs/version-1.6/guides/sink-to-nats.md
@@ -54,7 +54,7 @@ The NATS sink connector in RisingWave provides at-least-once delivery semantics.
 
 :::note
 
-According to the [NATS documentation](https://docs.nats.io/running-a-nats-service/nats_admin/jetstream_admin/naming), stream names must adhere to subject naming rules as well as being friendly to the file system. Here are the recommended guidelines for stream names:
+According to the [NATS documentation](https://docs.nats.io/running-a-nats-service/nats_admin/jetstream_admin/naming), stream names must adhere to subject naming rules as well as be friendly to the file system. Here are the recommended guidelines for stream names:
 
 - Use alphanumeric values.
 - Avoid spaces, tabs, periods (`.`), greater than (`>`) or asterisks (`*`).

--- a/versioned_docs/version-1.6/guides/sink-to-nats.md
+++ b/versioned_docs/version-1.6/guides/sink-to-nats.md
@@ -37,8 +37,9 @@ WITH (
    connect_mode=<connect_mode>
    username='<your user name>',
    password='<your password>'
-   jwt=`<your jwt>`,
-   nkey=`<your nkey>`
+   jwt='<your jwt>',
+   nkey='<your nkey>',
+   type='<sink data type>'
 )
 FORMAT PLAIN ENCODE JSON;
 ```
@@ -73,3 +74,4 @@ According to the [NATS documentation](https://docs.nats.io/running-a-nats-servic
 |`connect_mode`|Required. Authentication mode for the connection. Allowed values: `plain`: No authentication; `user_and_password`: Use user name and password for authentication. For this option, `username` and `password` must be specified; `credential`: Use JSON Web Token (JWT) and NKeys for authentication. For this option, `jwt` and `nkey` must be specified.  |
 |`jwt` and `nkey`|JWT and NKEY for authentication. For details, see [JWT](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/jwt) and [NKeys](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth).|
 |`username` and `password`| Conditional. The client user name and pasword. Required when `connect_mode` is `user_and_password`.|
+|`type`|Required. Sink data type. Its value should be append-only.|

--- a/versioned_docs/version-1.7/guides/sink-to-nats.md
+++ b/versioned_docs/version-1.7/guides/sink-to-nats.md
@@ -37,8 +37,9 @@ WITH (
    connect_mode=<connect_mode>
    username='<your user name>',
    password='<your password>'
-   jwt=`<your jwt>`,
-   nkey=`<your nkey>`
+   jwt='<your jwt>',
+   nkey='<your nkey>',
+   type='<sink data type>'
 );
 ```
 
@@ -72,3 +73,4 @@ According to the [NATS documentation](https://docs.nats.io/running-a-nats-servic
 |`connect_mode`|Required. Authentication mode for the connection. Allowed values: `plain`: No authentication; `user_and_password`: Use user name and password for authentication. For this option, `username` and `password` must be specified; `credential`: Use JSON Web Token (JWT) and NKeys for authentication. For this option, `jwt` and `nkey` must be specified.  |
 |`jwt` and `nkey`|JWT and NKEY for authentication. For details, see [JWT](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/jwt) and [NKeys](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth).|
 |`username` and `password`| Conditional. The client user name and pasword. Required when `connect_mode` is `user_and_password`.|
+|`type`|Required. Sink data type. Its value should be append-only.|

--- a/versioned_docs/version-1.8/guides/sink-to-nats.md
+++ b/versioned_docs/version-1.8/guides/sink-to-nats.md
@@ -37,8 +37,9 @@ WITH (
    connect_mode=<connect_mode>
    username='<your user name>',
    password='<your password>'
-   jwt=`<your jwt>`,
-   nkey=`<your nkey>`
+   jwt='<your jwt>',
+   nkey='<your nkey>',
+   type='<sink data type>'
 );
 ```
 
@@ -52,7 +53,7 @@ The NATS sink connector in RisingWave provides at-least-once delivery semantics.
 
 :::note
 
-According to the [NATS documentation](https://docs.nats.io/running-a-nats-service/nats_admin/jetstream_admin/naming), stream names must adhere to subject naming rules as well as being friendly to the file system. Here are the recommended guidelines for stream names:
+According to the [NATS documentation](https://docs.nats.io/running-a-nats-service/nats_admin/jetstream_admin/naming), stream names must adhere to subject naming rules as well as be friendly to the file system. Here are the recommended guidelines for stream names:
 
 - Use alphanumeric values.
 - Avoid spaces, tabs, periods (`.`), greater than (`>`) or asterisks (`*`).
@@ -72,3 +73,4 @@ According to the [NATS documentation](https://docs.nats.io/running-a-nats-servic
 |`connect_mode`|Required. Authentication mode for the connection. Allowed values: `plain`: No authentication; `user_and_password`: Use user name and password for authentication. For this option, `username` and `password` must be specified; `credential`: Use JSON Web Token (JWT) and NKeys for authentication. For this option, `jwt` and `nkey` must be specified.  |
 |`jwt` and `nkey`|JWT and NKEY for authentication. For details, see [JWT](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/jwt) and [NKeys](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth).|
 |`username` and `password`| Conditional. The client user name and pasword. Required when `connect_mode` is `user_and_password`.|
+|`type`|Required. Sink data type. Its value should be append-only.|


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - Add a field `type` to nats sink of ver 1.9, 1.8, 1.7, 1.6

- **Notes**

  - [ Include any supplementary context or references here. ]

- **Related code PR**

  

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/2103#event-12651841057

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
