### PR TITLE
Add functions `rw_recovery_status()` and `pg_is_in_recovery()` in doc

### DIFF
--- a/docs/sql/functions-operators/sql-function-sys-admin.md
+++ b/docs/sql/functions-operators/sql-function-sys-admin.md
@@ -72,6 +72,34 @@ SELECT has_any_column_privilege('test_user', 'foo_view'::regclass, 'INSERT');
 f
 ```
 
+## `rw_recovery_status()`
+
+Retrieves the current recovery status of the meta node. The return values can be one of `STARTING`, `RECOVERING`, or `RUNNING`.
+
+```sql title="Syntax"
+rw_recovery_status() -> varchar
+```
+
+```sql title="Example"
+SELECT rw_recovery_status();
+-- RESULT
+'RUNNING'
+```
+
+## `pg_is_in_recovery()`
+
+Checks if the PostgreSQL instance is currently in recovery mode.
+
+```sql title="Syntax"
+pg_is_in_recovery() -> boolean
+```
+
+```sql title="Example"
+SELECT pg_is_in_recovery();
+----RESULT
+t
+```
+
 ## `set_config()`
 
 ```sql title="Syntax"

--- a/docs/sql/functions-operators/sql-function-sys-admin.md
+++ b/docs/sql/functions-operators/sql-function-sys-admin.md
@@ -74,7 +74,7 @@ f
 
 ## `rw_recovery_status()`
 
-Retrieves the current recovery status of the meta node. The return values can be one of `STARTING`, `RECOVERING`, or `RUNNING`.
+Retrieves the current recovery status of the cluster. The return values can be one of `STARTING`, `RECOVERING`, or `RUNNING`.
 
 ```sql title="Syntax"
 rw_recovery_status() -> varchar


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Description

<!--
Please describe:

1. The motivation of this PR;
2. What's changed and how is the document site is affected;
3. References that's worth listed.
-->
Supports `rw_recovery_status()` and `pg_is_in_recovery()` in system administration functions
## Related code PR

<!--
Provide a link to the relevant code PR here, if applicable.
-->
https://github.com/risingwavelabs/risingwave/pull/17641
## Related doc issue

<!--
If this PR fixes/resolves the issue, please write "Resolve #xxx".
-->
Resolve https://github.com/risingwavelabs/risingwave-docs/issues/2364

<!--
❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.
-->

<!--
Edit the following sections when this PR is ready for review.
-->

## Rendered preview

<!--
Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation.
-->

## Checklist

- [ ] I have checked the doc site preview, and the updated parts look good.
- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
