### PR TITLE
correct the category of rust udf

### DIFF
--- a/docs/sql/commands/sql-create-function.md
+++ b/docs/sql/commands/sql-create-function.md
@@ -55,13 +55,6 @@ AS gcd
 USING LINK 'http://localhost:8815';
 ```
 
-Use `CREATE FUNCTION` to declare a UDF defined by Rust. For more details, see [Use UDFs in Rust](/sql/udf/udf-rust.md).
-
-```sql
-CREATE FUNCTION gcd(int, int) RETURNS int
-LANGUAGE wasm USING BASE64 'encoded-wasm-binary';
-```
-
 ## Embedded UDFs
 
 Here are examples of embedded UDFs.

--- a/docs/sql/udf/user-defined-functions.md
+++ b/docs/sql/udf/user-defined-functions.md
@@ -31,13 +31,15 @@ UDF is currently in Beta. Please contact us if you encounter any issues or have 
 
 ### UDFs as external functions
 
-RisingWave supports creating UDFs with the following programming languages:
+RisingWave supports creating external UDFs with the following programming languages:
 
 - [Python](/sql/udf/udf-python.md)
 
 - [Java](/sql/udf/udf-java.md)
 
 ### Embedded UDFs
+
+RisingWave supports creating embedded UDFs with the following programming languages:
 
 - [Python](/sql/udf/udf-python-embedded.md)
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -445,11 +445,6 @@ const sidebars = {
                       id: "sql/udf/udf-java",
                       label: "Java",
                     },
-                    {
-                      type: "doc",
-                      id: "sql/udf/udf-rust",
-                      label: "Rust",
-                    },
                   ],
                 },
                 {
@@ -468,6 +463,11 @@ const sidebars = {
                       id: "sql/udf/udf-javascript",
                       label: "JavaScript",
                     },
+                    {
+                      type: "doc",
+                      id: "sql/udf/udf-rust",
+                      label: "Rust",
+                    }
                   ],
                 },
                 {

--- a/versioned_docs/version-1.8/sql/commands/sql-create-function.md
+++ b/versioned_docs/version-1.8/sql/commands/sql-create-function.md
@@ -55,12 +55,6 @@ AS gcd
 USING LINK 'http://localhost:8815';
 ```
 
-Use `CREATE FUNCTION` to declare a UDF defined by Rust. For more details, see [Use UDFs in Rust](/sql/udf/udf-rust.md).
-
-```sql
-CREATE FUNCTION gcd(int, int) RETURNS int
-LANGUAGE wasm USING BASE64 'encoded-wasm-binary';
-```
 
 ## Embedded UDFs
 

--- a/versioned_docs/version-1.8/sql/udf/user-defined-functions.md
+++ b/versioned_docs/version-1.8/sql/udf/user-defined-functions.md
@@ -31,13 +31,15 @@ UDF is currently in Beta. Please contact us if you encounter any issues or have 
 
 ### UDFs as external functions
 
-RisingWave supports creating UDFs with the following programming languages:
+RisingWave supports creating external UDFs with the following programming languages:
 
 - [Python](/sql/udf/udf-python.md)
 
 - [Java](/sql/udf/udf-java.md)
 
 ### Embedded UDFs
+
+RisingWave supports creating embedded UDFs with the following programming languages:
 
 - [Python](/sql/udf/udf-python-embedded.md)
 

--- a/versioned_sidebars/version-1.8-sidebars.json
+++ b/versioned_sidebars/version-1.8-sidebars.json
@@ -417,11 +417,6 @@
                       "type": "doc",
                       "id": "sql/udf/udf-java",
                       "label": "Java"
-                    },
-                    {
-                      "type": "doc",
-                      "id": "sql/udf/udf-rust",
-                      "label": "Rust"
                     }
                   ]
                 },
@@ -440,6 +435,11 @@
                       "type": "doc",
                       "id": "sql/udf/udf-javascript",
                       "label": "JavaScript"
+                    },
+                    {
+                      "type": "doc",
+                      "id": "sql/udf/udf-rust",
+                      "label": "Rust"
                     }
                   ]
                 },


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - Rust UDF is categorized into external functions in the sidebar of 1.8 and 1.9, this PR fixed this issue and the related texts.

- **Notes**

  - [ Include any supplementary context or references here. ]

- **Related code PR**

  - [ Provide a link to the relevant code PR here, if applicable. ]

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/2119#event-12722908701
<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
