### PR TITLE
Add key encode clause for sink

### DIFF
--- a/docs/guides/create-sink-kafka.md
+++ b/docs/guides/create-sink-kafka.md
@@ -95,7 +95,7 @@ These options should be set in `FORMAT data_format ENCODE data_encode (key = 'va
 |force_append_only| If `true`, forces the sink to be `PLAIN` (also known as `append-only`), even if it cannot be.|
 |timestamptz.handling.mode|Controls the timestamptz output format. This parameter specifically applies to append-only or upsert sinks using JSON encoding. <br/> - If omitted, the output format of timestamptz is `2023-11-11T18:30:09.453000Z` which includes the UTC suffix `Z`. <br/> - When `utc_without_suffix` is specified, the format is changed to `2023-11-11 18:30:09.453000`.|
 |schemas.enable| Only configurable for upsert JSON sinks. By default, this value is `false` for upsert JSON sinks and `true` for debezium `JSON` sinks. If `true`, RisingWave will sink the data with the schema to the Kafka sink. Note that this is not referring to a schema registry containing a JSON schema, but rather schema formats defined using [Kafka Connect](https://www.confluent.io/blog/kafka-connect-deep-dive-converters-serialization-explained/#json-schemas).|
-|key_encode| Currently, the key encode can only be `TEXT`, and the primary key should be one of the following types: `varchar`, `bool`, `smallint`, `int`, and `bigint`.|
+|key_encode| Optional. When specified, the key encode can only be `TEXT`, and the primary key should be one and only one of the following types: `varchar`, `bool`, `smallint`, `int`, and `bigint`; When absent, both key and value will use the same setting of `ENCODE data_encode ( ... )`. |
 
 ### Avro specific parameters
 

--- a/docs/guides/create-sink-kafka.md
+++ b/docs/guides/create-sink-kafka.md
@@ -30,6 +30,7 @@ WITH (
 FORMAT data_format ENCODE data_encode [ (
     key = 'value'
 ) ]
+[KEY ENCODE key_encode [(...)]]
 ;
 ```
 
