### PR TITLE
refactor: reorder several pages in "Transform & query data"

### DIFF
--- a/docs/sql/functions-operators/sql-function-time-window.md
+++ b/docs/sql/functions-operators/sql-function-time-window.md
@@ -1,7 +1,7 @@
 ---
 id: sql-function-time-window
 slug: /sql-function-time-window
-title: Time window functions
+title: Time windows
 ---
 <head>
   <link rel="canonical" href="https://docs.risingwave.com/docs/current/sql-function-time-window/" />

--- a/sidebars.js
+++ b/sidebars.js
@@ -400,13 +400,13 @@ const sidebars = {
             },
             {
               type: "doc",
-              id: "transform/indexes",
-              label: "Indexes",
+              id: "sql/syntax/sql-pattern-temporal-filters",
+              label: "Temporal filters",
             },
             {
               type: "doc",
-              id: "sql/syntax/sql-pattern-temporal-filters",
-              label: "Temporal filters",
+              id: "transform/indexes",
+              label: "Indexes",
             },
             {
               type: "doc",
@@ -415,13 +415,35 @@ const sidebars = {
             },
             {
               type: "doc",
+              id: "sql/functions-operators/sql-function-time-window",
+              label: "Time windows",
+            },
+            {
+              type: "doc",
+              id: "transform/window-functions",
+              label: "Window functions",
+            },
+            {
+              type: "doc",
               id: "sql/syntax/sql-pattern-topn",
               label: "Top-N by group",
             },
             {
-              type: "doc",
-              id: "sql/functions-operators/sql-function-time-window",
-              label: "Time window functions",
+              type: "category",
+              label: "Emit on window close",
+              collapsible: true,
+              collapsed: true,
+              link: {
+                type: "doc",
+                id: "transform/emit-on-window-close",
+              },
+              items: [
+                {
+                  type: "doc",
+                  id: "transform/watermarks",
+                  label: "Watermarks",
+                },
+              ]
             },
             {
               type: "category",
@@ -486,28 +508,6 @@ const sidebars = {
                   label: "Foreign data",
                 },
               ],
-            },
-            {
-              type: "doc",
-              id: "transform/window-functions",
-              label: "Window functions",
-            },
-            {
-              type: "category",
-              label: "Emit on window close",
-              collapsible: true,
-              collapsed: true,
-              link: {
-                type: "doc",
-                id: "transform/emit-on-window-close",
-              },
-              items: [
-                {
-                  type: "doc",
-                  id: "transform/watermarks",
-                  label: "Watermarks",
-                },
-              ]
             },
             {
               type: "doc",


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Info

This PR reorders several pages in "Transform & query data" on the sidebar, so that related pages become adjacent to each other.

<img width="271" alt="截屏2024-07-19 13 20 45" src="https://github.com/user-attachments/assets/f73a04c0-3d69-49d4-bae1-702e629c2cc0">

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [x] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
