### PR TITLE
in 1.11 add commit_checkpoint_interval and remove clickhouse sink_dec…

### DIFF
--- a/docs/data-delivery.md
+++ b/docs/data-delivery.md
@@ -119,7 +119,6 @@ Sink decoupling is enabled by default for the following sinks:
 - [Kinesis](/guides/sink-to-iceberg.md)
 - [Google Pub/Sub](guides/sink-to-google-pubsub.md)
 - [Nats](/guides/sink-to-nats.md)
-- [Clickhouse](/guides/sink-to-clickhouse.md)
 
 Sink decoupling is enabled by default for the following sinks if `commit_checkpoint_interval` > 1:
 

--- a/docs/data-delivery.md
+++ b/docs/data-delivery.md
@@ -125,6 +125,7 @@ Sink decoupling is enabled by default for the following sinks if `commit_checkpo
 - [StarRocks](/guides/sink-to-starrocks.md)
 - [Delta Lake](/guides/sink-to-delta-lake.md)
 - [Apache Iceberg](/guides/sink-to-iceberg.md)
+- [Clickhouse](/guides/sink-to-clickhouse.md)
 
 Sink decoupling is enabled by default for the following sinks if the sink is append-only:
 

--- a/docs/guides/sink-to-clickhouse.md
+++ b/docs/guides/sink-to-clickhouse.md
@@ -46,6 +46,7 @@ WITH (
 | `clickhouse.password`   | Required. Password for accessing the ClickHouse server.|
 | `clickhouse.database`  | Required. Name of the ClickHouse database that you want to sink data to.|
 | `clickhouse.table`      | Required. Name of the ClickHouse table that you want to sink data to.|
+| `commit_checkpoint_interval`| Optional. Commit every N checkpoints (N > 0). If not set, it commits to ClickHouse at every checkpoint.|
 
 ### Upsert sinks
 


### PR DESCRIPTION
…ouple

<!--Edit the Info section when creating this PR.-->

## Info

- **Description**

  - Now we have 1.11 doc, so  as planned in https://github.com/risingwavelabs/risingwave-docs/pull/2345#pullrequestreview-2165071268, add `commit_checkpoint_interval` to clickhouse sink and remove clickhouse sink_decouple

- **Notes**

  - [ Include any supplementary context or references here. ]

- **Related code PR**

  - https://github.com/risingwavelabs/risingwave-docs/pull/2345

- **Related doc issue**
  
  Resolves https://github.com/risingwavelabs/risingwave-docs/issues/2357

<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->

<!--Edit the following sections when this PR is ready for review.-->

## For reviewers

- **Preview**

  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]

- **Key points**

  - [ Parts that may need revision or extra consideration. ]

## Before merging

- [ ] I have checked the doc site preview, and the updated parts look good.

- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