@@ -94,6 +95,7 @@ These options should be set in `FORMAT data_format ENCODE data_encode (key = 'va
 |force_append_only| If `true`, forces the sink to be `PLAIN` (also known as `append-only`), even if it cannot be.|
 |timestamptz.handling.mode|Controls the timestamptz output format. This parameter specifically applies to append-only or upsert sinks using JSON encoding. <br/> - If omitted, the output format of timestamptz is `2023-11-11T18:30:09.453000Z` which includes the UTC suffix `Z`. <br/> - When `utc_without_suffix` is specified, the format is changed to `2023-11-11 18:30:09.453000`.|
 |schemas.enable| Only configurable for upsert JSON sinks. By default, this value is `false` for upsert JSON sinks and `true` for debezium `JSON` sinks. If `true`, RisingWave will sink the data with the schema to the Kafka sink. Note that this is not referring to a schema registry containing a JSON schema, but rather schema formats defined using [Kafka Connect](https://www.confluent.io/blog/kafka-connect-deep-dive-converters-serialization-explained/#json-schemas).|
+|key_encode| Currently, the key encode can only be `TEXT`, and the primary key should be one of the following types: `varchar`, `bool`, `smallint`, `int`, and `bigint`.|
 
 ### Avro specific parameters
 

--- a/docs/guides/sink-to-aws-kinesis.md
+++ b/docs/guides/sink-to-aws-kinesis.md
@@ -56,7 +56,7 @@ These options should be set in `FORMAT data_format ENCODE data_encode (key = 'va
 |data_encode| Data encode. Supported encode: `JSON`. |
 |force_append_only| If `true`, forces the sink to be `PLAIN` (also known as `append-only`), even if it cannot be.|
 |timestamptz.handling.mode|Controls the timestamptz output format. This parameter specifically applies to append-only or upsert sinks using JSON encoding. <br/> - If omitted, the output format of timestamptz is `2023-11-11T18:30:09.453000Z` which includes the UTC suffix `Z`. <br/> - When `utc_without_suffix` is specified, the format is changed to `2023-11-11 18:30:09.453000`.|
-|key_encode| Currently, the key encode can only be `TEXT`, and the primary key should be one of the following types: `varchar`, `bool`, `smallint`, `int`, and `bigint`.|
+|key_encode| Optional. When specified, the key encode can only be `TEXT`, and the primary key should be one and only one of the following types: `varchar`, `bool`, `smallint`, `int`, and `bigint`; When absent, both key and value will use the same setting of `ENCODE data_encode ( ... )`. |
 
 ## Examples
 

--- a/docs/guides/sink-to-aws-kinesis.md
+++ b/docs/guides/sink-to-aws-kinesis.md
@@ -26,6 +26,7 @@ WITH (
 FORMAT data_format ENCODE data_encode [ (
     key = 'value'
 ) ]
+[KEY ENCODE key_encode [(...)]]
 ;
 ```
 
@@ -55,6 +56,7 @@ These options should be set in `FORMAT data_format ENCODE data_encode (key = 'va
 |data_encode| Data encode. Supported encode: `JSON`. |
 |force_append_only| If `true`, forces the sink to be `PLAIN` (also known as `append-only`), even if it cannot be.|
 |timestamptz.handling.mode|Controls the timestamptz output format. This parameter specifically applies to append-only or upsert sinks using JSON encoding. <br/> - If omitted, the output format of timestamptz is `2023-11-11T18:30:09.453000Z` which includes the UTC suffix `Z`. <br/> - When `utc_without_suffix` is specified, the format is changed to `2023-11-11 18:30:09.453000`.|
+|key_encode| Currently, the key encode can only be `TEXT`, and the primary key should be one of the following types: `varchar`, `bool`, `smallint`, `int`, and `bigint`.|
 
 ## Examples
 

--- a/docs/guides/sink-to-google-pubsub.md
+++ b/docs/guides/sink-to-google-pubsub.md
@@ -22,6 +22,7 @@ WITH (
 FORMAT data_format ENCODE data_encode [ (
     key = 'value'
 ) ]
+[KEY ENCODE key_encode [(...)]]
 ;
 ```
 
@@ -46,6 +47,7 @@ These options should be set in `FORMAT data_format ENCODE data_encode (key = 'va
 |data_format| Data format. Allowed format: `PLAIN`.|
 |data_encode| Data encode. Supported encode: `JSON`.|
 |force_append_only| Required by default and must be `true`, which forces the sink to be `PLAIN` (also known as append-only).|
+|key_encode| Currently, the key encode can only be `TEXT`, and the primary key should be one of the following types: `varchar`, `bool`, `smallint`, `int`, and `bigint`.|
 
 ## Example
 

--- a/docs/guides/sink-to-google-pubsub.md
+++ b/docs/guides/sink-to-google-pubsub.md
@@ -47,7 +47,7 @@ These options should be set in `FORMAT data_format ENCODE data_encode (key = 'va
 |data_format| Data format. Allowed format: `PLAIN`.|
 |data_encode| Data encode. Supported encode: `JSON`.|
 |force_append_only| Required by default and must be `true`, which forces the sink to be `PLAIN` (also known as append-only).|
-|key_encode| Currently, the key encode can only be `TEXT`, and the primary key should be one of the following types: `varchar`, `bool`, `smallint`, `int`, and `bigint`.|
+|key_encode| Optional. When specified, the key encode can only be `TEXT`, and the primary key should be one and only one of the following types: `varchar`, `bool`, `smallint`, `int`, and `bigint`; When absent, both key and value will use the same setting of `ENCODE data_encode ( ... )`. |
 
 ## Example
 

--- a/docs/guides/sink-to-pulsar.md
+++ b/docs/guides/sink-to-pulsar.md
@@ -64,7 +64,7 @@ These options should be set in `FORMAT data_format ENCODE data_encode (key = 'va
 |data_encode| Data encode. Supported encode: `JSON`. |
 |force_append_only| If `true`, forces the sink to be `PLAIN` (also known as `append-only`), even if it cannot be.|
 |timestamptz.handling.mode|Controls the timestamptz output format. This parameter specifically applies to append-only or upsert sinks using JSON encoding. <br/> - If omitted, the output format of timestamptz is `2023-11-11T18:30:09.453000Z` which includes the UTC suffix `Z`. <br/> - When `utc_without_suffix` is specified, the format is changed to `2023-11-11 18:30:09.453000`.|
-|key_encode| Currently, the key encode can only be `TEXT`, and the primary key should be one of the following types: `varchar`, `bool`, `smallint`, `int`, and `bigint`.|
+|key_encode| Optional. When specified, the key encode can only be `TEXT`, and the primary key should be one and only one of the following types: `varchar`, `bool`, `smallint`, `int`, and `bigint`; When absent, both key and value will use the same setting of `ENCODE data_encode ( ... )`. |
 
 ## Example
 

--- a/docs/guides/sink-to-pulsar.md
+++ b/docs/guides/sink-to-pulsar.md
@@ -31,6 +31,7 @@ WITH (
 )
 FORMAT data_format ENCODE data_encode [ (
     key = 'value' ) ]
+[KEY ENCODE key_encode [(...)]]
 ;
 ```
 
@@ -63,6 +64,7 @@ These options should be set in `FORMAT data_format ENCODE data_encode (key = 'va
 |data_encode| Data encode. Supported encode: `JSON`. |
 |force_append_only| If `true`, forces the sink to be `PLAIN` (also known as `append-only`), even if it cannot be.|
 |timestamptz.handling.mode|Controls the timestamptz output format. This parameter specifically applies to append-only or upsert sinks using JSON encoding. <br/> - If omitted, the output format of timestamptz is `2023-11-11T18:30:09.453000Z` which includes the UTC suffix `Z`. <br/> - When `utc_without_suffix` is specified, the format is changed to `2023-11-11 18:30:09.453000`.|
+|key_encode| Currently, the key encode can only be `TEXT`, and the primary key should be one of the following types: `varchar`, `bool`, `smallint`, `int`, and `bigint`.|
 
 ## Example
 

--- a/docs/guides/sink-to-redis.md
+++ b/docs/guides/sink-to-redis.md
@@ -53,7 +53,7 @@ These options should be set in `FORMAT data_format ENCODE data_encode (key = 'va
 |force_append_only| If `true`, forces the sink to be `PLAIN` (also known as `append-only`), even if it cannot be.|
 |key_format| Required if `data_encode` is `TEMPLATE`. Specify the format for the key as a string. |
 |value_format| Required if `data_encode` is `TEMPLATE`. Specify the format for the value as a string. |
-|key_encode| Currently, the key encode can only be `TEXT`, and the primary key should be one of the following types: `varchar`, `bool`, `smallint`, `int`, and `bigint`.|
+|key_encode| Optional. When specified, the key encode can only be `TEXT`, and the primary key should be one and only one of the following types: `varchar`, `bool`, `smallint`, `int`, and `bigint`; When absent, both key and value will use the same setting of `ENCODE data_encode ( ... )`. |
 
 
 ## Example

--- a/docs/guides/sink-to-redis.md
+++ b/docs/guides/sink-to-redis.md
@@ -29,6 +29,7 @@ WITH (
 )
 FORMAT data_format ENCODE data_encode [ (
     key = 'value' ) ]
+[KEY ENCODE key_encode [(...)]]
 ;
 ```
 
@@ -52,6 +53,8 @@ These options should be set in `FORMAT data_format ENCODE data_encode (key = 'va
 |force_append_only| If `true`, forces the sink to be `PLAIN` (also known as `append-only`), even if it cannot be.|
 |key_format| Required if `data_encode` is `TEMPLATE`. Specify the format for the key as a string. |
 |value_format| Required if `data_encode` is `TEMPLATE`. Specify the format for the value as a string. |
+|key_encode| Currently, the key encode can only be `TEXT`, and the primary key should be one of the following types: `varchar`, `bool`, `smallint`, `int`, and `bigint`.|
+
 
 ## Example
 


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - Add key encode clause for these sinks: Kafka, Pulsar, Kinesis, Redis, and PubSub

- **Related code PR**

  - https://github.com/risingwavelabs/risingwave/pull/16377

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/2148

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
