### PR TITLE
doc: add restore guide for sql backend meta store

### DIFF
--- a/docs/manage/meta-backup.md
+++ b/docs/manage/meta-backup.md
@@ -68,7 +68,7 @@ If the cluster has been using a SQL database as meta store backend, use the foll
     This step is especially important because the meta backup and recovery process does not replicate SST files. It is not permitted for multiple clusters to run with the same SSTs set at any time, as this can corrupt the SST files.
     :::
 2. Create an new meta store, i.e. a new SQL database instance.   
-   Note that this new SQL database instance must have the exact same tables defined as the original, but all tables should remain empty. To achive this, you can use the [schema migration tool](https://github.com/risingwavelabs/risingwave/tree/main/src/meta/model_v2/migration) to create tables, and then truncate the `seaql_migrations` table.
+   Note that this new SQL database instance must have the exact same tables defined as the original, but all tables should remain empty. To achive this, you can optionally use the [schema migration tool](https://github.com/risingwavelabs/risingwave/tree/main/src/meta/model_v2/migration) to create tables, then truncate the `seaql_migrations` table, which will have been populated by the tool.
 3. Restore the meta snapshot to the new meta store.
 
     ```bash

--- a/docs/manage/meta-backup.md
+++ b/docs/manage/meta-backup.md
@@ -71,9 +71,9 @@ If the cluster has been using a SQL database as meta store backend, follow these
     :::note
     This step is especially important because the meta backup and recovery process does not replicate SST files. It is not permitted for multiple clusters to run with the same SSTs set at any time, as this can corrupt the SST files.
     :::
-2. Create an new meta store, i.e. a new SQL database instance.   
-   
-   Note that this new SQL database instance must have the exact same tables defined as the original, but all tables should remain empty. To achieve this, you can optionally use the [schema migration tool](https://github.com/risingwavelabs/risingwave/tree/main/src/meta/model_v2/migration) to create tables, then truncate those non-empty tables, which will have been populated by the tool.
+2. Create a new meta store, i.e. a new SQL database instance.
+
+   Note that this new SQL database instance must have the exact same tables defined as the original, but all tables should remain empty. To achieve this, you can optionally use the [schema migration tool](https://github.com/risingwavelabs/risingwave/tree/main/src/meta/model_v2/migration) to create tables, then truncate those non-empty tables populated by the tool.
 3. Restore the meta snapshot to the new meta store.
 
     ```bash

--- a/docs/manage/meta-backup.md
+++ b/docs/manage/meta-backup.md
@@ -68,7 +68,7 @@ If the cluster has been using a SQL database as meta store backend, use the foll
     This step is especially important because the meta backup and recovery process does not replicate SST files. It is not permitted for multiple clusters to run with the same SSTs set at any time, as this can corrupt the SST files.
     :::
 2. Create an new meta store, i.e. a new SQL database instance.   
-   Note that this new SQL database instance must have the exact same tables defined as the original, but all tables should remain empty. Optionally you can use the [schema migration tool](https://github.com/risingwavelabs/risingwave/tree/main/src/meta/model_v2/migration) to achieve this.
+   Note that this new SQL database instance must have the exact same tables defined as the original, but all tables should remain empty. To achive this, you can use the [schema migration tool](https://github.com/risingwavelabs/risingwave/tree/main/src/meta/model_v2/migration) to create tables, and then truncate the `seaql_migrations` table.
 3. Restore the meta snapshot to the new meta store.
 
     ```bash

--- a/docs/manage/meta-backup.md
+++ b/docs/manage/meta-backup.md
@@ -59,16 +59,21 @@ Here's an example of how to delete a meta snapshot with `risectl`:
 risectl meta delete-meta-snapshots [snapshot_ids]
 ```
 
-## Restore from a meta snapshot (SQL database as meta store backend)
+## Restore from a meta snapshot
 
-If the cluster has been using a SQL database as meta store backend, use the following steps to restore from a meta snapshot.
+Below are two separate methods to restore from a meta snapshot using SQL database and etcd as the meta store backend.
+
+### SQL database as meta store backend
+
+If the cluster has been using a SQL database as meta store backend, follow these steps to restore from a meta snapshot.
 
 1. Shut down the meta service.
     :::note
     This step is especially important because the meta backup and recovery process does not replicate SST files. It is not permitted for multiple clusters to run with the same SSTs set at any time, as this can corrupt the SST files.
     :::
-2. Create an new meta store, i.e. a new SQL database instance.   
-   Note that this new SQL database instance must have the exact same tables defined as the original, but all tables should remain empty. To achieve this, you can optionally use the [schema migration tool](https://github.com/risingwavelabs/risingwave/tree/main/src/meta/model_v2/migration) to create tables, then truncate the `seaql_migrations` table, which will have been populated by the tool.
+2. Create a new meta store, i.e. a new SQL database instance.
+
+   Note that this new SQL database instance must have the exact same tables defined as the original, but all tables should remain empty. To achieve this, you can optionally use the [schema migration tool](https://github.com/risingwavelabs/risingwave/tree/main/src/meta/model_v2/migration) to create tables, then truncate the `seaql_migrations` table, which will be populated by the tool.
 3. Restore the meta snapshot to the new meta store.
 
     ```bash
@@ -103,15 +108,15 @@ If the cluster has been using a SQL database as meta store backend, use the foll
     - `--hummock-storage-directory state_data`.
 4. Configure meta service to use the new meta store.
 
-## Restore from a meta snapshot (etcd as meta store backend)
+### etcd as meta store backend
 
-If the cluster has been using etcd as meta store backend, use the following steps to restore from a meta snapshot.
+If the cluster has been using etcd as meta store backend, follow these steps to restore from a meta snapshot.
 
 1. Shut down the meta service.
     :::note
     This step is especially important because the meta backup and recovery process does not replicate SST files. It is not permitted for multiple clusters to run with the same SSTs set at any time, as this can corrupt the SST files.
     :::
-2. Create an new meta store, i.e. a new and empty etcd instance.
+2. Create a new meta store, i.e. a new and empty etcd instance.
 3. Restore the meta snapshot to the new meta store.
 
     ```bash

--- a/docs/manage/meta-backup.md
+++ b/docs/manage/meta-backup.md
@@ -90,7 +90,7 @@ If the cluster has been using a SQL database as meta store backend, use the foll
     ```
     psql=> show parameters;
                   Name                     |                Value                 | Mutable
-   ----------------------------------------+--------------------------------------+---------
+    ---------------------------------------+--------------------------------------+---------
     state_store                            | hummock+s3://state_bucket            | f
     data_directory                         | state_data                           | f
     backup_storage_url                     | s3://backup_bucket                   | t
@@ -141,7 +141,7 @@ If the cluster has been using etcd as meta store backend, use the following step
     ```
     psql=> show parameters;
                   Name                     |                Value                 | Mutable
-   ----------------------------------------+--------------------------------------+---------
+    ---------------------------------------+--------------------------------------+---------
     state_store                            | hummock+s3://state_bucket            | f
     data_directory                         | state_data                           | f
     backup_storage_url                     | s3://backup_bucket                   | t

--- a/docs/manage/meta-backup.md
+++ b/docs/manage/meta-backup.md
@@ -68,7 +68,7 @@ If the cluster has been using a SQL database as meta store backend, use the foll
     This step is especially important because the meta backup and recovery process does not replicate SST files. It is not permitted for multiple clusters to run with the same SSTs set at any time, as this can corrupt the SST files.
     :::
 2. Create an new meta store, i.e. a new SQL database instance.   
-   Note that this new SQL database instance must have the exact same tables defined as the original, but all tables should remain empty. To achive this, you can optionally use the [schema migration tool](https://github.com/risingwavelabs/risingwave/tree/main/src/meta/model_v2/migration) to create tables, then truncate the `seaql_migrations` table, which will have been populated by the tool.
+   Note that this new SQL database instance must have the exact same tables defined as the original, but all tables should remain empty. To achieve this, you can optionally use the [schema migration tool](https://github.com/risingwavelabs/risingwave/tree/main/src/meta/model_v2/migration) to create tables, then truncate the `seaql_migrations` table, which will have been populated by the tool.
 3. Restore the meta snapshot to the new meta store.
 
     ```bash


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Description

Previously the restore guide is only for etcd backend meta store. This PR add content for sql backend meta store.
Specifically, a new section is created for sql backend, with some content duplicated from the etcd backend.

## Related code PR

<!--
Provide a link to the relevant code PR here, if applicable.
-->

## Related doc issue

<!--
Provide a link to the relevant doc issue here, if applicable.
If this PR fixes/resolves the issue, please write "Resolve #xxx".
-->

<!--
❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.
-->

<!--
Edit the following sections when this PR is ready for review.
-->

## Rendered preview

<!--
Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation.
-->

## Checklist

- [ ] I have checked the doc site preview, and the updated parts look good.
- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
