### PR TITLE
Add `snapshot.interval` and `snapshot.batch_size` parameters

### DIFF
--- a/docs/guides/ingest-from-mysql-cdc.md
+++ b/docs/guides/ingest-from-mysql-cdc.md
@@ -195,6 +195,8 @@ The following fields are used when creating a CDC table.
 |Field|Notes|
 |---|---|
 |snapshot| Optional. If `false`, CDC backfill will be disabled and only upstream events that have occurred after the creation of the table will be consumed. This option can only be applied for tables created from a shared source. |
+|snapshot.interval| Optional. Specifies the barrier interval for buffering upstream events. The default value is `1`. |
+|snapshot.batch_size| Optional. Specifies the batch size of a snapshot read query from the upstream table. The default value is `1000`. |
 
 #### Debezium parameters
 

--- a/docs/guides/ingest-from-postgres-cdc.md
+++ b/docs/guides/ingest-from-postgres-cdc.md
@@ -207,7 +207,8 @@ The following fields are used when creating a CDC table.
 |Field|Notes|
 |---|---|
 |snapshot| Optional. If `false`, CDC backfill will be disabled and only upstream events that have occurred after the creation of the table will be consumed. This option can only be applied for tables created from a shared source. |
-
+|snapshot.interval| Optional. Specifies the barrier interval for buffering upstream events. The default value is `1`. |
+|snapshot.batch_size| Optional. Specifies the batch size of a snapshot read query from the upstream table. The default value is `1000`. |
 
 #### Debezium parameters
 


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - In MySQL and PG, add `snapshot.interval` and `snapshot.batch_size` parameters under `WITH` option to create a table from CDC source.
 
- **Related code PR**

  - https://github.com/risingwavelabs/risingwave/pull/16426

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/2110

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
