### PR TITLE
2130 doc support a single ascii char as escape in like

### DIFF
--- a/docs/sql/functions-operators/sql-function-string.md
+++ b/docs/sql/functions-operators/sql-function-string.md
@@ -656,9 +656,9 @@ upper('tom') → 'TOM'
 ## `LIKE` pattern matching expressions
 
 ```sql
-string [ NOT ] { LIKE | ILIKE } pattern
+string [ NOT ] { LIKE | ILIKE } pattern [ ESCAPE 'escape_char' ]
 
-string [!]~~[*] pattern
+string [!]~~[*] pattern [ ESCAPE 'escape_char' ]
 ```
 
 The `LIKE` expression returns true if the string matches the supplied pattern. The `NOT LIKE` expression returns false if `LIKE` returns true. By using `ILIKE` instead of `LIKE`, the matching becomes case-insensitive.
@@ -675,13 +675,15 @@ If the pattern does not contain `_` or `%`, then the pattern only represents the
 
 ### Escape
 
-To match a literal underscore or percent sign without matching other characters, the respective character in pattern must be preceded by the escape character `\`. To match the escape character itself, write two escape characters: `\\`.
+To match a literal underscore or percent sign without matching other characters, the respective character in the pattern must be preceded by the escape character `\`. To match the escape character itself, write two escape characters: `\\`.
 
-:::note
+Or you can use `ESCAPE ''` to disable the escape mechanism, and you can also customize an escape character using the `ESCAPE` clause. 
 
-You can use `ESCAPE ''` to disable the escape mechanism, but specifying a custom escape character using the `ESCAPE` clause is not supported.
+Below are the characters supported to be specified as the escape character:
 
-:::
+- The underscore character `'_'`.
+- An empty string `''`.
+- UTF-8 characters.
 
 ### Examples
 

--- a/docs/sql/functions-operators/sql-function-string.md
+++ b/docs/sql/functions-operators/sql-function-string.md
@@ -679,7 +679,7 @@ To match a literal underscore or percent sign without matching other characters,
 
 Or you can use `ESCAPE ''` to disable the escape mechanism, and you can also customize an escape character using the `ESCAPE` clause. 
 
-Below are the characters supported to be specified as the escape character:
+Below are the characters supported to be specified as the 'escape_char':
 
 - The underscore character `'_'`.
 - An empty string `''`.


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - [ What's changed? Which parts of the docs are affected? ]

- **Notes**

  - [ Include any supplementary context or references here. ]

- **Related code PR**

  - https://github.com/risingwavelabs/risingwave/pull/16057

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/2130
<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`CharlieSYH`, `emile-00`, & `hengm3467`).
