### PR TITLE
fix(subscription): fix incorrect example for persisting progress in RW

### DIFF
--- a/docs/transform/subscription.md
+++ b/docs/transform/subscription.md
@@ -262,7 +262,7 @@ First, we need to create a table for storing the progress.
 CREATE TABLE IF NOT EXISTS subscription_progress (
     sub_name VARCHAR PRIMARY KEY,
     progress BIGINT
-);
+) ON CONFLICT OVERWRITE;
 ```
 
 Here's an example python code for retrieving and updating the consumption progress:
@@ -276,11 +276,7 @@ def get_last_progress(conn, sub_name):
 
 def update_progress(conn, sub_name, progress):
     with conn.cursor() as cur:
-        cur.execute("""
-            INSERT INTO subscription_progress (sub_name, progress)
-            VALUES (%s, %s)
-            ON CONFLICT (sub_name) DO UPDATE SET progress = %s
-        """, (sub_name, progress, progress))
+        cur.execute("INSERT INTO subscription_progress (sub_name, progress)", (sub_name, progress, progress))
         cur.execute("FLUSH")
         conn.commit()
 ```

--- a/versioned_docs/version-1.10/transform/subscription.md
+++ b/versioned_docs/version-1.10/transform/subscription.md
@@ -258,7 +258,7 @@ First, we need to create a table for storing the progress.
 CREATE TABLE IF NOT EXISTS subscription_progress (
     sub_name VARCHAR PRIMARY KEY,
     progress BIGINT
-);
+) ON CONFLICT OVERWRITE;
 ```
 
 Here's an example python code for retrieving and updating the consumption progress:
@@ -272,11 +272,7 @@ def get_last_progress(conn, sub_name):
 
 def update_progress(conn, sub_name, progress):
     with conn.cursor() as cur:
-        cur.execute("""
-            INSERT INTO subscription_progress (sub_name, progress)
-            VALUES (%s, %s)
-            ON CONFLICT (sub_name) DO UPDATE SET progress = %s
-        """, (sub_name, progress, progress))
+        cur.execute("INSERT INTO subscription_progress (sub_name, progress)", (sub_name, progress, progress))
         cur.execute("FLUSH")
         conn.commit()
 ```

--- a/versioned_docs/version-1.9/transform/subscription.md
+++ b/versioned_docs/version-1.9/transform/subscription.md
@@ -220,7 +220,7 @@ First, we need to create a table for storing the progress.
 CREATE TABLE IF NOT EXISTS subscription_progress (
     sub_name VARCHAR PRIMARY KEY,
     progress BIGINT
-);
+) ON CONFLICT OVERWRITE;
 ```
 
 Here's an example python code for retrieving and updating the consumption progress:
@@ -234,11 +234,7 @@ def get_last_progress(conn, sub_name):
 
 def update_progress(conn, sub_name, progress):
     with conn.cursor() as cur:
-        cur.execute("""
-            INSERT INTO subscription_progress (sub_name, progress)
-            VALUES (%s, %s)
-            ON CONFLICT (sub_name) DO UPDATE SET progress = %s
-        """, (sub_name, progress, progress))
+        cur.execute("INSERT INTO subscription_progress (sub_name, progress)", (sub_name, progress, progress))
         cur.execute("FLUSH")
         conn.commit()
 ```


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Description

RisingWave doesn't support `ON CONFLICT` for `INSERT`. We should use `ON CONFLICT` in `CREATE TABLE` instead.


## Related code PR

<!--
Provide a link to the relevant code PR here, if applicable.
-->

## Related doc issue

<!--
If this PR fixes/resolves the issue, please write "Resolve #xxx".
-->
Resolve

<!--
❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.
-->

<!--
Edit the following sections when this PR is ready for review.
-->

## Rendered preview

<!--
Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation.
-->

## Checklist

- [ ] I have checked the doc site preview, and the updated parts look good.
- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
