### PR TITLE
Rename `s3_v2` into `s3` in doc

### DIFF
--- a/docs/ingest/ingest-from-s3.md
+++ b/docs/ingest/ingest-from-s3.md
@@ -19,7 +19,7 @@ CREATE SOURCE [ IF NOT EXISTS ] source_name
 schema_definition
 [INCLUDE { header | key | offset | partition | timestamp } [AS <column_name>]]
 WITH (
-   connector='s3_v2',
+   connector='s3',
    connector_parameter='value', ...
 )
 FORMAT data_format ENCODE data_encode (
@@ -31,62 +31,6 @@ FORMAT data_format ENCODE data_encode (
 :::info
 For CSV data, specify the delimiter in the `delimiter` option in `ENCODE properties`.
 :::
-
-import rr from '@theme/RailroadDiagram'
-
-export const svg = rr.Diagram(
-    rr.Stack(
-        rr.Sequence(
-            rr.Terminal('CREATE SOURCE'),
-            rr.Optional(rr.Terminal('IF NOT EXISTS')),
-            rr.NonTerminal('source_name', 'skip')
-        ),
-        rr.NonTerminal('schema_definition', 'skip'),
-        rr.Sequence(
-            rr.Terminal('FORMAT'),
-            rr.NonTerminal('format', 'skip')
-        ),
-        rr.Sequence(
-            rr.Terminal('ENCODE'),
-            rr.NonTerminal('encode', 'skip'),
-            rr.Optional(
-                rr.Sequence(
-                rr.Terminal('('),
-                rr.NonTerminal('encode_parameter', 'skip'),
-                rr.Terminal(')'),
-                ),
-            ),
-        ),
-        rr.Sequence(
-            rr.Terminal('WITH'),
-            rr.Terminal('('),
-            rr.Stack(
-                rr.Stack(
-                    rr.Sequence(
-                        rr.Terminal('connector'),
-                        rr.Terminal('='),
-                        rr.Terminal('\'s3_v2\''),
-                        rr.Terminal(','),
-                    ),
-                    rr.OneOrMore(
-                        rr.Sequence(
-                            rr.NonTerminal('connector_parameter', 'skip'),
-                            rr.Terminal('='),
-                            rr.Terminal('\''),
-                            rr.NonTerminal('value', 'skip'),
-                            rr.Terminal('\''),
-                            rr.Terminal(','),
-                        ),
-                    ),
-                ),
-                rr.Terminal(')'),
-            ),
-        ),
-        rr.Terminal(';'),
-    )
-);
-
-<drawer SVG={svg} />
 
 **schema_definition**:
 
@@ -101,7 +45,7 @@ export const svg = rr.Diagram(
 
 |Field|Notes|
 |---|---|
-|connector|Required. Support the `s3_v2` (recommended) connector only. [Learn more about `s3_v2`](#s3_v2-connector).|
+|connector|Required. Support the `s3` (recommended) connector only. |
 |s3.region_name |Required. The service region.|
 |s3.bucket_name |Required. The name of the bucket the data source is stored in. |
 |s3.credentials.access|Required. This field indicates the access key ID of AWS. |
@@ -120,23 +64,6 @@ Empty cells in CSV files will be parsed to `NULL`.
 |*without_header*| Whether the first line is header. Accepted values: `'true'`, `'false'`. Default: `'true'`.|
 |*delimiter*| How RisingWave splits contents. For `JSON` encode, the delimiter is `\n`. |
 
-### `s3_v2` connector
-
-:::note BETA FEATURE
-
-The `s3_v2` connector is currently in Beta. Please contact us if you encounter any issues or have feedback.
-
-:::
-
-:::note DEPRECATED S3 Connector
-
-We have deprecated the legacy S3 Connector due to poor scalability and potential timeouts when dealing with a large number of files.
-While this decision forbids the creation of new stream jobs using the deprecate connector, existing streaming jobs will not be impacted and can continue to run as usual.
-
-:::
-
-The `s3_v2` connector is designed to address the scalability and performance limitations of the `s3` connector by implementing a more efficient listing and fetching mechanism. If you want to explore the technical details of this new approach, refer to [the design document](https://github.com/risingwavelabs/rfcs/blob/main/rfcs/0076-refined-s3-source.md).
-
 ## Examples
 
 Here are examples of connecting RisingWave to an S3 source to read data from individual streams.
@@ -154,7 +81,7 @@ CREATE TABLE s(
     age int
 ) 
 WITH (
-    connector = 's3_v2',
+    connector = 's3',
     s3.region_name = 'ap-southeast-2',
     s3.bucket_name = 'example-s3-source',
     s3.credentials.access = 'xxxxx',
@@ -176,7 +103,7 @@ CREATE TABLE s3(
     mark int,
 )
 WITH (
-    connector = 's3_v2',
+    connector = 's3',
     match_pattern = '%Ring%*.ndjson',
     s3.region_name = 'ap-southeast-2',
     s3.bucket_name = 'example-s3-source',
@@ -209,11 +136,11 @@ You need to create a materialized view from the source or create a table with th
 
 ```sql
 -- Create a materialized view from the source
-CREATE SOURCE s3_source WITH ( connector = 's3_v2', ... );
+CREATE SOURCE s3_source WITH ( connector = 's3', ... );
 CREATE MATERIALIZED VIEW mv AS SELECT * FROM s3_source;
 
 -- Create a table with the S3 connector
-CREATE TABLE s3_table ( ... ) WITH ( connector = 's3_v2', ... );
+CREATE TABLE s3_table ( ... ) WITH ( connector = 's3', ... );
 ```
 
 ### Read Parquet files from S3

--- a/docs/ingest/ingest-from-s3.md
+++ b/docs/ingest/ingest-from-s3.md
@@ -45,7 +45,7 @@ For CSV data, specify the delimiter in the `delimiter` option in `ENCODE propert
 
 |Field|Notes|
 |---|---|
-|connector|Required. Support the `s3` (recommended) connector only. |
+|connector|Required. Support the `s3` connector only. |
 |s3.region_name |Required. The service region.|
 |s3.bucket_name |Required. The name of the bucket the data source is stored in. |
 |s3.credentials.access|Required. This field indicates the access key ID of AWS. |


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Description


For the latest version, rename `s3_v2` with `s3` in doc


## Related code PR


https://github.com/risingwavelabs/risingwave/pull/17963


## Related doc issue


Resolve https://github.com/risingwavelabs/risingwave-docs/issues/2472.


<!--
❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.
-->

<!--
Edit the following sections when this PR is ready for review.
-->

## Rendered preview

<!--
Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation.
-->

## Checklist

- [ ] I have checked the doc site preview, and the updated parts look good.
- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
