### PR TITLE
fix(source): compatible formats for protobuf & avro

### DIFF
--- a/docs/ingest/formats-and-encode-parameters.md
+++ b/docs/ingest/formats-and-encode-parameters.md
@@ -30,8 +30,8 @@ The `FORMAT` parameter represents the organization format of the data and includ
 The `ENCODE` parameter represents the data encoding and includes the following options:
 
 - `JSON`: Data serialized in JSON format in the message queue, compatible with all `FORMAT` options.
-- `AVRO`: Data serialized in AVRO format in the message queue, compatible with all `FORMAT` options.
-- `Protobuf`: Data serialized in Protobuf format in the message queue, compatible with `FORMAT PLAIN / UPSERT / CANAL`.
+- `AVRO`: Data serialized in AVRO format in the message queue, compatible with `FORMAT PLAIN / UPSERT / DEBEZIUM`.
+- `Protobuf`: Data serialized in Protobuf format in the message queue, compatible with `FORMAT PLAIN`.
 - `CSV`: Data serialized in CSV format in the message queue, compatible with `FORMAT PLAIN`.
 - `Bytes`: Data exists in the message queue in raw bytes format, compatible with `FORMAT PLAIN`.
 

--- a/versioned_docs/version-1.8/ingest/formats-and-encode-parameters.md
+++ b/versioned_docs/version-1.8/ingest/formats-and-encode-parameters.md
@@ -30,8 +30,8 @@ The `FORMAT` parameter represents the organization format of the data and includ
 The `ENCODE` parameter represents the data encoding and includes the following options:
 
 - `JSON`: Data serialized in JSON format in the message queue, compatible with all `FORMAT` options.
-- `AVRO`: Data serialized in AVRO format in the message queue, compatible with all `FORMAT` options.
-- `Protobuf`: Data serialized in Protobuf format in the message queue, compatible with `FORMAT PLAIN / UPSERT / CANAL`.
+- `AVRO`: Data serialized in AVRO format in the message queue, compatible with `FORMAT PLAIN / UPSERT / DEBEZIUM`.
+- `Protobuf`: Data serialized in Protobuf format in the message queue, compatible with `FORMAT PLAIN`.
 - `CSV`: Data serialized in CSV format in the message queue, compatible with `FORMAT PLAIN`.
 - `Bytes`: Data exists in the message queue in raw bytes format, compatible with `FORMAT PLAIN`.
 

--- a/versioned_docs/version-1.9/ingest/formats-and-encode-parameters.md
+++ b/versioned_docs/version-1.9/ingest/formats-and-encode-parameters.md
@@ -30,8 +30,8 @@ The `FORMAT` parameter represents the organization format of the data and includ
 The `ENCODE` parameter represents the data encoding and includes the following options:
 
 - `JSON`: Data serialized in JSON format in the message queue, compatible with all `FORMAT` options.
-- `AVRO`: Data serialized in AVRO format in the message queue, compatible with all `FORMAT` options.
-- `Protobuf`: Data serialized in Protobuf format in the message queue, compatible with `FORMAT PLAIN / UPSERT / CANAL`.
+- `AVRO`: Data serialized in AVRO format in the message queue, compatible with `FORMAT PLAIN / UPSERT / DEBEZIUM`.
+- `Protobuf`: Data serialized in Protobuf format in the message queue, compatible with `FORMAT PLAIN`.
 - `CSV`: Data serialized in CSV format in the message queue, compatible with `FORMAT PLAIN`.
 - `Bytes`: Data exists in the message queue in raw bytes format, compatible with `FORMAT PLAIN`.
 


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - Remove the misclaim of source supporting the following format + encode combinations:
    - upsert protobuf
    - canal protobuf
    - maxwell avro
    - canal avro
    - debezium_mongo avro

- **Notes**

  - Reported by user, and we will support `upsert protobuf` soon
  - Content duplicated with [another page](https://docs.risingwave.com/docs/current/supported-sources-and-formats/) will be resolved by #2294, but it will take some time

- **Related code PR**

  - [ Provide a link to the relevant code PR here, if applicable. ]

- **Related doc issue**
  
  https://github.com/risingwavelabs/risingwave-docs/pull/1871#discussion_r1669566681

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
