### PR TITLE
add details of how often index operations are flushed via Elasticsearch sink

### DIFF
--- a/docs/guides/sink-to-elasticsearch.md
+++ b/docs/guides/sink-to-elasticsearch.md
@@ -2,13 +2,19 @@
 id: sink-to-elasticsearch
 title: Sink data from RisingWave to Elasticsearch
 description: Sink data from RisingWave to Elasticsearch.
-slug: /sink-to-elasticsearch 
+slug: /sink-to-elasticsearch
 ---
 You can deliver the data that has been ingested and transformed in RisingWave to Elasticsearch to serve searches or analytics.
 
 This guide describes how to sink data from RisingWave to Elasticsearch using the Elasticsearch sink connector in RisingWave.
 
 [Elasticsearch](https://www.elastic.co/elasticsearch/) is a distributed, RESTful search and analytics engine capable of addressing a growing number of use cases. It centrally stores your data for lightning-fast search, fine‑tuned relevancy, and powerful analytics that scale with ease.
+
+The Elasticsearch sink connecter in RisingWave will perform index operations via the [bulk API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#docs-bulk-api-request), flushing updates whenever one of these criteria is met:
+
+- 1,000 operations
+- 5mb of updates
+- 5 seconds since the last flush (assuming new actions are queued)
 
 :::note Beta Feature
 The Elasticsearch sink connector in RisingWave is currently a Beta feature that supports only versions 7.x and 8.x of Elasticsearch. Please contact us if you encounter any issues or have feedback.
@@ -38,7 +44,7 @@ WITH (
   primary_key = '<primary key of the sink_from object>',
   { index = '<your Elasticsearch index>' | index_column = '<your index column>' },
   url = 'http://<ES hostname>:<ES port>',
-  username = '<your ES username>', 
+  username = '<your ES username>',
   password = '<your password>',
   delimiter='<delimiter>'
 );


### PR DESCRIPTION
## Info

- **Description**

  - Elasticsearch sink guide

- **Related code PR**

  - These rules were determined based on https://github.com/risingwavelabs/risingwave/blob/656ad33bd9f7df90da130c917f1a4f1f6be20e90/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSink.java#L208-L233.

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
