### PR TITLE
fix(md): fix ill-formed links in markdown files

### DIFF
--- a/cloud/console-overview.md
+++ b/cloud/console-overview.md
@@ -69,7 +69,7 @@ width="270px"
 
 The sample queries cover the most common steps in RisingWave, such as establishing a connection with a data source, processing data by defining materialized views and querying the results.
 
-See [Explore RisingWave with examples](/quickstart.md/?step=4) for details.
+See [Explore RisingWave with examples](./quickstart.md#step-4-explore-risingwave-with-examples) for details.
 
 #### Switch users
 

--- a/docs/risingwave-sql-101.md
+++ b/docs/risingwave-sql-101.md
@@ -7,11 +7,11 @@ slug: /risingwave-sql-101
 
 In this guide, we will walk you through some of the most used SQL commands in RisingWave. This is a simple yet typical data processing workflow that shows how to manipulate data with RisingWave.
 
-> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands. 
+> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands.
 
 ## Before we start
 
-Ensure that you have [started and connected to RisingWave](get-started.md/#run-risingwave).
+Ensure that you have [started and connected to RisingWave](./get-started.md).
 
 ## Create a table
 
@@ -19,18 +19,18 @@ Now let's create a table to store data about taxi trips.
 
 ```sql
 CREATE TABLE taxi_trips (
-    trip_id int, 
-    taxi_id int, 
-    completed_at timestamp, 
-    distance double precision, 
+    trip_id int,
+    taxi_id int,
+    completed_at timestamp,
+    distance double precision,
     duration double precision);
 ```
 
 And let's add some data to the table.
 
 ```sql
-INSERT INTO taxi_trips VALUES 
-(1, 1001, '2022-07-01 22:00:00', 4, 6), 
+INSERT INTO taxi_trips VALUES
+(1, 1001, '2022-07-01 22:00:00', 4, 6),
 (2, 1002, '2022-07-01 22:01:00', 6, 9);
 ```
 
@@ -60,10 +60,10 @@ We can now query the average speed.
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration |     avg_speed      
+ no_of_trips | total_distance | total_duration |     avg_speed
 -------------+----------------+----------------+--------------------
            2 |             10 |             15 | 0.6666666666666666
 (1 row)
@@ -81,10 +81,10 @@ As soon as we insert the new record, the materialized view `mv_avg_speed` will b
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration | avg_speed 
+ no_of_trips | total_distance | total_duration | avg_speed
 -------------+----------------+----------------+-----------
            3 |             13 |             20 |      0.65
 (1 row)
@@ -100,21 +100,21 @@ Creating a materialized view from a source is similar to creating from a table.
 The following statement creates a materialized view for three columns in a connected source named `debezium_json_mysql_source`.
 
 ```sql title="To create a materialized view from a source:"
-CREATE MATERIALIZED VIEW debezium_json_mysql_mv 
-AS 
+CREATE MATERIALIZED VIEW debezium_json_mysql_mv
+AS
     SELECT COLUMN1, COLUMN2, COLUMN3 FROM debezium_json_mysql_source;
 ```
 > For details about creating a source, see [CREATE SOURCE](sql/commands/sql-create-source.md).
 
 ## Create a materialized view on materialized views
 
-With RisingWave, you can also create a materialized view from an existing materialized view. 
+With RisingWave, you can also create a materialized view from an existing materialized view.
 
 ```sql title="To create a materialized view from existing materialized views:"
 CREATE MATERIALIZED VIEW m3
-AS 
-    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2 
-    FROM m1 
+AS
+    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2
+    FROM m1
     INNER JOIN m2 ON m1.v1 = m2.v1;
 ```
 

--- a/src/pages/release-notes.md
+++ b/src/pages/release-notes.md
@@ -46,22 +46,22 @@ This version was released on July 30, 2024.
 - Supports additional metadata columns for CDC tables. [#17051](https://github.com/risingwavelabs/risingwave/pull/17051). See [Ingest data from PostgreSQL CDC](/docs/current/ingest-from-postgres-cdc/), [Ingest data from MySQL CDC](/docs/current/ingest-from-mysql-cdc/), and [Ingest data from MongoDB CDC](/docs/current/ingest-from-mongodb-cdc/).
 - Automatically maps upstream table schema when creating MySQL and PostgreSQL tables. [#16986](https://github.com/risingwavelabs/risingwave/pull/16986). See [Ingest data from PostgreSQL CDC](/docs/current/ingest-from-postgres-cdc/) and [Ingest data from MySQL CDC](/docs/current/ingest-from-mysql-cdc/).
 - Sets a network timeout for JDBC sink connections. [#17244](https://github.com/risingwavelabs/risingwave/pull/17244).
-- Enables sink decouple by default for Kafka, Kinesis, Pulsar, Google Pub/Sub, NATS, MQTT, ClickHouse sinks. [#17221](https://github.com/risingwavelabs/risingwave/pull/17221). See [Overview of data delivery](docs/current/data-delivery/#sink-decoupling).
-- Supports the `KEY ENCODE` clause when creating a sink. [#16377](https://github.com/risingwavelabs/risingwave/pull/16377). See [Sink to Kafka](docs/current/create-sink-kafka/), [Sink data from RisingWave to Google Pub/Sub](/docs/current/sink-to-google-pubsub/), [Sink to AWS Kinesis](docs/current/sink-to-aws-kinesis/), [Sink data from RisingWave to Apache Pulsar](/docs/current/sink-to-pulsar/), [Sink data from RisingWave to Redis](/docs/current/sink-to-redis/).
-- Supports `FORMAT PLAIN ENCODE AVRO` for Kafka sinks. [#17216](https://github.com/risingwavelabs/risingwave/pull/17216). See [Sink to Kafka](docs/current/create-sink-kafka/).
+- Enables sink decouple by default for Kafka, Kinesis, Pulsar, Google Pub/Sub, NATS, MQTT, ClickHouse sinks. [#17221](https://github.com/risingwavelabs/risingwave/pull/17221). See [Overview of data delivery](/docs/current/data-delivery/#sink-decoupling).
+- Supports the `KEY ENCODE` clause when creating a sink. [#16377](https://github.com/risingwavelabs/risingwave/pull/16377). See [Sink to Kafka](/docs/current/create-sink-kafka/), [Sink data from RisingWave to Google Pub/Sub](/docs/current/sink-to-google-pubsub/), [Sink to AWS Kinesis](/docs/current/sink-to-aws-kinesis/), [Sink data from RisingWave to Apache Pulsar](/docs/current/sink-to-pulsar/), [Sink data from RisingWave to Redis](/docs/current/sink-to-redis/).
+- Supports `FORMAT PLAIN ENCODE AVRO` for Kafka sinks. [#17216](https://github.com/risingwavelabs/risingwave/pull/17216). See [Sink to Kafka](/docs/current/create-sink-kafka/).
 - Supports DynamoDB sink. [#16670](https://github.com/risingwavelabs/risingwave/pull/16670). See [Sink data from RisingWave to Amazon DynamoDB](/docs/current/sink-to-dynamodb/).
 - Supports Microsoft SQL Server sinks for self-hosted SQL Server and Azure SQL. [#17154](https://github.com/risingwavelabs/risingwave/pull/17154). See [Sink data from RisingWave to SQL Server](/docs/current/sink-to-sqlserver/).
 - Supports OpenSearch sink. [#16330](https://github.com/risingwavelabs/risingwave/pull/16330). See [Sink data from RisingWave to OpenSearch](/docs/current/sink-to-opensearch/).
 - Supports checkpoint decouple for StarRocks sinks. [#16816](https://github.com/risingwavelabs/risingwave/pull/16816). See [Sink data from RisingWave to StarRocks](/docs/current/sink-to-starrocks/).
 - Supports checkpoint decouple for Delta Lake sinks. [#16777](https://github.com/risingwavelabs/risingwave/pull/16777). See [Sink data from RisingWave to Delta Lake](/docs/current/sink-to-delta-lake/).
-- Supports sinking serial types. [#16969](https://github.com/risingwavelabs/risingwave/pull/16969). See [Sink to Kafka](docs/current/create-sink-kafka/).
+- Supports sinking serial types. [#16969](https://github.com/risingwavelabs/risingwave/pull/16969). See [Sink to Kafka](/docs/current/create-sink-kafka/).
 
 #### Cluster configuration changes
 
 - Sets arrangement backfill as the default. [#14846](https://github.com/risingwavelabs/risingwave/pull/14846).
 - Supports spill hash join to avoid OOM issues. [#17122](https://github.com/risingwavelabs/risingwave/pull/17122).
 - Supports spill hash aggregation for batch queries. [#16771](https://github.com/risingwavelabs/risingwave/pull/16771).
-- Changes the algorithm that calculates the reserve memory size. [#16992](https://github.com/risingwavelabs/risingwave/pull/16992). See [FAQ](docs/current/rw-faq/#why-the-memory-usage-is-so-high).
+- Changes the algorithm that calculates the reserve memory size. [#16992](https://github.com/risingwavelabs/risingwave/pull/16992). See [FAQ](/docs/current/rw-faq/#why-the-memory-usage-is-so-high).
 
 #### Bug fixes
 
@@ -130,7 +130,7 @@ v1.9.0 was skipped due to some critical bugs.
 
 #### Cluster configuration changes
 
-- Supports using `ALTER SYSTEM` to set a system-wide default value for a session parameter. [#16062](https://github.com/risingwavelabs/risingwave/pull/16062). See [`ALTER SYSTEM`](docs/1.9/sql-alter-system/).
+- Supports using `ALTER SYSTEM` to set a system-wide default value for a session parameter. [#16062](https://github.com/risingwavelabs/risingwave/pull/16062). See [`ALTER SYSTEM`](/docs/1.9/sql-alter-system/).
 - Modifies the meaning of `streaming_rate_limit=0`, which now means pausing the snapshot read stream for backfill, and pausing source read for sources. This statement previously disabled the rate limit within the session. [#16333](https://github.com/risingwavelabs/risingwave/pull/16333). See [View and configure runtime parameters](/docs/1.9/view-configure-runtime-parameters/).
 - Supports configuring the reserved memory bytes of the compute node by using `RW_RESERVED_MEMORY_BYTES` runtime parameter and `reserved-memory-bytes` startup option.  [#16433](https://github.com/risingwavelabs/risingwave/pull/16433). See [View and configure runtime parameters](/docs/1.9/view-configure-runtime-parameters/).
 - Introduce new timeout and retry configurations for ObjectStore and deprecate ambiguous timeout configurations. [#16231](https://github.com/risingwavelabs/risingwave/pull/16231).

--- a/versioned_docs/version-1.0.0/guides/ingest-from-citus-cdc.md
+++ b/versioned_docs/version-1.0.0/guides/ingest-from-citus-cdc.md
@@ -51,9 +51,9 @@ There are a few limitations when ingesting CDC data from Citus in RisingWave.
 
 The native CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in the docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in the docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Create a table in RisingWave using the native CDC connector
 
@@ -65,7 +65,7 @@ Note that a primary key must be specified.
 CREATE TABLE [ IF NOT EXISTS ] source_name (
     column_name data_type PRIMARY KEY , ...
     [PRIMARY KEY ( column_name, ... )]
-) 
+)
 WITH (
     connector='citus-cdc',
     <field>=<value>, ...

--- a/versioned_docs/version-1.0.0/guides/ingest-from-mysql-cdc.md
+++ b/versioned_docs/version-1.0.0/guides/ingest-from-mysql-cdc.md
@@ -131,9 +131,9 @@ If your MySQL is hosted on AWS RDS, the configuration process is different. We w
 
 The native MySQL CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Create a table using the native CDC connector in RisingWave
 

--- a/versioned_docs/version-1.0.0/guides/ingest-from-postgres-cdc.md
+++ b/versioned_docs/version-1.0.0/guides/ingest-from-postgres-cdc.md
@@ -134,9 +134,9 @@ Here we will use a standard class instance without Multi-AZ deployment as an exa
 
 The native PostgreSQL CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Create a table using the native CDC connector
 

--- a/versioned_docs/version-1.0.0/guides/sink-to-mysql.md
+++ b/versioned_docs/version-1.0.0/guides/sink-to-mysql.md
@@ -107,9 +107,9 @@ To install and start RisingWave locally, see the [Get started](/get-started.md) 
 
 The native MySQL CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Create a sink
 

--- a/versioned_docs/version-1.0.0/guides/sink-to-postgres.md
+++ b/versioned_docs/version-1.0.0/guides/sink-to-postgres.md
@@ -91,9 +91,9 @@ To install and start RisingWave locally, see the [Get started](/get-started.md) 
 
 The native PostgreSQL CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Create a sink​
 

--- a/versioned_docs/version-1.0.0/key-concepts.md
+++ b/versioned_docs/version-1.0.0/key-concepts.md
@@ -73,7 +73,7 @@ A stateless worker node that compacts data for the storage engine.
 
 ### Connector node
 
-The connector node is a Java component that handles consuming CDC events from upstream systems and sinking data from RisingWave to downstream systems. When running RisingWave with Docker, this node is enabled by default. If running RisingWave locally, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+The connector node is a Java component that handles consuming CDC events from upstream systems and sinking data from RisingWave to downstream systems. When running RisingWave with Docker, this node is enabled by default. If running RisingWave locally, see [Enable the connector node](./deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ### Meta service
 

--- a/versioned_docs/version-1.0.0/manage/meta-backup.md
+++ b/versioned_docs/version-1.0.0/manage/meta-backup.md
@@ -32,7 +32,7 @@ Here's an example of how to create a new meta snapshot with `risectl`:
 risectl meta backup-meta
 ```
 
-`risectl` is included in the pre-built RisingWave binary. It can also be built from source. For details, see [Install RisingWave from the binaries](/deploy/risingwave-trial.md/?method=binaries).
+`risectl` is included in the pre-built RisingWave binary. It can also be built from source. For details, see [Install RisingWave from the binaries](../deploy/risingwave-trial.md?method=binaries).
 
 ## View existing meta snapshots
 
@@ -45,7 +45,7 @@ SELECT meta_snapshot_id FROM rw_catalog.rw_meta_snapshot;
 Example output:
 
 ```bash
- meta_snapshot_id 
+ meta_snapshot_id
 ------------------
                 3
                 4
@@ -99,13 +99,13 @@ Use the following steps to perform a time travel query.
    Example output:
 
     ```bash
-        safe_epoch    |      safe_epoch_ts      | max_committed_epoch | max_committed_epoch_ts  
+        safe_epoch    |      safe_epoch_ts      | max_committed_epoch | max_committed_epoch_ts
     ------------------+-------------------------+---------------------+-------------------------
      3603859827458048 | 2022-12-28 11:08:56.918 |    3603862776381440 | 2022-12-28 11:09:41.915
      3603898821640192 | 2022-12-28 11:18:51.922 |    3603900263432192 | 2022-12-28 11:19:13.922
     ```
 
-   Valid epochs are within range (`safe_epoch`,`max_committed_epoch`). For example, any epochs in [3603859827458048, 3603862776381440] or in [3603898821640192, 3603900263432192] are acceptable.  
+   Valid epochs are within range (`safe_epoch`,`max_committed_epoch`). For example, any epochs in [3603859827458048, 3603862776381440] or in [3603898821640192, 3603900263432192] are acceptable.
    `safe_epoch_ts` and `max_committed_epoch_ts` are human-readable equivalences.
 2. Set session config `QUERY_EPOCH`. By default, it's 0, which means disabling historical query.
 

--- a/versioned_docs/version-1.0.0/risingwave-sql-101.md
+++ b/versioned_docs/version-1.0.0/risingwave-sql-101.md
@@ -7,11 +7,11 @@ slug: /risingwave-sql-101
 
 In this guide, we will walk you through some of the most used SQL commands in RisingWave. This is a simple yet typical data processing workflow that shows how to manipulate data with RisingWave.
 
-> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands. 
+> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands.
 
 ## Before we start
 
-Ensure that you have [started and connected to RisingWave](get-started.md/#run-risingwave).
+Ensure that you have [started and connected to RisingWave](./get-started.md).
 
 ## Create a table
 
@@ -19,18 +19,18 @@ Now let's create a table to store data about taxi trips.
 
 ```sql
 CREATE TABLE taxi_trips (
-    trip_id int, 
-    taxi_id int, 
-    completed_at timestamp, 
-    distance double precision, 
+    trip_id int,
+    taxi_id int,
+    completed_at timestamp,
+    distance double precision,
     duration double precision);
 ```
 
 And let's add some data to the table.
 
 ```sql
-INSERT INTO taxi_trips VALUES 
-(1, 1001, '2022-07-01 22:00:00', 4, 6), 
+INSERT INTO taxi_trips VALUES
+(1, 1001, '2022-07-01 22:00:00', 4, 6),
 (2, 1002, '2022-07-01 22:01:00', 6, 9);
 ```
 
@@ -60,10 +60,10 @@ We can now query the average speed.
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration |     avg_speed      
+ no_of_trips | total_distance | total_duration |     avg_speed
 -------------+----------------+----------------+--------------------
            2 |             10 |             15 | 0.6666666666666666
 (1 row)
@@ -81,10 +81,10 @@ As soon as we insert the new record, the materialized view `mv_avg_speed` will b
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration | avg_speed 
+ no_of_trips | total_distance | total_duration | avg_speed
 -------------+----------------+----------------+-----------
            3 |             13 |             20 |      0.65
 (1 row)
@@ -100,21 +100,21 @@ Creating a materialized view from a source is similar to creating from a table.
 The following statement creates a materialized view for three columns in a connected source named `debezium_json_mysql_source`.
 
 ```sql title="To create a materialized view from a source:"
-CREATE MATERIALIZED VIEW debezium_json_mysql_mv 
-AS 
+CREATE MATERIALIZED VIEW debezium_json_mysql_mv
+AS
     SELECT COLUMN1, COLUMN2, COLUMN3 FROM debezium_json_mysql_source;
 ```
 > For details about creating a source, see [CREATE SOURCE](sql/commands/sql-create-source.md).
 
 ## Create a materialized view on materialized views
 
-With RisingWave, you can also create a materialized view from an existing materialized view. 
+With RisingWave, you can also create a materialized view from an existing materialized view.
 
 ```sql title="To create a materialized view from existing materialized views:"
 CREATE MATERIALIZED VIEW m3
-AS 
-    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2 
-    FROM m1 
+AS
+    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2
+    FROM m1
     INNER JOIN m2 ON m1.v1 = m2.v1;
 ```
 

--- a/versioned_docs/version-1.0.0/sql/functions-operators/sql-function-aggregate.md
+++ b/versioned_docs/version-1.0.0/sql/functions-operators/sql-function-aggregate.md
@@ -9,7 +9,7 @@ title: Aggregate functions
 
 Aggregate functions compute a single result from a set of input values.
 
-The DISTINCT option, ORDER BY clauses, and FILTER clauses can be used in aggregate expressions. The DISTINCT option cannot be used with an ORDER BY clause. For details about the supported syntax, see [Aggregate expressions](/sql/query-syntax/query-syntax-value-exp.md/#aggregate-expressions).
+The DISTINCT option, ORDER BY clauses, and FILTER clauses can be used in aggregate expressions. The DISTINCT option cannot be used with an ORDER BY clause. For details about the supported syntax, see [Aggregate expressions](../query-syntax/query-syntax-value-exp.md#aggregate-expressions).
 
 ## General-purpose aggregate functions
 
@@ -20,10 +20,10 @@ Returns an array from input values in which each value in the set is assigned to
 #### Syntax
 
 ```sql
-array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array       
-```  
+array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array
+```
 
----  
+---
 
 ### `avg`
 
@@ -32,14 +32,14 @@ Returns the average (arithmetic mean) of the selected values.
 #### Syntax
 
 ```sql
-avg ( expression ) -> see description   
-```  
+avg ( expression ) -> see description
+```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
 
 Return type is numeric for integer inputs and double precision for float point inputs.
 
----  
+---
 
 ### `bool_and`
 
@@ -51,7 +51,7 @@ Returns true if all input values are true, otherwise false.
 bool_and ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `bool_or`
 
@@ -63,7 +63,7 @@ Returns true if at least one input value is true, otherwise false.
 bool_or ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `count`
 
@@ -72,12 +72,12 @@ Returns the number of non-null rows.
 #### Syntax
 
 ```sql
-count ( expression ) -> bigint    
-```  
+count ( expression ) -> bigint
+```
 
-Input types include bool, smallint, int, bigint, numeric, real, double precision, and string.  
+Input types include bool, smallint, int, bigint, numeric, real, double precision, and string.
 
----  
+---
 
 ### `jsonb_agg`
 
@@ -86,12 +86,12 @@ Aggregates values, including nulls, as a JSON array. The `ORDER BY` clause is op
 #### Syntax
 
 ```sql
-jsonb_agg ( expression ) -> jsonb    
+jsonb_agg ( expression ) -> jsonb
 ```
 
 Currently, input types include boolean, smallint, int, bigint, real, double precision, varchar and jsonb.
 
----  
+---
 
 ### `jsonb_object_agg`
 
@@ -100,42 +100,42 @@ Aggregates name/value pairs as a JSON object.
 #### Syntax
 
 ```sql
-jsonb_object_agg ( key , value ) -> jsonb   
+jsonb_object_agg ( key , value ) -> jsonb
 ```
 
 `key`: varchar only.
 
 `value`: Currently supports null, boolean, smallint, int, bigint, real, double precision, varchar and jsonb.
 
----  
+---
 
 ### `max`
 
-Returns the maximum value in a set of values.  
+Returns the maximum value in a set of values.
 
 #### Syntax
 
 ```sql
-max ( expression ) -> same as input type    
-```  
+max ( expression ) -> same as input type
+```
 
-Input types include smallint, int, bigint, numeric, real, double precision, and string.  
+Input types include smallint, int, bigint, numeric, real, double precision, and string.
 
----  
+---
 
 ### `min`
 
-Returns the minimum value in a set of values.  
+Returns the minimum value in a set of values.
 
 #### Syntax
 
 ```sql
-min ( expression ) -> same as input type  
-```  
+min ( expression ) -> same as input type
+```
 
-Input types include smallint, int, bigint, numeric, real, double precision, and string.  
+Input types include smallint, int, bigint, numeric, real, double precision, and string.
 
----  
+---
 
 ### `string_agg`
 
@@ -144,10 +144,10 @@ Combines non-null values into a string, separated by `delimiter_string`. The `OR
 #### Syntax
 
 ```sql
-string_agg ( expression, delimiter_string ) -> output_string  
+string_agg ( expression, delimiter_string ) -> output_string
 ```
 
----  
+---
 
 ### `sum`
 
@@ -156,7 +156,7 @@ Returns the sum of all input values.
 #### Syntax
 
 ```sql
-sum ( expression )  
+sum ( expression )
 ```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
@@ -175,11 +175,11 @@ Calculates the population standard deviation of the input values. Returns `NULL`
 stddev_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `stddev_samp`
 
-Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.  
+Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.
 
 #### Syntax
 
@@ -187,7 +187,7 @@ Calculates the sample standard deviation of the input values. Returns `NULL` if 
 stddev_samp ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_pop`
 
@@ -199,7 +199,7 @@ Calculates the population variance of the input values. Returns `NULL` if the in
 var_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_samp`
 
@@ -237,7 +237,7 @@ This example calculates the mode of the values in `column1` from `table1`.
 SELECT mode() WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
 
----  
+---
 
 ### `percentile_cont`
 
@@ -263,7 +263,7 @@ This example calculates the median (50th percentile) of the values in `column1` 
 SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
 
----  
+---
 
 ### `percentile_disc`
 

--- a/versioned_docs/version-1.0.0/sql/functions-operators/sql-function-cast.md
+++ b/versioned_docs/version-1.0.0/sql/functions-operators/sql-function-cast.md
@@ -22,7 +22,7 @@ value :: type
 |Parameter        | Description     |
 |-----------------|-----------------|
 |*value*          |The value to be converted.|
-|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Data types](/sql/sql-data-types.md/#casts).|
+|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Casting](../data-types/data-type-casting.md).|
 
 
 ## Example

--- a/versioned_docs/version-1.1/guides/ingest-from-citus-cdc.md
+++ b/versioned_docs/version-1.1/guides/ingest-from-citus-cdc.md
@@ -51,9 +51,9 @@ There are a few limitations when ingesting CDC data from Citus in RisingWave.
 
 The native CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in the docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in the docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Create a table in RisingWave using the native CDC connector
 
@@ -65,7 +65,7 @@ Note that a primary key must be specified.
 CREATE TABLE [ IF NOT EXISTS ] source_name (
     column_name data_type PRIMARY KEY , ...
     [PRIMARY KEY ( column_name, ... )]
-) 
+)
 WITH (
     connector='citus-cdc',
     <field>=<value>, ...

--- a/versioned_docs/version-1.1/guides/ingest-from-mysql-cdc.md
+++ b/versioned_docs/version-1.1/guides/ingest-from-mysql-cdc.md
@@ -131,9 +131,9 @@ If your MySQL is hosted on AWS RDS, the configuration process is different. We w
 
 The native MySQL CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Create a table using the native CDC connector in RisingWave
 

--- a/versioned_docs/version-1.1/guides/ingest-from-postgres-cdc.md
+++ b/versioned_docs/version-1.1/guides/ingest-from-postgres-cdc.md
@@ -134,9 +134,9 @@ Here we will use a standard class instance without Multi-AZ deployment as an exa
 
 The native PostgreSQL CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Create a table using the native CDC connector
 

--- a/versioned_docs/version-1.1/guides/sink-to-mysql.md
+++ b/versioned_docs/version-1.1/guides/sink-to-mysql.md
@@ -108,9 +108,9 @@ To install and start RisingWave locally, see the [Get started](/get-started.md) 
 
 The native MySQL CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Create a sink
 

--- a/versioned_docs/version-1.1/guides/sink-to-postgres.md
+++ b/versioned_docs/version-1.1/guides/sink-to-postgres.md
@@ -91,9 +91,9 @@ To install and start RisingWave locally, see the [Get started](/get-started.md) 
 
 The native PostgreSQL CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Create a sink​
 

--- a/versioned_docs/version-1.1/key-concepts.md
+++ b/versioned_docs/version-1.1/key-concepts.md
@@ -73,7 +73,7 @@ A stateless worker node that compacts data for the storage engine.
 
 ### Connector node
 
-The connector node is a Java component that handles consuming CDC events from upstream systems and sinking data from RisingWave to downstream systems. When running RisingWave with Docker, this node is enabled by default. If running RisingWave locally, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+The connector node is a Java component that handles consuming CDC events from upstream systems and sinking data from RisingWave to downstream systems. When running RisingWave with Docker, this node is enabled by default. If running RisingWave locally, see [Enable the connector node](./deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ### Meta service
 

--- a/versioned_docs/version-1.1/manage/meta-backup.md
+++ b/versioned_docs/version-1.1/manage/meta-backup.md
@@ -32,7 +32,7 @@ Here's an example of how to create a new meta snapshot with `risectl`:
 risectl meta backup-meta
 ```
 
-`risectl` is included in the pre-built RisingWave binary. It can also be built from source. For details, see [Install RisingWave from the binaries](/deploy/risingwave-trial.md/?method=binaries).
+`risectl` is included in the pre-built RisingWave binary. It can also be built from source. For details, see [Install RisingWave from the binaries](../deploy/risingwave-trial.md?method=binaries).
 
 ## View existing meta snapshots
 
@@ -45,7 +45,7 @@ SELECT meta_snapshot_id FROM rw_catalog.rw_meta_snapshot;
 Example output:
 
 ```bash
- meta_snapshot_id 
+ meta_snapshot_id
 ------------------
                 3
                 4
@@ -99,13 +99,13 @@ Use the following steps to perform a time travel query.
    Example output:
 
     ```bash
-        safe_epoch    |      safe_epoch_ts      | max_committed_epoch | max_committed_epoch_ts  
+        safe_epoch    |      safe_epoch_ts      | max_committed_epoch | max_committed_epoch_ts
     ------------------+-------------------------+---------------------+-------------------------
      3603859827458048 | 2022-12-28 11:08:56.918 |    3603862776381440 | 2022-12-28 11:09:41.915
      3603898821640192 | 2022-12-28 11:18:51.922 |    3603900263432192 | 2022-12-28 11:19:13.922
     ```
 
-   Valid epochs are within range (`safe_epoch`,`max_committed_epoch`). For example, any epochs in [3603859827458048, 3603862776381440] or in [3603898821640192, 3603900263432192] are acceptable.  
+   Valid epochs are within range (`safe_epoch`,`max_committed_epoch`). For example, any epochs in [3603859827458048, 3603862776381440] or in [3603898821640192, 3603900263432192] are acceptable.
    `safe_epoch_ts` and `max_committed_epoch_ts` are human-readable equivalences.
 2. Set session config `QUERY_EPOCH`. By default, it's 0, which means disabling historical query.
 

--- a/versioned_docs/version-1.1/risingwave-sql-101.md
+++ b/versioned_docs/version-1.1/risingwave-sql-101.md
@@ -7,11 +7,11 @@ slug: /risingwave-sql-101
 
 In this guide, we will walk you through some of the most used SQL commands in RisingWave. This is a simple yet typical data processing workflow that shows how to manipulate data with RisingWave.
 
-> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands. 
+> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands.
 
 ## Before we start
 
-Ensure that you have [started and connected to RisingWave](get-started.md/#run-risingwave).
+Ensure that you have [started and connected to RisingWave](./get-started.md).
 
 ## Create a table
 
@@ -19,18 +19,18 @@ Now let's create a table to store data about taxi trips.
 
 ```sql
 CREATE TABLE taxi_trips (
-    trip_id int, 
-    taxi_id int, 
-    completed_at timestamp, 
-    distance double precision, 
+    trip_id int,
+    taxi_id int,
+    completed_at timestamp,
+    distance double precision,
     duration double precision);
 ```
 
 And let's add some data to the table.
 
 ```sql
-INSERT INTO taxi_trips VALUES 
-(1, 1001, '2022-07-01 22:00:00', 4, 6), 
+INSERT INTO taxi_trips VALUES
+(1, 1001, '2022-07-01 22:00:00', 4, 6),
 (2, 1002, '2022-07-01 22:01:00', 6, 9);
 ```
 
@@ -60,10 +60,10 @@ We can now query the average speed.
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration |     avg_speed      
+ no_of_trips | total_distance | total_duration |     avg_speed
 -------------+----------------+----------------+--------------------
            2 |             10 |             15 | 0.6666666666666666
 (1 row)
@@ -81,10 +81,10 @@ As soon as we insert the new record, the materialized view `mv_avg_speed` will b
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration | avg_speed 
+ no_of_trips | total_distance | total_duration | avg_speed
 -------------+----------------+----------------+-----------
            3 |             13 |             20 |      0.65
 (1 row)
@@ -100,21 +100,21 @@ Creating a materialized view from a source is similar to creating from a table.
 The following statement creates a materialized view for three columns in a connected source named `debezium_json_mysql_source`.
 
 ```sql title="To create a materialized view from a source:"
-CREATE MATERIALIZED VIEW debezium_json_mysql_mv 
-AS 
+CREATE MATERIALIZED VIEW debezium_json_mysql_mv
+AS
     SELECT COLUMN1, COLUMN2, COLUMN3 FROM debezium_json_mysql_source;
 ```
 > For details about creating a source, see [CREATE SOURCE](sql/commands/sql-create-source.md).
 
 ## Create a materialized view on materialized views
 
-With RisingWave, you can also create a materialized view from an existing materialized view. 
+With RisingWave, you can also create a materialized view from an existing materialized view.
 
 ```sql title="To create a materialized view from existing materialized views:"
 CREATE MATERIALIZED VIEW m3
-AS 
-    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2 
-    FROM m1 
+AS
+    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2
+    FROM m1
     INNER JOIN m2 ON m1.v1 = m2.v1;
 ```
 

--- a/versioned_docs/version-1.1/sql/functions-operators/sql-function-aggregate.md
+++ b/versioned_docs/version-1.1/sql/functions-operators/sql-function-aggregate.md
@@ -9,7 +9,7 @@ title: Aggregate functions
 
 Aggregate functions compute a single result from a set of input values.
 
-For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](/sql/query-syntax/query-syntax-value-exp.md/#aggregate-expressions).
+For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](../query-syntax/query-syntax-value-exp.md#aggregate-expressions).
 
 
 ## General-purpose aggregate functions
@@ -21,10 +21,10 @@ Returns an array from input values in which each value in the set is assigned to
 #### Syntax
 
 ```sql
-array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array       
-```  
+array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array
+```
 
----  
+---
 
 ### `avg`
 
@@ -33,14 +33,14 @@ Returns the average (arithmetic mean) of the selected values.
 #### Syntax
 
 ```sql
-avg ( expression ) -> see description   
-```  
+avg ( expression ) -> see description
+```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
 
 Return type is numeric for integer inputs and double precision for float point inputs.
 
----  
+---
 
 ### `bool_and`
 
@@ -52,7 +52,7 @@ Returns true if all input values are true, otherwise false.
 bool_and ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `bool_or`
 
@@ -64,7 +64,7 @@ Returns true if at least one input value is true, otherwise false.
 bool_or ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `count`
 
@@ -73,12 +73,12 @@ Returns the number of non-null rows.
 #### Syntax
 
 ```sql
-count ( expression ) -> bigint    
-```  
+count ( expression ) -> bigint
+```
 
-Input types include bool, smallint, int, bigint, numeric, real, double precision, and string.  
+Input types include bool, smallint, int, bigint, numeric, real, double precision, and string.
 
----  
+---
 
 ### `jsonb_agg`
 
@@ -87,12 +87,12 @@ Aggregates values, including nulls, as a JSON array. The `ORDER BY` clause is op
 #### Syntax
 
 ```sql
-jsonb_agg ( expression ) -> jsonb    
+jsonb_agg ( expression ) -> jsonb
 ```
 
 Currently, input types include boolean, smallint, int, bigint, real, double precision, varchar and jsonb.
 
----  
+---
 
 ### `jsonb_object_agg`
 
@@ -101,42 +101,42 @@ Aggregates name/value pairs as a JSON object.
 #### Syntax
 
 ```sql
-jsonb_object_agg ( key , value ) -> jsonb   
+jsonb_object_agg ( key , value ) -> jsonb
 ```
 
 `key`: varchar only.
 
 `value`: Currently supports null, boolean, smallint, int, bigint, real, double precision, varchar and jsonb.
 
----  
+---
 
 ### `max`
 
-Returns the maximum value in a set of values.  
+Returns the maximum value in a set of values.
 
 #### Syntax
 
 ```sql
-max ( expression ) -> same as input type    
-```  
+max ( expression ) -> same as input type
+```
 
-Input types include smallint, int, bigint, numeric, real, double precision, and string.  
+Input types include smallint, int, bigint, numeric, real, double precision, and string.
 
----  
+---
 
 ### `min`
 
-Returns the minimum value in a set of values.  
+Returns the minimum value in a set of values.
 
 #### Syntax
 
 ```sql
-min ( expression ) -> same as input type  
-```  
+min ( expression ) -> same as input type
+```
 
-Input types include smallint, int, bigint, numeric, real, double precision, and string.  
+Input types include smallint, int, bigint, numeric, real, double precision, and string.
 
----  
+---
 
 ### `string_agg`
 
@@ -145,10 +145,10 @@ Combines non-null values into a string, separated by `delimiter_string`. The `OR
 #### Syntax
 
 ```sql
-string_agg ( expression, delimiter_string ) -> output_string  
+string_agg ( expression, delimiter_string ) -> output_string
 ```
 
----  
+---
 
 ### `sum`
 
@@ -157,7 +157,7 @@ Returns the sum of all input values.
 #### Syntax
 
 ```sql
-sum ( expression )  
+sum ( expression )
 ```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
@@ -176,11 +176,11 @@ Calculates the population standard deviation of the input values. Returns `NULL`
 stddev_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `stddev_samp`
 
-Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.  
+Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.
 
 #### Syntax
 
@@ -188,7 +188,7 @@ Calculates the sample standard deviation of the input values. Returns `NULL` if 
 stddev_samp ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_pop`
 
@@ -200,7 +200,7 @@ Calculates the population variance of the input values. Returns `NULL` if the in
 var_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_samp`
 
@@ -238,7 +238,7 @@ This example calculates the mode of the values in `column1` from `table1`.
 SELECT mode() WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
 
----  
+---
 
 ### `percentile_cont`
 
@@ -264,7 +264,7 @@ This example calculates the median (50th percentile) of the values in `column1` 
 SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
 
----  
+---
 
 ### `percentile_disc`
 
@@ -315,8 +315,8 @@ INSERT INTO items_sold VALUES ('Foo', 'L', 10),('Foo', 'M', 20),('Bar', 'M', 15)
 ```
 
 ```sql title="Get grouping results"
-SELECT brand, size, sum(sales), grouping(brand), grouping(size), grouping(brand,size), count(DISTINCT sales) 
-FROM items_sold 
+SELECT brand, size, sum(sales), grouping(brand), grouping(size), grouping(brand,size), count(DISTINCT sales)
+FROM items_sold
 GROUP BY GROUPING SETS ((brand), (size), ());
 ------RESULTS
 Bar NULL 20 0 1 1 2

--- a/versioned_docs/version-1.1/sql/functions-operators/sql-function-cast.md
+++ b/versioned_docs/version-1.1/sql/functions-operators/sql-function-cast.md
@@ -22,7 +22,7 @@ value :: type
 |Parameter        | Description     |
 |-----------------|-----------------|
 |*value*          |The value to be converted.|
-|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Data types](/sql/sql-data-types.md/#casts).|
+|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Casting](../data-types/data-type-casting.md).|
 
 
 ## Example

--- a/versioned_docs/version-1.10/risingwave-sql-101.md
+++ b/versioned_docs/version-1.10/risingwave-sql-101.md
@@ -7,11 +7,11 @@ slug: /risingwave-sql-101
 
 In this guide, we will walk you through some of the most used SQL commands in RisingWave. This is a simple yet typical data processing workflow that shows how to manipulate data with RisingWave.
 
-> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands. 
+> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands.
 
 ## Before we start
 
-Ensure that you have [started and connected to RisingWave](get-started.md/#run-risingwave).
+Ensure that you have [started and connected to RisingWave](./get-started.md).
 
 ## Create a table
 
@@ -19,18 +19,18 @@ Now let's create a table to store data about taxi trips.
 
 ```sql
 CREATE TABLE taxi_trips (
-    trip_id int, 
-    taxi_id int, 
-    completed_at timestamp, 
-    distance double precision, 
+    trip_id int,
+    taxi_id int,
+    completed_at timestamp,
+    distance double precision,
     duration double precision);
 ```
 
 And let's add some data to the table.
 
 ```sql
-INSERT INTO taxi_trips VALUES 
-(1, 1001, '2022-07-01 22:00:00', 4, 6), 
+INSERT INTO taxi_trips VALUES
+(1, 1001, '2022-07-01 22:00:00', 4, 6),
 (2, 1002, '2022-07-01 22:01:00', 6, 9);
 ```
 
@@ -60,10 +60,10 @@ We can now query the average speed.
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration |     avg_speed      
+ no_of_trips | total_distance | total_duration |     avg_speed
 -------------+----------------+----------------+--------------------
            2 |             10 |             15 | 0.6666666666666666
 (1 row)
@@ -81,10 +81,10 @@ As soon as we insert the new record, the materialized view `mv_avg_speed` will b
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration | avg_speed 
+ no_of_trips | total_distance | total_duration | avg_speed
 -------------+----------------+----------------+-----------
            3 |             13 |             20 |      0.65
 (1 row)
@@ -100,21 +100,21 @@ Creating a materialized view from a source is similar to creating from a table.
 The following statement creates a materialized view for three columns in a connected source named `debezium_json_mysql_source`.
 
 ```sql title="To create a materialized view from a source:"
-CREATE MATERIALIZED VIEW debezium_json_mysql_mv 
-AS 
+CREATE MATERIALIZED VIEW debezium_json_mysql_mv
+AS
     SELECT COLUMN1, COLUMN2, COLUMN3 FROM debezium_json_mysql_source;
 ```
 > For details about creating a source, see [CREATE SOURCE](sql/commands/sql-create-source.md).
 
 ## Create a materialized view on materialized views
 
-With RisingWave, you can also create a materialized view from an existing materialized view. 
+With RisingWave, you can also create a materialized view from an existing materialized view.
 
 ```sql title="To create a materialized view from existing materialized views:"
 CREATE MATERIALIZED VIEW m3
-AS 
-    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2 
-    FROM m1 
+AS
+    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2
+    FROM m1
     INNER JOIN m2 ON m1.v1 = m2.v1;
 ```
 

--- a/versioned_docs/version-1.10/sql/functions-operators/sql-function-aggregate.md
+++ b/versioned_docs/version-1.10/sql/functions-operators/sql-function-aggregate.md
@@ -9,7 +9,7 @@ title: Aggregate functions
 
 Aggregate functions compute a single result from a set of input values.
 
-For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](/sql/query-syntax/query-syntax-value-exp.md/#aggregate-expressions).
+For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](../query-syntax/query-syntax-value-exp.md#aggregate-expressions).
 
 ## General-purpose aggregate functions
 

--- a/versioned_docs/version-1.10/sql/functions-operators/sql-function-cast.md
+++ b/versioned_docs/version-1.10/sql/functions-operators/sql-function-cast.md
@@ -22,7 +22,7 @@ value :: type
 |Parameter        | Description     |
 |-----------------|-----------------|
 |*value*          |The value to be converted.|
-|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Data types](/sql/sql-data-types.md/#casts).|
+|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Casting](../data-types/data-type-casting.md).|
 
 
 ## Example

--- a/versioned_docs/version-1.2/guides/ingest-from-citus-cdc.md
+++ b/versioned_docs/version-1.2/guides/ingest-from-citus-cdc.md
@@ -51,9 +51,9 @@ There are a few limitations when ingesting CDC data from Citus in RisingWave.
 
 The native CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in the docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in the docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Create a table in RisingWave using the native CDC connector
 
@@ -65,7 +65,7 @@ Note that a primary key must be specified.
 CREATE TABLE [ IF NOT EXISTS ] source_name (
     column_name data_type PRIMARY KEY , ...
     [PRIMARY KEY ( column_name, ... )]
-) 
+)
 WITH (
     connector='citus-cdc',
     <field>=<value>, ...

--- a/versioned_docs/version-1.2/guides/ingest-from-mysql-cdc.md
+++ b/versioned_docs/version-1.2/guides/ingest-from-mysql-cdc.md
@@ -127,9 +127,9 @@ If your MySQL is hosted on AWS RDS, the configuration process is different. We w
 
 The native MySQL CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 :::note EXPERIMENTAL ENHANCEMENT AVAILABLE
 

--- a/versioned_docs/version-1.2/guides/ingest-from-postgres-cdc.md
+++ b/versioned_docs/version-1.2/guides/ingest-from-postgres-cdc.md
@@ -134,9 +134,9 @@ Here we will use a standard class instance without Multi-AZ deployment as an exa
 
 The native PostgreSQL CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Create a table using the native CDC connector
 

--- a/versioned_docs/version-1.2/guides/sink-to-mysql.md
+++ b/versioned_docs/version-1.2/guides/sink-to-mysql.md
@@ -108,9 +108,9 @@ To install and start RisingWave locally, see the [Get started](/get-started.md) 
 
 The native MySQL CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Create a sink
 

--- a/versioned_docs/version-1.2/guides/sink-to-postgres.md
+++ b/versioned_docs/version-1.2/guides/sink-to-postgres.md
@@ -91,9 +91,9 @@ To install and start RisingWave locally, see the [Get started](/get-started.md) 
 
 The native PostgreSQL CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Create a sink​
 

--- a/versioned_docs/version-1.2/key-concepts.md
+++ b/versioned_docs/version-1.2/key-concepts.md
@@ -73,7 +73,7 @@ A stateless worker node that compacts data for the storage engine.
 
 ### Connector node
 
-The connector node is a Java component that handles consuming CDC events from upstream systems and sinking data from RisingWave to downstream systems. When running RisingWave with Docker, this node is enabled by default. If running RisingWave locally, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+The connector node is a Java component that handles consuming CDC events from upstream systems and sinking data from RisingWave to downstream systems. When running RisingWave with Docker, this node is enabled by default. If running RisingWave locally, see [Enable the connector node](./deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ### Meta service
 

--- a/versioned_docs/version-1.2/manage/meta-backup.md
+++ b/versioned_docs/version-1.2/manage/meta-backup.md
@@ -32,7 +32,7 @@ Here's an example of how to create a new meta snapshot with `risectl`:
 risectl meta backup-meta
 ```
 
-`risectl` is included in the pre-built RisingWave binary. It can also be built from source. For details, see [Install RisingWave from the binaries](/deploy/risingwave-trial.md/?method=binaries).
+`risectl` is included in the pre-built RisingWave binary. It can also be built from source. For details, see [Install RisingWave from the binaries](../deploy/risingwave-trial.md?method=binaries).
 
 ## View existing meta snapshots
 
@@ -45,7 +45,7 @@ SELECT meta_snapshot_id FROM rw_catalog.rw_meta_snapshot;
 Example output:
 
 ```bash
- meta_snapshot_id 
+ meta_snapshot_id
 ------------------
                 3
                 4
@@ -99,13 +99,13 @@ Use the following steps to perform a time travel query.
    Example output:
 
     ```bash
-        safe_epoch    |      safe_epoch_ts      | max_committed_epoch | max_committed_epoch_ts  
+        safe_epoch    |      safe_epoch_ts      | max_committed_epoch | max_committed_epoch_ts
     ------------------+-------------------------+---------------------+-------------------------
      3603859827458048 | 2022-12-28 11:08:56.918 |    3603862776381440 | 2022-12-28 11:09:41.915
      3603898821640192 | 2022-12-28 11:18:51.922 |    3603900263432192 | 2022-12-28 11:19:13.922
     ```
 
-   Valid epochs are within range (`safe_epoch`,`max_committed_epoch`). For example, any epochs in [3603859827458048, 3603862776381440] or in [3603898821640192, 3603900263432192] are acceptable.  
+   Valid epochs are within range (`safe_epoch`,`max_committed_epoch`). For example, any epochs in [3603859827458048, 3603862776381440] or in [3603898821640192, 3603900263432192] are acceptable.
    `safe_epoch_ts` and `max_committed_epoch_ts` are human-readable equivalences.
 2. Set session config `QUERY_EPOCH`. By default, it's 0, which means disabling historical query.
 

--- a/versioned_docs/version-1.2/risingwave-sql-101.md
+++ b/versioned_docs/version-1.2/risingwave-sql-101.md
@@ -7,11 +7,11 @@ slug: /risingwave-sql-101
 
 In this guide, we will walk you through some of the most used SQL commands in RisingWave. This is a simple yet typical data processing workflow that shows how to manipulate data with RisingWave.
 
-> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands. 
+> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands.
 
 ## Before we start
 
-Ensure that you have [started and connected to RisingWave](get-started.md/#run-risingwave).
+Ensure that you have [started and connected to RisingWave](./get-started.md).
 
 ## Create a table
 
@@ -19,18 +19,18 @@ Now let's create a table to store data about taxi trips.
 
 ```sql
 CREATE TABLE taxi_trips (
-    trip_id int, 
-    taxi_id int, 
-    completed_at timestamp, 
-    distance double precision, 
+    trip_id int,
+    taxi_id int,
+    completed_at timestamp,
+    distance double precision,
     duration double precision);
 ```
 
 And let's add some data to the table.
 
 ```sql
-INSERT INTO taxi_trips VALUES 
-(1, 1001, '2022-07-01 22:00:00', 4, 6), 
+INSERT INTO taxi_trips VALUES
+(1, 1001, '2022-07-01 22:00:00', 4, 6),
 (2, 1002, '2022-07-01 22:01:00', 6, 9);
 ```
 
@@ -60,10 +60,10 @@ We can now query the average speed.
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration |     avg_speed      
+ no_of_trips | total_distance | total_duration |     avg_speed
 -------------+----------------+----------------+--------------------
            2 |             10 |             15 | 0.6666666666666666
 (1 row)
@@ -81,10 +81,10 @@ As soon as we insert the new record, the materialized view `mv_avg_speed` will b
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration | avg_speed 
+ no_of_trips | total_distance | total_duration | avg_speed
 -------------+----------------+----------------+-----------
            3 |             13 |             20 |      0.65
 (1 row)
@@ -100,21 +100,21 @@ Creating a materialized view from a source is similar to creating from a table.
 The following statement creates a materialized view for three columns in a connected source named `debezium_json_mysql_source`.
 
 ```sql title="To create a materialized view from a source:"
-CREATE MATERIALIZED VIEW debezium_json_mysql_mv 
-AS 
+CREATE MATERIALIZED VIEW debezium_json_mysql_mv
+AS
     SELECT COLUMN1, COLUMN2, COLUMN3 FROM debezium_json_mysql_source;
 ```
 > For details about creating a source, see [CREATE SOURCE](sql/commands/sql-create-source.md).
 
 ## Create a materialized view on materialized views
 
-With RisingWave, you can also create a materialized view from an existing materialized view. 
+With RisingWave, you can also create a materialized view from an existing materialized view.
 
 ```sql title="To create a materialized view from existing materialized views:"
 CREATE MATERIALIZED VIEW m3
-AS 
-    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2 
-    FROM m1 
+AS
+    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2
+    FROM m1
     INNER JOIN m2 ON m1.v1 = m2.v1;
 ```
 

--- a/versioned_docs/version-1.2/sql/functions-operators/sql-function-aggregate.md
+++ b/versioned_docs/version-1.2/sql/functions-operators/sql-function-aggregate.md
@@ -9,7 +9,7 @@ title: Aggregate functions
 
 Aggregate functions compute a single result from a set of input values.
 
-For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](/sql/query-syntax/query-syntax-value-exp.md/#aggregate-expressions).
+For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](../query-syntax/query-syntax-value-exp.md#aggregate-expressions).
 
 ## General-purpose aggregate functions
 
@@ -18,24 +18,24 @@ For details about the supported syntaxes of aggregate expressions, see [Aggregat
 Returns an array from input values in which each value in the set is assigned to an array element. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```sql title=Syntax
-array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array       
-```  
+array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array
+```
 
----  
+---
 
 ### `avg`
 
 Returns the average (arithmetic mean) of the selected values.
 
 ```bash title=Syntax
-avg ( expression ) -> see description   
-```  
+avg ( expression ) -> see description
+```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
 
 Return type is numeric for integer inputs and double precision for float point inputs.
 
----  
+---
 
 ### `bool_and`
 
@@ -45,7 +45,7 @@ Returns true if all input values are true, otherwise false.
 bool_and ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `bool_or`
 
@@ -55,69 +55,69 @@ Returns true if at least one input value is true, otherwise false.
 bool_or ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `count`
 
 Returns the number of non-null rows.
 
 ```bash title=Syntax
-count ( expression ) -> bigint    
-```  
+count ( expression ) -> bigint
+```
 
 The input can be of any supported data type.
 
----  
+---
 
 ### `jsonb_agg`
 
 Aggregates values, including nulls, as a JSON array. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```bash title=Syntax
-jsonb_agg ( expression ) -> jsonb    
+jsonb_agg ( expression ) -> jsonb
 ```
 
 Currently, input types include boolean, smallint, int, bigint, real, double precision, varchar and jsonb.
 
----  
+---
 
 ### `jsonb_object_agg`
 
 Aggregates name/value pairs as a JSON object.
 
 ```bash title=Syntax
-jsonb_object_agg ( key , value ) -> jsonb   
+jsonb_object_agg ( key , value ) -> jsonb
 ```
 
 `key`: varchar only.
 
 `value`: Currently supports null, boolean, smallint, int, bigint, real, double precision, varchar, and jsonb.
 
----  
+---
 
 ### `max`
 
-Returns the maximum value in a set of values.  
+Returns the maximum value in a set of values.
 
 ```bash title=Syntax
-max ( expression ) -> same as input type    
-```  
+max ( expression ) -> same as input type
+```
 
 Input can be of any numeric, string, date/time, or interval type, or an array of these types.
 
----  
+---
 
 ### `min`
 
-Returns the minimum value in a set of values.  
+Returns the minimum value in a set of values.
 
 ```bash title=Syntax
-min ( expression ) -> same as input type  
-```  
+min ( expression ) -> same as input type
+```
 
-Input can be of any numeric, string, date/time, or interval type, or an array of these types.  
+Input can be of any numeric, string, date/time, or interval type, or an array of these types.
 
----  
+---
 
 ### `string_agg`
 
@@ -126,17 +126,17 @@ Combines non-null values into a string, separated by `delimiter_string`. The `OR
 #### Syntax
 
 ```bash title=Syntax
-string_agg ( expression, delimiter_string ) -> output_string  
+string_agg ( expression, delimiter_string ) -> output_string
 ```
 
----  
+---
 
 ### `sum`
 
 Returns the sum of all input values.
 
 ```bash title=Syntax
-sum ( expression )  
+sum ( expression )
 ```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
@@ -153,17 +153,17 @@ Calculates the population standard deviation of the input values. Returns `NULL`
 stddev_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `stddev_samp`
 
-Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.  
+Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.
 
 ```bash title=Syntax
 stddev_samp ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_pop`
 
@@ -173,7 +173,7 @@ Calculates the population variance of the input values. Returns `NULL` if the in
 var_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_samp`
 
@@ -205,7 +205,7 @@ This example calculates the mode of the values in `column1` from `table1`.
 SELECT mode() WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
 
----  
+---
 
 ### `percentile_cont`
 
@@ -227,7 +227,7 @@ This example calculates the median (50th percentile) of the values in `column1` 
 SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
 
----  
+---
 
 ### `percentile_disc`
 
@@ -274,8 +274,8 @@ INSERT INTO items_sold VALUES ('Foo', 'L', 10),('Foo', 'M', 20),('Bar', 'M', 15)
 ```
 
 ```sql title="Get grouping results"
-SELECT brand, size, sum(sales), grouping(brand), grouping(size), grouping(brand,size), count(DISTINCT sales) 
-FROM items_sold 
+SELECT brand, size, sum(sales), grouping(brand), grouping(size), grouping(brand,size), count(DISTINCT sales)
+FROM items_sold
 GROUP BY GROUPING SETS ((brand), (size), ());
 ------RESULTS
 Bar NULL 20 0 1 1 2

--- a/versioned_docs/version-1.2/sql/functions-operators/sql-function-cast.md
+++ b/versioned_docs/version-1.2/sql/functions-operators/sql-function-cast.md
@@ -22,7 +22,7 @@ value :: type
 |Parameter        | Description     |
 |-----------------|-----------------|
 |*value*          |The value to be converted.|
-|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Data types](/sql/sql-data-types.md/#casts).|
+|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Casting](../data-types/data-type-casting.md).|
 
 
 ## Example

--- a/versioned_docs/version-1.3/concepts/key-concepts.md
+++ b/versioned_docs/version-1.3/concepts/key-concepts.md
@@ -87,7 +87,7 @@ A stateless worker node that compacts data for the storage engine.
 
 ### Connector node
 
-The connector node is a Java component that handles consuming CDC events from upstream systems and sinking data from RisingWave to downstream systems. When running RisingWave with Docker, this node is enabled by default. If running RisingWave locally, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+The connector node is a Java component that handles consuming CDC events from upstream systems and sinking data from RisingWave to downstream systems. When running RisingWave with Docker, this node is enabled by default. If running RisingWave locally, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ### Meta service
 

--- a/versioned_docs/version-1.3/guides/ingest-from-citus-cdc.md
+++ b/versioned_docs/version-1.3/guides/ingest-from-citus-cdc.md
@@ -51,9 +51,9 @@ There are a few limitations when ingesting CDC data from Citus in RisingWave.
 
 The native CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in the docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in the docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Create a table in RisingWave using the native CDC connector
 
@@ -65,7 +65,7 @@ Note that a primary key must be specified.
 CREATE TABLE [ IF NOT EXISTS ] source_name (
     column_name data_type PRIMARY KEY , ...
     [PRIMARY KEY ( column_name, ... )]
-) 
+)
 WITH (
     connector='citus-cdc',
     <field>=<value>, ...

--- a/versioned_docs/version-1.3/guides/ingest-from-mysql-cdc.md
+++ b/versioned_docs/version-1.3/guides/ingest-from-mysql-cdc.md
@@ -127,9 +127,9 @@ If your MySQL is hosted on AWS RDS, the configuration process is different. We w
 
 The native MySQL CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 :::note EXPERIMENTAL ENHANCEMENT AVAILABLE
 

--- a/versioned_docs/version-1.3/guides/ingest-from-postgres-cdc.md
+++ b/versioned_docs/version-1.3/guides/ingest-from-postgres-cdc.md
@@ -134,9 +134,9 @@ Here we will use a standard class instance without Multi-AZ deployment as an exa
 
 The native PostgreSQL CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Create a table using the native CDC connector
 

--- a/versioned_docs/version-1.3/guides/sink-to-cassandra.md
+++ b/versioned_docs/version-1.3/guides/sink-to-cassandra.md
@@ -2,7 +2,7 @@
 id: sink-to-cassandra
 title: Sink data from RisingWave to Cassandra or ScyllaDB
 description: Sink data from RisingWave to Cassandra or ScyllaDB.
-slug: /sink-to-cassandra 
+slug: /sink-to-cassandra
 ---
 You can sink data from RisingWave to [Cassandra](https://cassandra.apache.org/). As [ScyllaDB](https://www.scylladb.com/) can work as a drop-in replacement for Cassandra, it means you can sink data from RisingWave to ScyllaDB as well.
 
@@ -16,7 +16,7 @@ The Cassandra sink connector in RisingWave is currently in Beta. Please contact 
 
 - Ensure your Cassandra or ScyllaDB cluster is accessible from RisingWave.
 
-- The Cassandra sink connector in RisingWave relies on the connector node to work. Please ensure the connector node is enabled in RisingWave. For details, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+- The Cassandra sink connector in RisingWave relies on the connector node to work. Please ensure the connector node is enabled in RisingWave. For details, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Syntax
 
@@ -31,7 +31,7 @@ WITH (
     cassandra.url = '<node1>,<node2>,<node3>',
     cassandra.keyspace = '<keyspace>',
     cassandra.table = '<cassandra_table>',
-    cassandra.datacenter = '<data_center>' 
+    cassandra.datacenter = '<data_center>'
 );
 ```
 

--- a/versioned_docs/version-1.3/guides/sink-to-elasticsearch.md
+++ b/versioned_docs/version-1.3/guides/sink-to-elasticsearch.md
@@ -2,7 +2,7 @@
 id: sink-to-elasticsearch
 title: Sink data from RisingWave to Elasticsearch
 description: Sink data from RisingWave to Elasticsearch.
-slug: /sink-to-elasticsearch 
+slug: /sink-to-elasticsearch
 ---
 You can deliver the data that has been ingested and transformed in RisingWave to Elasticsearch to serve searches or analytics.
 
@@ -24,7 +24,7 @@ The Elasticsearch sink connector in RisingWave provides at-least-once delivery s
 
 - Ensure the Elasticsearch cluster (version 7.x or 8.x) is accessible from RisingWave.
 
-- The Elastic sink connector in RisingWave relies on the connector node to work. Please ensure the connector node is enabled in RisingWave. For details, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+- The Elastic sink connector in RisingWave relies on the connector node to work. Please ensure the connector node is enabled in RisingWave. For details, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Create a Elasticsearch sink
 
@@ -37,7 +37,7 @@ WITH (
   connector = 'elasticsearch',
   index = '<your Elasticsearch index>',
   url = 'http://<ES hostname>:<ES port>',
-  username = '<your ES username>', 
+  username = '<your ES username>',
   password = '<your password>',
   delimiter='<delimiter>'
 );

--- a/versioned_docs/version-1.3/guides/sink-to-mysql.md
+++ b/versioned_docs/version-1.3/guides/sink-to-mysql.md
@@ -108,9 +108,9 @@ To install and start RisingWave locally, see the [Get started](/get-started.md) 
 
 The native MySQL CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Create a sink
 

--- a/versioned_docs/version-1.3/guides/sink-to-postgres.md
+++ b/versioned_docs/version-1.3/guides/sink-to-postgres.md
@@ -91,9 +91,9 @@ To install and start RisingWave locally, see the [Get started](/get-started.md) 
 
 The native PostgreSQL CDC connector is implemented by the connector node in RisingWave. The connector node handles the connections with upstream and downstream systems.
 
-The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](/deploy/risingwave-trial.md/?method=docker-compose).
+The connector node is enabled by default in this docker-compose configuration. To learn about how to start RisingWave with this configuration, see [Docker Compose](../deploy/risingwave-trial.md?method=docker-compose).
 
-If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](/deploy/risingwave-trial.md/?method=binaries#optional-enable-the-connector-node).
+If you are running RisingWave locally with the pre-built library or with the source code, the connector node needs to be started separately. To learn about how to start the connector node in this case, see [Enable the connector node](../deploy/risingwave-trial.md?method=binaries#optional-enable-the-connector-node).
 
 ## Create a sink​
 

--- a/versioned_docs/version-1.3/manage/meta-backup.md
+++ b/versioned_docs/version-1.3/manage/meta-backup.md
@@ -32,7 +32,7 @@ Here's an example of how to create a new meta snapshot with `risectl`:
 risectl meta backup-meta
 ```
 
-`risectl` is included in the pre-built RisingWave binary. It can also be built from source. For details, see [Install RisingWave from the binaries](/deploy/risingwave-trial.md/?method=binaries).
+`risectl` is included in the pre-built RisingWave binary. It can also be built from source. For details, see [Install RisingWave from the binaries](../deploy/risingwave-trial.md?method=binaries).
 
 ## View existing meta snapshots
 
@@ -45,7 +45,7 @@ SELECT meta_snapshot_id FROM rw_catalog.rw_meta_snapshot;
 Example output:
 
 ```bash
- meta_snapshot_id 
+ meta_snapshot_id
 ------------------
                 3
                 4
@@ -108,13 +108,13 @@ Use the following steps to perform a time travel query.
    Example output:
 
     ```bash
-        safe_epoch    |      safe_epoch_ts      | max_committed_epoch | max_committed_epoch_ts  
+        safe_epoch    |      safe_epoch_ts      | max_committed_epoch | max_committed_epoch_ts
     ------------------+-------------------------+---------------------+-------------------------
      3603859827458048 | 2022-12-28 11:08:56.918 |    3603862776381440 | 2022-12-28 11:09:41.915
      3603898821640192 | 2022-12-28 11:18:51.922 |    3603900263432192 | 2022-12-28 11:19:13.922
     ```
 
-   Valid epochs are within range (`safe_epoch`,`max_committed_epoch`). For example, any epochs in [3603859827458048, 3603862776381440] or in [3603898821640192, 3603900263432192] are acceptable.  
+   Valid epochs are within range (`safe_epoch`,`max_committed_epoch`). For example, any epochs in [3603859827458048, 3603862776381440] or in [3603898821640192, 3603900263432192] are acceptable.
    `safe_epoch_ts` and `max_committed_epoch_ts` are human-readable equivalences.
 2. Set session config `QUERY_EPOCH`. By default, it's 0, which means disabling historical query.
 

--- a/versioned_docs/version-1.3/risingwave-sql-101.md
+++ b/versioned_docs/version-1.3/risingwave-sql-101.md
@@ -7,11 +7,11 @@ slug: /risingwave-sql-101
 
 In this guide, we will walk you through some of the most used SQL commands in RisingWave. This is a simple yet typical data processing workflow that shows how to manipulate data with RisingWave.
 
-> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands. 
+> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands.
 
 ## Before we start
 
-Ensure that you have [started and connected to RisingWave](get-started.md/#run-risingwave).
+Ensure that you have [started and connected to RisingWave](./get-started.md).
 
 ## Create a table
 
@@ -19,18 +19,18 @@ Now let's create a table to store data about taxi trips.
 
 ```sql
 CREATE TABLE taxi_trips (
-    trip_id int, 
-    taxi_id int, 
-    completed_at timestamp, 
-    distance double precision, 
+    trip_id int,
+    taxi_id int,
+    completed_at timestamp,
+    distance double precision,
     duration double precision);
 ```
 
 And let's add some data to the table.
 
 ```sql
-INSERT INTO taxi_trips VALUES 
-(1, 1001, '2022-07-01 22:00:00', 4, 6), 
+INSERT INTO taxi_trips VALUES
+(1, 1001, '2022-07-01 22:00:00', 4, 6),
 (2, 1002, '2022-07-01 22:01:00', 6, 9);
 ```
 
@@ -60,10 +60,10 @@ We can now query the average speed.
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration |     avg_speed      
+ no_of_trips | total_distance | total_duration |     avg_speed
 -------------+----------------+----------------+--------------------
            2 |             10 |             15 | 0.6666666666666666
 (1 row)
@@ -81,10 +81,10 @@ As soon as we insert the new record, the materialized view `mv_avg_speed` will b
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration | avg_speed 
+ no_of_trips | total_distance | total_duration | avg_speed
 -------------+----------------+----------------+-----------
            3 |             13 |             20 |      0.65
 (1 row)
@@ -100,21 +100,21 @@ Creating a materialized view from a source is similar to creating from a table.
 The following statement creates a materialized view for three columns in a connected source named `debezium_json_mysql_source`.
 
 ```sql title="To create a materialized view from a source:"
-CREATE MATERIALIZED VIEW debezium_json_mysql_mv 
-AS 
+CREATE MATERIALIZED VIEW debezium_json_mysql_mv
+AS
     SELECT COLUMN1, COLUMN2, COLUMN3 FROM debezium_json_mysql_source;
 ```
 > For details about creating a source, see [CREATE SOURCE](sql/commands/sql-create-source.md).
 
 ## Create a materialized view on materialized views
 
-With RisingWave, you can also create a materialized view from an existing materialized view. 
+With RisingWave, you can also create a materialized view from an existing materialized view.
 
 ```sql title="To create a materialized view from existing materialized views:"
 CREATE MATERIALIZED VIEW m3
-AS 
-    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2 
-    FROM m1 
+AS
+    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2
+    FROM m1
     INNER JOIN m2 ON m1.v1 = m2.v1;
 ```
 

--- a/versioned_docs/version-1.3/sql/functions-operators/sql-function-aggregate.md
+++ b/versioned_docs/version-1.3/sql/functions-operators/sql-function-aggregate.md
@@ -9,7 +9,7 @@ title: Aggregate functions
 
 Aggregate functions compute a single result from a set of input values.
 
-For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](/sql/query-syntax/query-syntax-value-exp.md/#aggregate-expressions).
+For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](../query-syntax/query-syntax-value-exp.md#aggregate-expressions).
 
 ## General-purpose aggregate functions
 
@@ -18,24 +18,24 @@ For details about the supported syntaxes of aggregate expressions, see [Aggregat
 Returns an array from input values in which each value in the set is assigned to an array element. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```sql title=Syntax
-array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array       
-```  
+array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array
+```
 
----  
+---
 
 ### `avg`
 
 Returns the average (arithmetic mean) of the selected values.
 
 ```bash title=Syntax
-avg ( expression ) -> see description   
-```  
+avg ( expression ) -> see description
+```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
 
 Return type is numeric for integer inputs and double precision for float point inputs.
 
----  
+---
 
 ### `bit_and`
 
@@ -45,7 +45,7 @@ Returns the bitwise AND of all non-null input values or null if no non-null valu
 bit_and ( smallint, int, or bigint ) -> same as input type
 ```
 
----  
+---
 
 ### `bit_or`
 
@@ -55,7 +55,7 @@ Returns the bitwise OR of all non-null input values or null if no non-null value
 bit_or ( smallint, int, or bigint ) -> same as input type
 ```
 
----  
+---
 
 ### `bool_and`
 
@@ -65,7 +65,7 @@ Returns true if all input values are true, otherwise false.
 bool_and ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `bool_or`
 
@@ -75,69 +75,69 @@ Returns true if at least one input value is true, otherwise false.
 bool_or ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `count`
 
 Returns the number of non-null rows.
 
 ```bash title=Syntax
-count ( expression ) -> bigint    
-```  
+count ( expression ) -> bigint
+```
 
 The input can be of any supported data type.
 
----  
+---
 
 ### `jsonb_agg`
 
 Aggregates values, including nulls, as a JSON array. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```bash title=Syntax
-jsonb_agg ( expression ) -> jsonb    
+jsonb_agg ( expression ) -> jsonb
 ```
 
 Currently, input types include boolean, smallint, int, bigint, real, double precision, varchar and jsonb.
 
----  
+---
 
 ### `jsonb_object_agg`
 
 Aggregates name/value pairs as a JSON object.
 
 ```bash title=Syntax
-jsonb_object_agg ( key , value ) -> jsonb   
+jsonb_object_agg ( key , value ) -> jsonb
 ```
 
 `key`: varchar only.
 
 `value`: Currently supports null, boolean, smallint, int, bigint, real, double precision, varchar, and jsonb.
 
----  
+---
 
 ### `max`
 
-Returns the maximum value in a set of values.  
+Returns the maximum value in a set of values.
 
 ```bash title=Syntax
-max ( expression ) -> same as input type    
-```  
+max ( expression ) -> same as input type
+```
 
 Input can be of any numeric, string, date/time, or interval type, or an array of these types.
 
----  
+---
 
 ### `min`
 
-Returns the minimum value in a set of values.  
+Returns the minimum value in a set of values.
 
 ```bash title=Syntax
-min ( expression ) -> same as input type  
-```  
+min ( expression ) -> same as input type
+```
 
-Input can be of any numeric, string, date/time, or interval type, or an array of these types.  
+Input can be of any numeric, string, date/time, or interval type, or an array of these types.
 
----  
+---
 
 ### `string_agg`
 
@@ -146,17 +146,17 @@ Combines non-null values into a string, separated by `delimiter_string`. The `OR
 #### Syntax
 
 ```bash title=Syntax
-string_agg ( expression, delimiter_string ) -> output_string  
+string_agg ( expression, delimiter_string ) -> output_string
 ```
 
----  
+---
 
 ### `sum`
 
 Returns the sum of all input values.
 
 ```bash title=Syntax
-sum ( expression )  
+sum ( expression )
 ```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
@@ -173,17 +173,17 @@ Calculates the population standard deviation of the input values. Returns `NULL`
 stddev_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `stddev_samp`
 
-Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.  
+Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.
 
 ```bash title=Syntax
 stddev_samp ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_pop`
 
@@ -193,7 +193,7 @@ Calculates the population variance of the input values. Returns `NULL` if the in
 var_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_samp`
 
@@ -225,7 +225,7 @@ This example calculates the mode of the values in `column1` from `table1`.
 SELECT mode() WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
 
----  
+---
 
 ### `percentile_cont`
 
@@ -247,7 +247,7 @@ This example calculates the median (50th percentile) of the values in `column1` 
 SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
 
----  
+---
 
 ### `percentile_disc`
 
@@ -294,8 +294,8 @@ INSERT INTO items_sold VALUES ('Foo', 'L', 10),('Foo', 'M', 20),('Bar', 'M', 15)
 ```
 
 ```sql title="Get grouping results"
-SELECT brand, size, sum(sales), grouping(brand), grouping(size), grouping(brand,size), count(DISTINCT sales) 
-FROM items_sold 
+SELECT brand, size, sum(sales), grouping(brand), grouping(size), grouping(brand,size), count(DISTINCT sales)
+FROM items_sold
 GROUP BY GROUPING SETS ((brand), (size), ());
 ------RESULTS
 Bar NULL 20 0 1 1 2

--- a/versioned_docs/version-1.3/sql/functions-operators/sql-function-cast.md
+++ b/versioned_docs/version-1.3/sql/functions-operators/sql-function-cast.md
@@ -22,7 +22,7 @@ value :: type
 |Parameter        | Description     |
 |-----------------|-----------------|
 |*value*          |The value to be converted.|
-|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Data types](/sql/sql-data-types.md/#casts).|
+|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Casting](../data-types/data-type-casting.md).|
 
 
 ## Example

--- a/versioned_docs/version-1.4/risingwave-sql-101.md
+++ b/versioned_docs/version-1.4/risingwave-sql-101.md
@@ -7,11 +7,11 @@ slug: /risingwave-sql-101
 
 In this guide, we will walk you through some of the most used SQL commands in RisingWave. This is a simple yet typical data processing workflow that shows how to manipulate data with RisingWave.
 
-> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands. 
+> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands.
 
 ## Before we start
 
-Ensure that you have [started and connected to RisingWave](get-started.md/#run-risingwave).
+Ensure that you have [started and connected to RisingWave](./get-started.md).
 
 ## Create a table
 
@@ -19,18 +19,18 @@ Now let's create a table to store data about taxi trips.
 
 ```sql
 CREATE TABLE taxi_trips (
-    trip_id int, 
-    taxi_id int, 
-    completed_at timestamp, 
-    distance double precision, 
+    trip_id int,
+    taxi_id int,
+    completed_at timestamp,
+    distance double precision,
     duration double precision);
 ```
 
 And let's add some data to the table.
 
 ```sql
-INSERT INTO taxi_trips VALUES 
-(1, 1001, '2022-07-01 22:00:00', 4, 6), 
+INSERT INTO taxi_trips VALUES
+(1, 1001, '2022-07-01 22:00:00', 4, 6),
 (2, 1002, '2022-07-01 22:01:00', 6, 9);
 ```
 
@@ -60,10 +60,10 @@ We can now query the average speed.
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration |     avg_speed      
+ no_of_trips | total_distance | total_duration |     avg_speed
 -------------+----------------+----------------+--------------------
            2 |             10 |             15 | 0.6666666666666666
 (1 row)
@@ -81,10 +81,10 @@ As soon as we insert the new record, the materialized view `mv_avg_speed` will b
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration | avg_speed 
+ no_of_trips | total_distance | total_duration | avg_speed
 -------------+----------------+----------------+-----------
            3 |             13 |             20 |      0.65
 (1 row)
@@ -100,21 +100,21 @@ Creating a materialized view from a source is similar to creating from a table.
 The following statement creates a materialized view for three columns in a connected source named `debezium_json_mysql_source`.
 
 ```sql title="To create a materialized view from a source:"
-CREATE MATERIALIZED VIEW debezium_json_mysql_mv 
-AS 
+CREATE MATERIALIZED VIEW debezium_json_mysql_mv
+AS
     SELECT COLUMN1, COLUMN2, COLUMN3 FROM debezium_json_mysql_source;
 ```
 > For details about creating a source, see [CREATE SOURCE](sql/commands/sql-create-source.md).
 
 ## Create a materialized view on materialized views
 
-With RisingWave, you can also create a materialized view from an existing materialized view. 
+With RisingWave, you can also create a materialized view from an existing materialized view.
 
 ```sql title="To create a materialized view from existing materialized views:"
 CREATE MATERIALIZED VIEW m3
-AS 
-    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2 
-    FROM m1 
+AS
+    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2
+    FROM m1
     INNER JOIN m2 ON m1.v1 = m2.v1;
 ```
 

--- a/versioned_docs/version-1.4/sql/functions-operators/sql-function-aggregate.md
+++ b/versioned_docs/version-1.4/sql/functions-operators/sql-function-aggregate.md
@@ -9,7 +9,7 @@ title: Aggregate functions
 
 Aggregate functions compute a single result from a set of input values.
 
-For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](/sql/query-syntax/query-syntax-value-exp.md/#aggregate-expressions).
+For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](../query-syntax/query-syntax-value-exp.md#aggregate-expressions).
 
 ## General-purpose aggregate functions
 
@@ -18,24 +18,24 @@ For details about the supported syntaxes of aggregate expressions, see [Aggregat
 Returns an array from input values in which each value in the set is assigned to an array element. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```sql title=Syntax
-array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array       
-```  
+array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array
+```
 
----  
+---
 
 ### `avg`
 
 Returns the average (arithmetic mean) of the selected values.
 
 ```bash title=Syntax
-avg ( expression ) -> see description   
-```  
+avg ( expression ) -> see description
+```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
 
 Return type is numeric for integer inputs and double precision for float point inputs.
 
----  
+---
 
 ### `bit_and`
 
@@ -45,7 +45,7 @@ Returns the bitwise AND of all non-null input values or null if no non-null valu
 bit_and ( smallint, int, or bigint ) -> same as input type
 ```
 
----  
+---
 
 ### `bit_or`
 
@@ -55,7 +55,7 @@ Returns the bitwise OR of all non-null input values or null if no non-null value
 bit_or ( smallint, int, or bigint ) -> same as input type
 ```
 
----  
+---
 
 ### `bool_and`
 
@@ -65,7 +65,7 @@ Returns true if all input values are true, otherwise false.
 bool_and ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `bool_or`
 
@@ -75,69 +75,69 @@ Returns true if at least one input value is true, otherwise false.
 bool_or ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `count`
 
 Returns the number of non-null rows.
 
 ```bash title=Syntax
-count ( expression ) -> bigint    
-```  
+count ( expression ) -> bigint
+```
 
 The input can be of any supported data type.
 
----  
+---
 
 ### `jsonb_agg`
 
 Aggregates values, including nulls, as a JSON array. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```bash title=Syntax
-jsonb_agg ( expression ) -> jsonb    
+jsonb_agg ( expression ) -> jsonb
 ```
 
 Currently, input types include boolean, smallint, int, bigint, real, double precision, varchar and jsonb.
 
----  
+---
 
 ### `jsonb_object_agg`
 
 Aggregates name/value pairs as a JSON object.
 
 ```bash title=Syntax
-jsonb_object_agg ( key , value ) -> jsonb   
+jsonb_object_agg ( key , value ) -> jsonb
 ```
 
 `key`: varchar only.
 
 `value`: Currently supports null, boolean, smallint, int, bigint, real, double precision, varchar, and jsonb.
 
----  
+---
 
 ### `max`
 
-Returns the maximum value in a set of values.  
+Returns the maximum value in a set of values.
 
 ```bash title=Syntax
-max ( expression ) -> same as input type    
-```  
+max ( expression ) -> same as input type
+```
 
 Input can be of any numeric, string, date/time, or interval type, or an array of these types.
 
----  
+---
 
 ### `min`
 
-Returns the minimum value in a set of values.  
+Returns the minimum value in a set of values.
 
 ```bash title=Syntax
-min ( expression ) -> same as input type  
-```  
+min ( expression ) -> same as input type
+```
 
-Input can be of any numeric, string, date/time, or interval type, or an array of these types.  
+Input can be of any numeric, string, date/time, or interval type, or an array of these types.
 
----  
+---
 
 ### `string_agg`
 
@@ -146,17 +146,17 @@ Combines non-null values into a string, separated by `delimiter_string`. The `OR
 #### Syntax
 
 ```bash title=Syntax
-string_agg ( expression, delimiter_string ) -> output_string  
+string_agg ( expression, delimiter_string ) -> output_string
 ```
 
----  
+---
 
 ### `sum`
 
 Returns the sum of all input values.
 
 ```bash title=Syntax
-sum ( expression )  
+sum ( expression )
 ```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
@@ -173,17 +173,17 @@ Calculates the population standard deviation of the input values. Returns `NULL`
 stddev_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `stddev_samp`
 
-Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.  
+Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.
 
 ```bash title=Syntax
 stddev_samp ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_pop`
 
@@ -193,7 +193,7 @@ Calculates the population variance of the input values. Returns `NULL` if the in
 var_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_samp`
 
@@ -225,7 +225,7 @@ This example calculates the mode of the values in `column1` from `table1`.
 SELECT mode() WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
 
----  
+---
 
 ### `percentile_cont`
 
@@ -247,7 +247,7 @@ This example calculates the median (50th percentile) of the values in `column1` 
 SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
 
----  
+---
 
 ### `percentile_disc`
 
@@ -294,8 +294,8 @@ INSERT INTO items_sold VALUES ('Foo', 'L', 10),('Foo', 'M', 20),('Bar', 'M', 15)
 ```
 
 ```sql title="Get grouping results"
-SELECT brand, size, sum(sales), grouping(brand), grouping(size), grouping(brand,size), count(DISTINCT sales) 
-FROM items_sold 
+SELECT brand, size, sum(sales), grouping(brand), grouping(size), grouping(brand,size), count(DISTINCT sales)
+FROM items_sold
 GROUP BY GROUPING SETS ((brand), (size), ());
 ------RESULTS
 Bar NULL 20 0 1 1 2

--- a/versioned_docs/version-1.4/sql/functions-operators/sql-function-cast.md
+++ b/versioned_docs/version-1.4/sql/functions-operators/sql-function-cast.md
@@ -22,7 +22,7 @@ value :: type
 |Parameter        | Description     |
 |-----------------|-----------------|
 |*value*          |The value to be converted.|
-|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Data types](/sql/sql-data-types.md/#casts).|
+|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Casting](../data-types/data-type-casting.md).|
 
 
 ## Example

--- a/versioned_docs/version-1.5/risingwave-sql-101.md
+++ b/versioned_docs/version-1.5/risingwave-sql-101.md
@@ -7,11 +7,11 @@ slug: /risingwave-sql-101
 
 In this guide, we will walk you through some of the most used SQL commands in RisingWave. This is a simple yet typical data processing workflow that shows how to manipulate data with RisingWave.
 
-> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands. 
+> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands.
 
 ## Before we start
 
-Ensure that you have [started and connected to RisingWave](get-started.md/#run-risingwave).
+Ensure that you have [started and connected to RisingWave](./get-started.md).
 
 ## Create a table
 
@@ -19,18 +19,18 @@ Now let's create a table to store data about taxi trips.
 
 ```sql
 CREATE TABLE taxi_trips (
-    trip_id int, 
-    taxi_id int, 
-    completed_at timestamp, 
-    distance double precision, 
+    trip_id int,
+    taxi_id int,
+    completed_at timestamp,
+    distance double precision,
     duration double precision);
 ```
 
 And let's add some data to the table.
 
 ```sql
-INSERT INTO taxi_trips VALUES 
-(1, 1001, '2022-07-01 22:00:00', 4, 6), 
+INSERT INTO taxi_trips VALUES
+(1, 1001, '2022-07-01 22:00:00', 4, 6),
 (2, 1002, '2022-07-01 22:01:00', 6, 9);
 ```
 
@@ -60,10 +60,10 @@ We can now query the average speed.
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration |     avg_speed      
+ no_of_trips | total_distance | total_duration |     avg_speed
 -------------+----------------+----------------+--------------------
            2 |             10 |             15 | 0.6666666666666666
 (1 row)
@@ -81,10 +81,10 @@ As soon as we insert the new record, the materialized view `mv_avg_speed` will b
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration | avg_speed 
+ no_of_trips | total_distance | total_duration | avg_speed
 -------------+----------------+----------------+-----------
            3 |             13 |             20 |      0.65
 (1 row)
@@ -100,21 +100,21 @@ Creating a materialized view from a source is similar to creating from a table.
 The following statement creates a materialized view for three columns in a connected source named `debezium_json_mysql_source`.
 
 ```sql title="To create a materialized view from a source:"
-CREATE MATERIALIZED VIEW debezium_json_mysql_mv 
-AS 
+CREATE MATERIALIZED VIEW debezium_json_mysql_mv
+AS
     SELECT COLUMN1, COLUMN2, COLUMN3 FROM debezium_json_mysql_source;
 ```
 > For details about creating a source, see [CREATE SOURCE](sql/commands/sql-create-source.md).
 
 ## Create a materialized view on materialized views
 
-With RisingWave, you can also create a materialized view from an existing materialized view. 
+With RisingWave, you can also create a materialized view from an existing materialized view.
 
 ```sql title="To create a materialized view from existing materialized views:"
 CREATE MATERIALIZED VIEW m3
-AS 
-    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2 
-    FROM m1 
+AS
+    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2
+    FROM m1
     INNER JOIN m2 ON m1.v1 = m2.v1;
 ```
 

--- a/versioned_docs/version-1.5/sql/functions-operators/sql-function-aggregate.md
+++ b/versioned_docs/version-1.5/sql/functions-operators/sql-function-aggregate.md
@@ -9,7 +9,7 @@ title: Aggregate functions
 
 Aggregate functions compute a single result from a set of input values.
 
-For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](/sql/query-syntax/query-syntax-value-exp.md/#aggregate-expressions).
+For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](../query-syntax/query-syntax-value-exp.md#aggregate-expressions).
 
 ## General-purpose aggregate functions
 
@@ -18,24 +18,24 @@ For details about the supported syntaxes of aggregate expressions, see [Aggregat
 Returns an array from input values in which each value in the set is assigned to an array element. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```sql title=Syntax
-array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array       
-```  
+array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array
+```
 
----  
+---
 
 ### `avg`
 
 Returns the average (arithmetic mean) of the selected values.
 
 ```bash title=Syntax
-avg ( expression ) -> see description   
-```  
+avg ( expression ) -> see description
+```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
 
 Return type is numeric for integer inputs and double precision for float point inputs.
 
----  
+---
 
 ### `bit_and`
 
@@ -45,7 +45,7 @@ Returns the bitwise AND of all non-null input values or null if no non-null valu
 bit_and ( smallint, int, or bigint ) -> same as input type
 ```
 
----  
+---
 
 ### `bit_or`
 
@@ -55,7 +55,7 @@ Returns the bitwise OR of all non-null input values or null if no non-null value
 bit_or ( smallint, int, or bigint ) -> same as input type
 ```
 
----  
+---
 
 ### `bool_and`
 
@@ -65,7 +65,7 @@ Returns true if all input values are true, otherwise false.
 bool_and ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `bool_or`
 
@@ -75,63 +75,63 @@ Returns true if at least one input value is true, otherwise false.
 bool_or ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `count`
 
 Returns the number of non-null rows.
 
 ```bash title=Syntax
-count ( expression ) -> bigint    
-```  
+count ( expression ) -> bigint
+```
 
 The input can be of any supported data type.
 
----  
+---
 
 ### `jsonb_agg`
 
 Aggregates values, including nulls, as a JSON array. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```bash title=Syntax
-jsonb_agg ( any_element ) -> jsonb    
+jsonb_agg ( any_element ) -> jsonb
 ```
 
----  
+---
 
 ### `jsonb_object_agg`
 
 Aggregates name/value pairs as a JSON object.
 
 ```bash title=Syntax
-jsonb_object_agg ( key "string" , value "any" ) -> jsonb   
+jsonb_object_agg ( key "string" , value "any" ) -> jsonb
 ```
 
----  
+---
 
 ### `max`
 
-Returns the maximum value in a set of values.  
+Returns the maximum value in a set of values.
 
 ```bash title=Syntax
-max ( expression ) -> same as input type    
-```  
+max ( expression ) -> same as input type
+```
 
 Input can be of any numeric, string, date/time, or interval type, or an array of these types.
 
----  
+---
 
 ### `min`
 
-Returns the minimum value in a set of values.  
+Returns the minimum value in a set of values.
 
 ```bash title=Syntax
-min ( expression ) -> same as input type  
-```  
+min ( expression ) -> same as input type
+```
 
-Input can be of any numeric, string, date/time, or interval type, or an array of these types.  
+Input can be of any numeric, string, date/time, or interval type, or an array of these types.
 
----  
+---
 
 ### `string_agg`
 
@@ -140,17 +140,17 @@ Combines non-null values into a string, separated by `delimiter_string`. The `OR
 #### Syntax
 
 ```bash title=Syntax
-string_agg ( expression, delimiter_string ) -> output_string  
+string_agg ( expression, delimiter_string ) -> output_string
 ```
 
----  
+---
 
 ### `sum`
 
 Returns the sum of all input values.
 
 ```bash title=Syntax
-sum ( expression )  
+sum ( expression )
 ```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
@@ -167,17 +167,17 @@ Calculates the population standard deviation of the input values. Returns `NULL`
 stddev_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `stddev_samp`
 
-Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.  
+Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.
 
 ```bash title=Syntax
 stddev_samp ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_pop`
 
@@ -187,7 +187,7 @@ Calculates the population variance of the input values. Returns `NULL` if the in
 var_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_samp`
 
@@ -219,7 +219,7 @@ This example calculates the mode of the values in `column1` from `table1`.
 SELECT mode() WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
 
----  
+---
 
 ### `percentile_cont`
 
@@ -241,7 +241,7 @@ This example calculates the median (50th percentile) of the values in `column1` 
 SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
 
----  
+---
 
 ### `percentile_disc`
 
@@ -288,8 +288,8 @@ INSERT INTO items_sold VALUES ('Foo', 'L', 10),('Foo', 'M', 20),('Bar', 'M', 15)
 ```
 
 ```sql title="Get grouping results"
-SELECT brand, size, sum(sales), grouping(brand), grouping(size), grouping(brand,size), count(DISTINCT sales) 
-FROM items_sold 
+SELECT brand, size, sum(sales), grouping(brand), grouping(size), grouping(brand,size), count(DISTINCT sales)
+FROM items_sold
 GROUP BY GROUPING SETS ((brand), (size), ());
 ------RESULTS
 Bar NULL 20 0 1 1 2

--- a/versioned_docs/version-1.5/sql/functions-operators/sql-function-cast.md
+++ b/versioned_docs/version-1.5/sql/functions-operators/sql-function-cast.md
@@ -22,7 +22,7 @@ value :: type
 |Parameter        | Description     |
 |-----------------|-----------------|
 |*value*          |The value to be converted.|
-|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Data types](/sql/sql-data-types.md/#casts).|
+|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Casting](../data-types/data-type-casting.md).|
 
 
 ## Example

--- a/versioned_docs/version-1.6/risingwave-sql-101.md
+++ b/versioned_docs/version-1.6/risingwave-sql-101.md
@@ -7,11 +7,11 @@ slug: /risingwave-sql-101
 
 In this guide, we will walk you through some of the most used SQL commands in RisingWave. This is a simple yet typical data processing workflow that shows how to manipulate data with RisingWave.
 
-> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands. 
+> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands.
 
 ## Before we start
 
-Ensure that you have [started and connected to RisingWave](get-started.md/#run-risingwave).
+Ensure that you have [started and connected to RisingWave](./get-started.md).
 
 ## Create a table
 
@@ -19,18 +19,18 @@ Now let's create a table to store data about taxi trips.
 
 ```sql
 CREATE TABLE taxi_trips (
-    trip_id int, 
-    taxi_id int, 
-    completed_at timestamp, 
-    distance double precision, 
+    trip_id int,
+    taxi_id int,
+    completed_at timestamp,
+    distance double precision,
     duration double precision);
 ```
 
 And let's add some data to the table.
 
 ```sql
-INSERT INTO taxi_trips VALUES 
-(1, 1001, '2022-07-01 22:00:00', 4, 6), 
+INSERT INTO taxi_trips VALUES
+(1, 1001, '2022-07-01 22:00:00', 4, 6),
 (2, 1002, '2022-07-01 22:01:00', 6, 9);
 ```
 
@@ -60,10 +60,10 @@ We can now query the average speed.
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration |     avg_speed      
+ no_of_trips | total_distance | total_duration |     avg_speed
 -------------+----------------+----------------+--------------------
            2 |             10 |             15 | 0.6666666666666666
 (1 row)
@@ -81,10 +81,10 @@ As soon as we insert the new record, the materialized view `mv_avg_speed` will b
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration | avg_speed 
+ no_of_trips | total_distance | total_duration | avg_speed
 -------------+----------------+----------------+-----------
            3 |             13 |             20 |      0.65
 (1 row)
@@ -100,21 +100,21 @@ Creating a materialized view from a source is similar to creating from a table.
 The following statement creates a materialized view for three columns in a connected source named `debezium_json_mysql_source`.
 
 ```sql title="To create a materialized view from a source:"
-CREATE MATERIALIZED VIEW debezium_json_mysql_mv 
-AS 
+CREATE MATERIALIZED VIEW debezium_json_mysql_mv
+AS
     SELECT COLUMN1, COLUMN2, COLUMN3 FROM debezium_json_mysql_source;
 ```
 > For details about creating a source, see [CREATE SOURCE](sql/commands/sql-create-source.md).
 
 ## Create a materialized view on materialized views
 
-With RisingWave, you can also create a materialized view from an existing materialized view. 
+With RisingWave, you can also create a materialized view from an existing materialized view.
 
 ```sql title="To create a materialized view from existing materialized views:"
 CREATE MATERIALIZED VIEW m3
-AS 
-    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2 
-    FROM m1 
+AS
+    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2
+    FROM m1
     INNER JOIN m2 ON m1.v1 = m2.v1;
 ```
 

--- a/versioned_docs/version-1.6/sql/functions-operators/sql-function-aggregate.md
+++ b/versioned_docs/version-1.6/sql/functions-operators/sql-function-aggregate.md
@@ -9,7 +9,7 @@ title: Aggregate functions
 
 Aggregate functions compute a single result from a set of input values.
 
-For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](/sql/query-syntax/query-syntax-value-exp.md/#aggregate-expressions).
+For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](../query-syntax/query-syntax-value-exp.md#aggregate-expressions).
 
 ## General-purpose aggregate functions
 
@@ -18,24 +18,24 @@ For details about the supported syntaxes of aggregate expressions, see [Aggregat
 Returns an array from input values in which each value in the set is assigned to an array element. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```sql title=Syntax
-array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array       
-```  
+array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array
+```
 
----  
+---
 
 ### `avg`
 
 Returns the average (arithmetic mean) of the selected values.
 
 ```bash title=Syntax
-avg ( expression ) -> see description   
-```  
+avg ( expression ) -> see description
+```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
 
 Return type is numeric for integer inputs and double precision for float point inputs.
 
----  
+---
 
 ### `bit_and`
 
@@ -45,7 +45,7 @@ Returns the bitwise AND of all non-null input values or null if no non-null valu
 bit_and ( smallint, int, or bigint ) -> same as input type
 ```
 
----  
+---
 
 ### `bit_or`
 
@@ -55,7 +55,7 @@ Returns the bitwise OR of all non-null input values or null if no non-null value
 bit_or ( smallint, int, or bigint ) -> same as input type
 ```
 
----  
+---
 
 ### `bool_and`
 
@@ -65,7 +65,7 @@ Returns true if all input values are true, otherwise false.
 bool_and ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `bool_or`
 
@@ -75,80 +75,80 @@ Returns true if at least one input value is true, otherwise false.
 bool_or ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `count`
 
 Returns the number of non-null rows.
 
 ```bash title=Syntax
-count ( expression ) -> bigint    
-```  
+count ( expression ) -> bigint
+```
 
 The input can be of any supported data type.
 
----  
+---
 
 ### `jsonb_agg`
 
 Aggregates values, including nulls, as a JSON array. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```bash title=Syntax
-jsonb_agg ( any_element ) -> jsonb    
+jsonb_agg ( any_element ) -> jsonb
 ```
 
----  
+---
 
 ### `jsonb_object_agg`
 
 Aggregates name/value pairs as a JSON object.
 
 ```bash title=Syntax
-jsonb_object_agg ( key "string" , value "any" ) -> jsonb   
+jsonb_object_agg ( key "string" , value "any" ) -> jsonb
 ```
 
----  
+---
 
 ### `max`
 
-Returns the maximum value in a set of values.  
+Returns the maximum value in a set of values.
 
 ```bash title=Syntax
-max ( expression ) -> same as input type    
-```  
+max ( expression ) -> same as input type
+```
 
 Input can be of any numeric, string, date/time, or interval type, or an array of these types.
 
----  
+---
 
 ### `min`
 
-Returns the minimum value in a set of values.  
+Returns the minimum value in a set of values.
 
 ```bash title=Syntax
-min ( expression ) -> same as input type  
-```  
+min ( expression ) -> same as input type
+```
 
-Input can be of any numeric, string, date/time, or interval type, or an array of these types.  
+Input can be of any numeric, string, date/time, or interval type, or an array of these types.
 
----  
+---
 
 ### `string_agg`
 
 Combines non-null values into a string, separated by `delimiter_string`. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```bash title=Syntax
-string_agg ( expression, delimiter_string ) -> output_string  
+string_agg ( expression, delimiter_string ) -> output_string
 ```
 
----  
+---
 
 ### `sum`
 
 Returns the sum of all input values.
 
 ```bash title=Syntax
-sum ( expression )  
+sum ( expression )
 ```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
@@ -165,17 +165,17 @@ Calculates the population standard deviation of the input values. Returns `NULL`
 stddev_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `stddev_samp`
 
-Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.  
+Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.
 
 ```bash title=Syntax
 stddev_samp ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_pop`
 
@@ -185,7 +185,7 @@ Calculates the population variance of the input values. Returns `NULL` if the in
 var_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_samp`
 
@@ -217,7 +217,7 @@ This example calculates the mode of the values in `column1` from `table1`.
 SELECT mode() WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
 
----  
+---
 
 ### `percentile_cont`
 
@@ -241,7 +241,7 @@ SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY column1) FROM table1;
 
 If NULL is provided, the function will not calculate a specific percentile and return NULL instead.
 
----  
+---
 
 ### `percentile_disc`
 
@@ -290,8 +290,8 @@ INSERT INTO items_sold VALUES ('Foo', 'L', 10),('Foo', 'M', 20),('Bar', 'M', 15)
 ```
 
 ```sql title="Get grouping results"
-SELECT brand, size, sum(sales), grouping(brand), grouping(size), grouping(brand,size), count(DISTINCT sales) 
-FROM items_sold 
+SELECT brand, size, sum(sales), grouping(brand), grouping(size), grouping(brand,size), count(DISTINCT sales)
+FROM items_sold
 GROUP BY GROUPING SETS ((brand), (size), ());
 ------RESULTS
 Bar NULL 20 0 1 1 2

--- a/versioned_docs/version-1.6/sql/functions-operators/sql-function-cast.md
+++ b/versioned_docs/version-1.6/sql/functions-operators/sql-function-cast.md
@@ -22,7 +22,7 @@ value :: type
 |Parameter        | Description     |
 |-----------------|-----------------|
 |*value*          |The value to be converted.|
-|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Data types](/sql/sql-data-types.md/#casts).|
+|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Casting](../data-types/data-type-casting.md).|
 
 
 ## Example

--- a/versioned_docs/version-1.7/risingwave-sql-101.md
+++ b/versioned_docs/version-1.7/risingwave-sql-101.md
@@ -7,11 +7,11 @@ slug: /risingwave-sql-101
 
 In this guide, we will walk you through some of the most used SQL commands in RisingWave. This is a simple yet typical data processing workflow that shows how to manipulate data with RisingWave.
 
-> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands. 
+> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands.
 
 ## Before we start
 
-Ensure that you have [started and connected to RisingWave](get-started.md/#run-risingwave).
+Ensure that you have [started and connected to RisingWave](./get-started.md).
 
 ## Create a table
 
@@ -19,18 +19,18 @@ Now let's create a table to store data about taxi trips.
 
 ```sql
 CREATE TABLE taxi_trips (
-    trip_id int, 
-    taxi_id int, 
-    completed_at timestamp, 
-    distance double precision, 
+    trip_id int,
+    taxi_id int,
+    completed_at timestamp,
+    distance double precision,
     duration double precision);
 ```
 
 And let's add some data to the table.
 
 ```sql
-INSERT INTO taxi_trips VALUES 
-(1, 1001, '2022-07-01 22:00:00', 4, 6), 
+INSERT INTO taxi_trips VALUES
+(1, 1001, '2022-07-01 22:00:00', 4, 6),
 (2, 1002, '2022-07-01 22:01:00', 6, 9);
 ```
 
@@ -60,10 +60,10 @@ We can now query the average speed.
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration |     avg_speed      
+ no_of_trips | total_distance | total_duration |     avg_speed
 -------------+----------------+----------------+--------------------
            2 |             10 |             15 | 0.6666666666666666
 (1 row)
@@ -81,10 +81,10 @@ As soon as we insert the new record, the materialized view `mv_avg_speed` will b
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration | avg_speed 
+ no_of_trips | total_distance | total_duration | avg_speed
 -------------+----------------+----------------+-----------
            3 |             13 |             20 |      0.65
 (1 row)
@@ -100,21 +100,21 @@ Creating a materialized view from a source is similar to creating from a table.
 The following statement creates a materialized view for three columns in a connected source named `debezium_json_mysql_source`.
 
 ```sql title="To create a materialized view from a source:"
-CREATE MATERIALIZED VIEW debezium_json_mysql_mv 
-AS 
+CREATE MATERIALIZED VIEW debezium_json_mysql_mv
+AS
     SELECT COLUMN1, COLUMN2, COLUMN3 FROM debezium_json_mysql_source;
 ```
 > For details about creating a source, see [CREATE SOURCE](sql/commands/sql-create-source.md).
 
 ## Create a materialized view on materialized views
 
-With RisingWave, you can also create a materialized view from an existing materialized view. 
+With RisingWave, you can also create a materialized view from an existing materialized view.
 
 ```sql title="To create a materialized view from existing materialized views:"
 CREATE MATERIALIZED VIEW m3
-AS 
-    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2 
-    FROM m1 
+AS
+    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2
+    FROM m1
     INNER JOIN m2 ON m1.v1 = m2.v1;
 ```
 

--- a/versioned_docs/version-1.7/sql/functions-operators/sql-function-aggregate.md
+++ b/versioned_docs/version-1.7/sql/functions-operators/sql-function-aggregate.md
@@ -9,7 +9,7 @@ title: Aggregate functions
 
 Aggregate functions compute a single result from a set of input values.
 
-For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](/sql/query-syntax/query-syntax-value-exp.md/#aggregate-expressions).
+For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](../query-syntax/query-syntax-value-exp.md#aggregate-expressions).
 
 ## General-purpose aggregate functions
 
@@ -18,24 +18,24 @@ For details about the supported syntaxes of aggregate expressions, see [Aggregat
 Returns an array from input values in which each value in the set is assigned to an array element. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```sql title=Syntax
-array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array       
-```  
+array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array
+```
 
----  
+---
 
 ### `avg`
 
 Returns the average (arithmetic mean) of the selected values.
 
 ```bash title=Syntax
-avg ( expression ) -> see description   
-```  
+avg ( expression ) -> see description
+```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
 
 Return type is numeric for integer inputs and double precision for float point inputs.
 
----  
+---
 
 ### `bit_and`
 
@@ -45,7 +45,7 @@ Returns the bitwise AND of all non-null input values or null if no non-null valu
 bit_and ( smallint, int, or bigint ) -> same as input type
 ```
 
----  
+---
 
 ### `bit_or`
 
@@ -55,7 +55,7 @@ Returns the bitwise OR of all non-null input values or null if no non-null value
 bit_or ( smallint, int, or bigint ) -> same as input type
 ```
 
----  
+---
 
 ### `bool_and`
 
@@ -65,7 +65,7 @@ Returns true if all input values are true, otherwise false.
 bool_and ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `bool_or`
 
@@ -75,80 +75,80 @@ Returns true if at least one input value is true, otherwise false.
 bool_or ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `count`
 
 Returns the number of non-null rows.
 
 ```bash title=Syntax
-count ( expression ) -> bigint    
-```  
+count ( expression ) -> bigint
+```
 
 The input can be of any supported data type.
 
----  
+---
 
 ### `jsonb_agg`
 
 Aggregates values, including nulls, as a JSON array. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```bash title=Syntax
-jsonb_agg ( any_element ) -> jsonb    
+jsonb_agg ( any_element ) -> jsonb
 ```
 
----  
+---
 
 ### `jsonb_object_agg`
 
 Aggregates name/value pairs as a JSON object.
 
 ```bash title=Syntax
-jsonb_object_agg ( key "string" , value "any" ) -> jsonb   
+jsonb_object_agg ( key "string" , value "any" ) -> jsonb
 ```
 
----  
+---
 
 ### `max`
 
-Returns the maximum value in a set of values.  
+Returns the maximum value in a set of values.
 
 ```bash title=Syntax
-max ( expression ) -> same as input type    
-```  
+max ( expression ) -> same as input type
+```
 
 Input can be of any numeric, string, date/time, or interval type, or an array of these types.
 
----  
+---
 
 ### `min`
 
-Returns the minimum value in a set of values.  
+Returns the minimum value in a set of values.
 
 ```bash title=Syntax
-min ( expression ) -> same as input type  
-```  
+min ( expression ) -> same as input type
+```
 
-Input can be of any numeric, string, date/time, or interval type, or an array of these types.  
+Input can be of any numeric, string, date/time, or interval type, or an array of these types.
 
----  
+---
 
 ### `string_agg`
 
 Combines non-null values into a string, separated by `delimiter_string`. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```bash title=Syntax
-string_agg ( expression, delimiter_string ) -> output_string  
+string_agg ( expression, delimiter_string ) -> output_string
 ```
 
----  
+---
 
 ### `sum`
 
 Returns the sum of all input values.
 
 ```bash title=Syntax
-sum ( expression )  
+sum ( expression )
 ```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
@@ -165,17 +165,17 @@ Calculates the population standard deviation of the input values. Returns `NULL`
 stddev_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `stddev_samp`
 
-Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.  
+Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.
 
 ```bash title=Syntax
 stddev_samp ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_pop`
 
@@ -185,7 +185,7 @@ Calculates the population variance of the input values. Returns `NULL` if the in
 var_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_samp`
 
@@ -217,7 +217,7 @@ This example calculates the mode of the values in `column1` from `table1`.
 SELECT mode() WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
 
----  
+---
 
 ### `percentile_cont`
 
@@ -241,7 +241,7 @@ SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY column1) FROM table1;
 
 If NULL is provided, the function will not calculate a specific percentile and return NULL instead.
 
----  
+---
 
 ### `percentile_disc`
 
@@ -290,8 +290,8 @@ INSERT INTO items_sold VALUES ('Foo', 'L', 10),('Foo', 'M', 20),('Bar', 'M', 15)
 ```
 
 ```sql title="Get grouping results"
-SELECT brand, size, sum(sales), grouping(brand), grouping(size), grouping(brand,size), count(DISTINCT sales) 
-FROM items_sold 
+SELECT brand, size, sum(sales), grouping(brand), grouping(size), grouping(brand,size), count(DISTINCT sales)
+FROM items_sold
 GROUP BY GROUPING SETS ((brand), (size), ());
 ------RESULTS
 Bar NULL 20 0 1 1 2

--- a/versioned_docs/version-1.7/sql/functions-operators/sql-function-cast.md
+++ b/versioned_docs/version-1.7/sql/functions-operators/sql-function-cast.md
@@ -22,7 +22,7 @@ value :: type
 |Parameter        | Description     |
 |-----------------|-----------------|
 |*value*          |The value to be converted.|
-|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Data types](/sql/sql-data-types.md/#casts).|
+|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Casting](../data-types/data-type-casting.md).|
 
 
 ## Example

--- a/versioned_docs/version-1.8/risingwave-sql-101.md
+++ b/versioned_docs/version-1.8/risingwave-sql-101.md
@@ -7,11 +7,11 @@ slug: /risingwave-sql-101
 
 In this guide, we will walk you through some of the most used SQL commands in RisingWave. This is a simple yet typical data processing workflow that shows how to manipulate data with RisingWave.
 
-> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands. 
+> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands.
 
 ## Before we start
 
-Ensure that you have [started and connected to RisingWave](get-started.md/#run-risingwave).
+Ensure that you have [started and connected to RisingWave](./get-started.md).
 
 ## Create a table
 
@@ -19,18 +19,18 @@ Now let's create a table to store data about taxi trips.
 
 ```sql
 CREATE TABLE taxi_trips (
-    trip_id int, 
-    taxi_id int, 
-    completed_at timestamp, 
-    distance double precision, 
+    trip_id int,
+    taxi_id int,
+    completed_at timestamp,
+    distance double precision,
     duration double precision);
 ```
 
 And let's add some data to the table.
 
 ```sql
-INSERT INTO taxi_trips VALUES 
-(1, 1001, '2022-07-01 22:00:00', 4, 6), 
+INSERT INTO taxi_trips VALUES
+(1, 1001, '2022-07-01 22:00:00', 4, 6),
 (2, 1002, '2022-07-01 22:01:00', 6, 9);
 ```
 
@@ -60,10 +60,10 @@ We can now query the average speed.
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration |     avg_speed      
+ no_of_trips | total_distance | total_duration |     avg_speed
 -------------+----------------+----------------+--------------------
            2 |             10 |             15 | 0.6666666666666666
 (1 row)
@@ -81,10 +81,10 @@ As soon as we insert the new record, the materialized view `mv_avg_speed` will b
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration | avg_speed 
+ no_of_trips | total_distance | total_duration | avg_speed
 -------------+----------------+----------------+-----------
            3 |             13 |             20 |      0.65
 (1 row)
@@ -100,21 +100,21 @@ Creating a materialized view from a source is similar to creating from a table.
 The following statement creates a materialized view for three columns in a connected source named `debezium_json_mysql_source`.
 
 ```sql title="To create a materialized view from a source:"
-CREATE MATERIALIZED VIEW debezium_json_mysql_mv 
-AS 
+CREATE MATERIALIZED VIEW debezium_json_mysql_mv
+AS
     SELECT COLUMN1, COLUMN2, COLUMN3 FROM debezium_json_mysql_source;
 ```
 > For details about creating a source, see [CREATE SOURCE](sql/commands/sql-create-source.md).
 
 ## Create a materialized view on materialized views
 
-With RisingWave, you can also create a materialized view from an existing materialized view. 
+With RisingWave, you can also create a materialized view from an existing materialized view.
 
 ```sql title="To create a materialized view from existing materialized views:"
 CREATE MATERIALIZED VIEW m3
-AS 
-    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2 
-    FROM m1 
+AS
+    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2
+    FROM m1
     INNER JOIN m2 ON m1.v1 = m2.v1;
 ```
 

--- a/versioned_docs/version-1.8/sql/functions-operators/sql-function-aggregate.md
+++ b/versioned_docs/version-1.8/sql/functions-operators/sql-function-aggregate.md
@@ -9,7 +9,7 @@ title: Aggregate functions
 
 Aggregate functions compute a single result from a set of input values.
 
-For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](/sql/query-syntax/query-syntax-value-exp.md/#aggregate-expressions).
+For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](../query-syntax/query-syntax-value-exp.md#aggregate-expressions).
 
 ## General-purpose aggregate functions
 
@@ -18,24 +18,24 @@ For details about the supported syntaxes of aggregate expressions, see [Aggregat
 Returns an array from input values in which each value in the set is assigned to an array element. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```sql title=Syntax
-array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array       
-```  
+array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array
+```
 
----  
+---
 
 ### `avg`
 
 Returns the average (arithmetic mean) of the selected values.
 
 ```bash title=Syntax
-avg ( expression ) -> see description   
-```  
+avg ( expression ) -> see description
+```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
 
 Return type is numeric for integer inputs and double precision for float point inputs.
 
----  
+---
 
 ### `bit_and`
 
@@ -45,7 +45,7 @@ Returns the bitwise AND of all non-null input values or null if no non-null valu
 bit_and ( smallint, int, or bigint ) -> same as input type
 ```
 
----  
+---
 
 ### `bit_or`
 
@@ -55,7 +55,7 @@ Returns the bitwise OR of all non-null input values or null if no non-null value
 bit_or ( smallint, int, or bigint ) -> same as input type
 ```
 
----  
+---
 
 ### `bool_and`
 
@@ -65,7 +65,7 @@ Returns true if all input values are true, otherwise false.
 bool_and ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `bool_or`
 
@@ -75,80 +75,80 @@ Returns true if at least one input value is true, otherwise false.
 bool_or ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `count`
 
 Returns the number of non-null rows.
 
 ```bash title=Syntax
-count ( expression ) -> bigint    
-```  
+count ( expression ) -> bigint
+```
 
 The input can be of any supported data type.
 
----  
+---
 
 ### `jsonb_agg`
 
 Aggregates values, including nulls, as a JSON array. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```bash title=Syntax
-jsonb_agg ( any_element ) -> jsonb    
+jsonb_agg ( any_element ) -> jsonb
 ```
 
----  
+---
 
 ### `jsonb_object_agg`
 
 Aggregates name/value pairs as a JSON object.
 
 ```bash title=Syntax
-jsonb_object_agg ( key "string" , value "any" ) -> jsonb   
+jsonb_object_agg ( key "string" , value "any" ) -> jsonb
 ```
 
----  
+---
 
 ### `max`
 
-Returns the maximum value in a set of values.  
+Returns the maximum value in a set of values.
 
 ```bash title=Syntax
-max ( expression ) -> same as input type    
-```  
+max ( expression ) -> same as input type
+```
 
 Input can be of any numeric, string, date/time, or interval type, or an array of these types.
 
----  
+---
 
 ### `min`
 
-Returns the minimum value in a set of values.  
+Returns the minimum value in a set of values.
 
 ```bash title=Syntax
-min ( expression ) -> same as input type  
-```  
+min ( expression ) -> same as input type
+```
 
-Input can be of any numeric, string, date/time, or interval type, or an array of these types.  
+Input can be of any numeric, string, date/time, or interval type, or an array of these types.
 
----  
+---
 
 ### `string_agg`
 
 Combines non-null values into a string, separated by `delimiter_string`. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```bash title=Syntax
-string_agg ( expression, delimiter_string ) -> output_string  
+string_agg ( expression, delimiter_string ) -> output_string
 ```
 
----  
+---
 
 ### `sum`
 
 Returns the sum of all input values.
 
 ```bash title=Syntax
-sum ( expression )  
+sum ( expression )
 ```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
@@ -165,17 +165,17 @@ Calculates the population standard deviation of the input values. Returns `NULL`
 stddev_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `stddev_samp`
 
-Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.  
+Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.
 
 ```bash title=Syntax
 stddev_samp ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_pop`
 
@@ -185,7 +185,7 @@ Calculates the population variance of the input values. Returns `NULL` if the in
 var_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_samp`
 
@@ -217,7 +217,7 @@ This example calculates the mode of the values in `column1` from `table1`.
 SELECT mode() WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
 
----  
+---
 
 ### `percentile_cont`
 
@@ -241,7 +241,7 @@ SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY column1) FROM table1;
 
 If NULL is provided, the function will not calculate a specific percentile and return NULL instead.
 
----  
+---
 
 ### `percentile_disc`
 
@@ -290,8 +290,8 @@ INSERT INTO items_sold VALUES ('Foo', 'L', 10),('Foo', 'M', 20),('Bar', 'M', 15)
 ```
 
 ```sql title="Get grouping results"
-SELECT brand, size, sum(sales), grouping(brand), grouping(size), grouping(brand,size), count(DISTINCT sales) 
-FROM items_sold 
+SELECT brand, size, sum(sales), grouping(brand), grouping(size), grouping(brand,size), count(DISTINCT sales)
+FROM items_sold
 GROUP BY GROUPING SETS ((brand), (size), ());
 ------RESULTS
 Bar NULL 20 0 1 1 2

--- a/versioned_docs/version-1.8/sql/functions-operators/sql-function-cast.md
+++ b/versioned_docs/version-1.8/sql/functions-operators/sql-function-cast.md
@@ -22,7 +22,7 @@ value :: type
 |Parameter        | Description     |
 |-----------------|-----------------|
 |*value*          |The value to be converted.|
-|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Data types](/sql/sql-data-types.md/#casts).|
+|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Casting](../data-types/data-type-casting.md).|
 
 
 ## Example

--- a/versioned_docs/version-1.9/risingwave-sql-101.md
+++ b/versioned_docs/version-1.9/risingwave-sql-101.md
@@ -7,11 +7,11 @@ slug: /risingwave-sql-101
 
 In this guide, we will walk you through some of the most used SQL commands in RisingWave. This is a simple yet typical data processing workflow that shows how to manipulate data with RisingWave.
 
-> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands. 
+> RisingWave uses Postgres-compatible SQL as the interface to manage and query data. For a complete list of supported SQL commands, please navigate to SQL references → Commands.
 
 ## Before we start
 
-Ensure that you have [started and connected to RisingWave](get-started.md/#run-risingwave).
+Ensure that you have [started and connected to RisingWave](./get-started.md).
 
 ## Create a table
 
@@ -19,18 +19,18 @@ Now let's create a table to store data about taxi trips.
 
 ```sql
 CREATE TABLE taxi_trips (
-    trip_id int, 
-    taxi_id int, 
-    completed_at timestamp, 
-    distance double precision, 
+    trip_id int,
+    taxi_id int,
+    completed_at timestamp,
+    distance double precision,
     duration double precision);
 ```
 
 And let's add some data to the table.
 
 ```sql
-INSERT INTO taxi_trips VALUES 
-(1, 1001, '2022-07-01 22:00:00', 4, 6), 
+INSERT INTO taxi_trips VALUES
+(1, 1001, '2022-07-01 22:00:00', 4, 6),
 (2, 1002, '2022-07-01 22:01:00', 6, 9);
 ```
 
@@ -60,10 +60,10 @@ We can now query the average speed.
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration |     avg_speed      
+ no_of_trips | total_distance | total_duration |     avg_speed
 -------------+----------------+----------------+--------------------
            2 |             10 |             15 | 0.6666666666666666
 (1 row)
@@ -81,10 +81,10 @@ As soon as we insert the new record, the materialized view `mv_avg_speed` will b
 SELECT * FROM mv_avg_speed;
 ```
 
-Here is the result we get. 
+Here is the result we get.
 
 ```
- no_of_trips | total_distance | total_duration | avg_speed 
+ no_of_trips | total_distance | total_duration | avg_speed
 -------------+----------------+----------------+-----------
            3 |             13 |             20 |      0.65
 (1 row)
@@ -100,21 +100,21 @@ Creating a materialized view from a source is similar to creating from a table.
 The following statement creates a materialized view for three columns in a connected source named `debezium_json_mysql_source`.
 
 ```sql title="To create a materialized view from a source:"
-CREATE MATERIALIZED VIEW debezium_json_mysql_mv 
-AS 
+CREATE MATERIALIZED VIEW debezium_json_mysql_mv
+AS
     SELECT COLUMN1, COLUMN2, COLUMN3 FROM debezium_json_mysql_source;
 ```
 > For details about creating a source, see [CREATE SOURCE](sql/commands/sql-create-source.md).
 
 ## Create a materialized view on materialized views
 
-With RisingWave, you can also create a materialized view from an existing materialized view. 
+With RisingWave, you can also create a materialized view from an existing materialized view.
 
 ```sql title="To create a materialized view from existing materialized views:"
 CREATE MATERIALIZED VIEW m3
-AS 
-    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2 
-    FROM m1 
+AS
+    SELECT m1.v1 as m1v1, m1.v2 as m1v2, m2.v1, m2.v2
+    FROM m1
     INNER JOIN m2 ON m1.v1 = m2.v1;
 ```
 

--- a/versioned_docs/version-1.9/sql/functions-operators/sql-function-aggregate.md
+++ b/versioned_docs/version-1.9/sql/functions-operators/sql-function-aggregate.md
@@ -9,7 +9,7 @@ title: Aggregate functions
 
 Aggregate functions compute a single result from a set of input values.
 
-For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](/sql/query-syntax/query-syntax-value-exp.md/#aggregate-expressions).
+For details about the supported syntaxes of aggregate expressions, see [Aggregate expressions](../query-syntax/query-syntax-value-exp.md#aggregate-expressions).
 
 ## General-purpose aggregate functions
 
@@ -18,24 +18,24 @@ For details about the supported syntaxes of aggregate expressions, see [Aggregat
 Returns an array from input values in which each value in the set is assigned to an array element. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```sql title=Syntax
-array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array       
-```  
+array_agg ( expression [ ORDER BY [ sort_expression { ASC | DESC } ] ] ) -> output_array
+```
 
----  
+---
 
 ### `avg`
 
 Returns the average (arithmetic mean) of the selected values.
 
 ```bash title=Syntax
-avg ( expression ) -> see description   
-```  
+avg ( expression ) -> see description
+```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
 
 Return type is numeric for integer inputs and double precision for float point inputs.
 
----  
+---
 
 ### `bit_and`
 
@@ -45,7 +45,7 @@ Returns the bitwise AND of all non-null input values or null if no non-null valu
 bit_and ( smallint, int, or bigint ) -> same as input type
 ```
 
----  
+---
 
 ### `bit_or`
 
@@ -55,7 +55,7 @@ Returns the bitwise OR of all non-null input values or null if no non-null value
 bit_or ( smallint, int, or bigint ) -> same as input type
 ```
 
----  
+---
 
 ### `bool_and`
 
@@ -65,7 +65,7 @@ Returns true if all input values are true, otherwise false.
 bool_and ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `bool_or`
 
@@ -75,80 +75,80 @@ Returns true if at least one input value is true, otherwise false.
 bool_or ( boolean ) -> boolean
 ```
 
----  
+---
 
 ### `count`
 
 Returns the number of non-null rows.
 
 ```bash title=Syntax
-count ( expression ) -> bigint    
-```  
+count ( expression ) -> bigint
+```
 
 The input can be of any supported data type.
 
----  
+---
 
 ### `jsonb_agg`
 
 Aggregates values, including nulls, as a JSON array. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```bash title=Syntax
-jsonb_agg ( any_element ) -> jsonb    
+jsonb_agg ( any_element ) -> jsonb
 ```
 
----  
+---
 
 ### `jsonb_object_agg`
 
 Aggregates name/value pairs as a JSON object.
 
 ```bash title=Syntax
-jsonb_object_agg ( key "string" , value "any" ) -> jsonb   
+jsonb_object_agg ( key "string" , value "any" ) -> jsonb
 ```
 
----  
+---
 
 ### `max`
 
-Returns the maximum value in a set of values.  
+Returns the maximum value in a set of values.
 
 ```bash title=Syntax
-max ( expression ) -> same as input type    
-```  
+max ( expression ) -> same as input type
+```
 
 Input can be of any numeric, string, date/time, or interval type, or an array of these types.
 
----  
+---
 
 ### `min`
 
-Returns the minimum value in a set of values.  
+Returns the minimum value in a set of values.
 
 ```bash title=Syntax
-min ( expression ) -> same as input type  
-```  
+min ( expression ) -> same as input type
+```
 
-Input can be of any numeric, string, date/time, or interval type, or an array of these types.  
+Input can be of any numeric, string, date/time, or interval type, or an array of these types.
 
----  
+---
 
 ### `string_agg`
 
 Combines non-null values into a string, separated by `delimiter_string`. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.
 
 ```bash title=Syntax
-string_agg ( expression, delimiter_string ) -> output_string  
+string_agg ( expression, delimiter_string ) -> output_string
 ```
 
----  
+---
 
 ### `sum`
 
 Returns the sum of all input values.
 
 ```bash title=Syntax
-sum ( expression )  
+sum ( expression )
 ```
 
 Input types include smallint, int, bigint, numeric, real, and double precision.
@@ -183,17 +183,17 @@ Calculates the population standard deviation of the input values. Returns `NULL`
 stddev_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `stddev_samp`
 
-Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.  
+Calculates the sample standard deviation of the input values. Returns `NULL` if the input contains fewer than two non-null values.
 
 ```bash title=Syntax
 stddev_samp ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_pop`
 
@@ -203,7 +203,7 @@ Calculates the population variance of the input values. Returns `NULL` if the in
 var_pop ( expression ) -> output_value
 ```
 
----  
+---
 
 ### `var_samp`
 
@@ -235,7 +235,7 @@ This example calculates the mode of the values in `column1` from `table1`.
 SELECT mode() WITHIN GROUP (ORDER BY column1) FROM table1;
 ```
 
----  
+---
 
 ### `percentile_cont`
 
@@ -259,7 +259,7 @@ SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY column1) FROM table1;
 
 If NULL is provided, the function will not calculate a specific percentile and return NULL instead.
 
----  
+---
 
 ### `percentile_disc`
 
@@ -308,8 +308,8 @@ INSERT INTO items_sold VALUES ('Foo', 'L', 10),('Foo', 'M', 20),('Bar', 'M', 15)
 ```
 
 ```sql title="Get grouping results"
-SELECT brand, size, sum(sales), grouping(brand), grouping(size), grouping(brand,size), count(DISTINCT sales) 
-FROM items_sold 
+SELECT brand, size, sum(sales), grouping(brand), grouping(size), grouping(brand,size), count(DISTINCT sales)
+FROM items_sold
 GROUP BY GROUPING SETS ((brand), (size), ());
 ------RESULTS
 Bar NULL 20 0 1 1 2

--- a/versioned_docs/version-1.9/sql/functions-operators/sql-function-cast.md
+++ b/versioned_docs/version-1.9/sql/functions-operators/sql-function-cast.md
@@ -22,7 +22,7 @@ value :: type
 |Parameter        | Description     |
 |-----------------|-----------------|
 |*value*          |The value to be converted.|
-|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Data types](/sql/sql-data-types.md/#casts).|
+|*type*           |The data type of the returned value.<br/>For the types you can cast the value to, see [Casting](../data-types/data-type-casting.md).|
 
 
 ## Example


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Description

Some broken links in our docs are blocking upgrading to Docusaurus v3. This PR fixes them.

Markdown guide from this PR:

- Use relative paths of `.md` files when doing cross-reference if possible, e.g. `[Explore RisingWave with examples](./quickstart.md#step-4-explore-risingwave-with-examples)`.
- No need to add `/` after the `.md` file path. ❌ `./get-started.md/#run-risingwave` ✅ `./get-started.md#run-risingwave` (the latter one can be clicked-into in VS Code)
- No need to maintain links to doc pages in Release Notes, because cross-referenceing by relative path is not supported between `pages` and `docs` directories. If using `/docs/current/...`, we must update these links each time we release a new version, and that's a burden.

## Checklist

- [x] I have checked the doc site preview, and the updated parts look good.
- [x] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
