### PR TITLE
Add note about kafka consumer group ID feature as replacement of FAQ

### DIFF
--- a/docs/ingest/ingest-from-kafka.md
+++ b/docs/ingest/ingest-from-kafka.md
@@ -624,6 +624,9 @@ WITH (
 
 </Tabs>
 
-## Related topics
 
-[Why does RisingWave not accept Kafka consumer group ID](/rw-faq.md#why-risingwave-does-not-accept-kafka-consumer-group-ids)
+---
+
+:::note
+We have noticed that there is a frequently asked question about the Kafka source: why doesn't RisingWave accept the Kafka consumer group ID? We want to inform you that we are actively working on supporting this feature. You can look forward to using the Kafka consumer group ID with RisingWave soon.
+:::

--- a/versioned_docs/version-1.7/ingest/ingest-from-kafka.md
+++ b/versioned_docs/version-1.7/ingest/ingest-from-kafka.md
@@ -525,6 +525,8 @@ WITH (
    properties.sasl.password='admin-secret'
 ) FORMAT PLAIN ENCODE JSON;
 ```
+---
 
-## Related topics
-[Why does RisingWave not accept Kafka consumer group ID](/rw-faq.md#why-risingwave-does-not-accept-kafka-consumer-group-ids)
+:::note
+We have noticed that there is a frequently asked question about the Kafka source: why doesn't RisingWave accept the Kafka consumer group ID? We want to inform you that we are actively working on supporting this feature. You can look forward to using the Kafka consumer group ID with RisingWave soon.
+:::

--- a/versioned_docs/version-1.8/ingest/ingest-from-kafka.md
+++ b/versioned_docs/version-1.8/ingest/ingest-from-kafka.md
@@ -528,6 +528,8 @@ WITH (
    properties.sasl.password='admin-secret'
 ) FORMAT PLAIN ENCODE JSON;
 ```
+---
 
-## Related topics
-[Why does RisingWave not accept Kafka consumer group ID](/rw-faq.md#why-risingwave-does-not-accept-kafka-consumer-group-ids)
+:::note
+We have noticed that there is a frequently asked question about the Kafka source: why doesn't RisingWave accept the Kafka consumer group ID? We want to inform you that we are actively working on supporting this feature. You can look forward to using the Kafka consumer group ID with RisingWave soon.
+:::


### PR DESCRIPTION


<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - The Kafka consumer group ID will be accepted in the future. Before that, since this is frequently asked in the Slack channel. We add a note in the doc to inform users about this. After the feature is supported, the note will be removed.
  - 
- **Notes**

  - [ Include any supplementary context or references here. ]

- **Related code PR**

- https://github.com/risingwavelabs/risingwave-docs/pull/2167

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/2207

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
