### PR TITLE
Doc: Automatically maps upstream table schema when creating MySQL and PG tables

### DIFF
--- a/docs/guides/ingest-from-mysql-cdc.md
+++ b/docs/guides/ingest-from-mysql-cdc.md
@@ -404,3 +404,31 @@ CREATE TABLE {{ this }}  (
     PRIMARY KEY(v1)
 ) FROM {{ ref('mysql_mydb') }} TABLE 'mydb.t1';
 ```
+
+## Automatically map upstream table schema
+
+RisingWave supports automatically mapping the upstream table schema when creating a CDC table from a MySQL CDC source. Instead of defining columns individually, you can use `*` when creating a table to ingest all columns from the source table. Note that `*` cannot be used if other columns are specified in the table creation process.
+
+Below is an example to create a table that ingests all columns from the upstream table from the MySQL database:
+
+```sql
+CREATE TABLE supplier (*) FROM mysql_source TABLE 'public.supplier';
+```
+
+And this it the output of `DESCRIBE supplier;`
+
+```sql
+       Name        |       Type        | Is Hidden | Description
+-------------------+-------------------+-----------+-------------
+ s_suppkey         | bigint            | false     |
+ s_name            | character varying | false     |
+ s_address         | character varying | false     |
+ s_nationkey       | bigint            | false     |
+ s_phone           | character varying | false     |
+ s_acctbal         | numeric           | false     |
+ s_comment         | character varying | false     |
+ primary key       | s_suppkey         |           |
+ distribution key  | s_suppkey         |           |
+ table description | supplier          |           |
+(10 rows)
+``` 

--- a/docs/guides/ingest-from-postgres-cdc.md
+++ b/docs/guides/ingest-from-postgres-cdc.md
@@ -404,3 +404,31 @@ CREATE TABLE {{ this }} (
     v2 timestamp with time zone
 ) FROM {{ ref('pg_mydb') }} TABLE 'public.tt3';
 ```
+
+## Automatically map upstream table schema
+
+RisingWave supports automatically mapping the upstream table schema when creating a CDC table from a PostgreSQL CDC source. Instead of defining columns individually, you can use `*` when creating a table to ingest all columns from the source table. Note that `*` cannot be used if other columns are specified in the table creation process.
+
+Below is an example to create a table that ingests all columns from the upstream table from the PostgreSQL database:
+
+```sql
+CREATE TABLE supplier (*) FROM pg_source TABLE 'public.supplier';
+```
+
+And this it the output of `DESCRIBE supplier;`
+
+```sql
+       Name        |       Type        | Is Hidden | Description
+-------------------+-------------------+-----------+-------------
+ s_suppkey         | bigint            | false     |
+ s_name            | character varying | false     |
+ s_address         | character varying | false     |
+ s_nationkey       | bigint            | false     |
+ s_phone           | character varying | false     |
+ s_acctbal         | numeric           | false     |
+ s_comment         | character varying | false     |
+ primary key       | s_suppkey         |           |
+ distribution key  | s_suppkey         |           |
+ table description | supplier          |           |
+(10 rows)
+``` 


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - Add doc about auto-map upstream table schema when creating MySQL and PG tables

- **Related code PR**

  - https://github.com/risingwavelabs/risingwave/pull/16986

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/2243

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
