### PR TITLE
fix(style): fix image height

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -555,3 +555,7 @@ html.mdx-page h2 {
 [data-theme="dark"] .markdown img:not(.disabled-zoom, .icon) {
   border: 2px solid #0a3246;
 }
+
+img {
+  height: auto;
+}


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Description

This PR fixes a image height bug introduced in the last PR.

Before:

<img width="1584" alt="截屏2024-08-30 22 16 49" src="https://github.com/user-attachments/assets/90ee92ee-6518-4d2d-a729-a8036da10371">

After:

<img width="1584" alt="截屏2024-08-30 22 16 53" src="https://github.com/user-attachments/assets/743864fb-6dae-4eeb-b9e6-ce8916839ec9">

<!--
Edit the following sections when this PR is ready for review.
-->

## Rendered preview

<!--
Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation.
-->

## Checklist

- [x] I have checked the doc site preview, and the updated parts look good.
- [x] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
