### PR TITLE
update pr template to make it more readable

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,39 +1,43 @@
 <!--Edit the Info section when creating this PR.-->
 
-## Info
+## Description
 
-- **Description**
+<!--
+Please describe:
 
-  - [ What's changed? Which parts of the docs are affected? ]
+1. The motivation of this PR;
+2. What's changed and how is the document site is affected;
+3. References that's worth listed.
+-->
 
-- **Notes**
+## Related code PR
 
-  - [ Include any supplementary context or references here. ]
+<!--
+Provide a link to the relevant code PR here, if applicable.
+-->
 
-- **Related code PR**
+## Related doc issue
 
-  - [ Provide a link to the relevant code PR here, if applicable. ]
+<!--
+Provide a link to the relevant doc issue here, if applicable.
+If this PR fixes/resolves the issue, please write "Resolve #xxx".
+-->
 
-- **Related doc issue**
-  
-  Resolves [ Provide a link to the relevant doc issue here, if applicable. ]
+<!--
+❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.
+-->
 
-<!--❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.-->
+<!--
+Edit the following sections when this PR is ready for review.
+-->
 
-<!--Edit the following sections when this PR is ready for review.-->
+## Rendered preview
 
-## For reviewers
+<!--
+Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation.
+-->
 
-- **Preview**
-
-  - [ Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation. ]
-
-- **Key points**
-
-  - [ Parts that may need revision or extra consideration. ]
-
-## Before merging
+## Checklist
 
 - [ ] I have checked the doc site preview, and the updated parts look good.
-
 - [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).


### PR DESCRIPTION
This PR updates the PR template to use markdown headers instead of unordered list to structure the PR description. I guess this can make the PR description more readable. Some unnecessary fields (I saw barely PRs having those fields filled) are removed.