### PR TITLE
chore(layout): move slack button to header, ask ai button to bottom right

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -187,6 +187,11 @@ const config: Config = {
           label: "GitHub",
           position: "right",
         },
+        {
+          href: "https://risingwave.com/slack",
+          label: "Slack",
+          position: "right",
+        },
       ],
     },
     footer: {
@@ -232,7 +237,7 @@ const config: Config = {
       type: "module",
       "runllm-server-address": "https://api.runllm.com",
       "runllm-assistant-id": "29",
-      "runllm-position": "TOP_RIGHT",
+      "runllm-position": "BOTTOM_RIGHT",
       "runllm-keyboard-shortcut": "disable",
       "runllm-theme-color": "#005EEC",
       "runllm-slack-community-url":

--- a/src/components/FeedbackForm/index.js
+++ b/src/components/FeedbackForm/index.js
@@ -25,9 +25,6 @@ export default function FeedbackForm(props) {
   return (
     <Stack width="100%">
       <div className={styles.breakLine}></div>
-      <div className={styles.communityLinkContainer}>
-        <CommunityLinkGroup />
-      </div>
 
       <form>
         <Stack direction="row" spacing={2} className={styles.rightGroupContainer}>


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Description

As title. Resolve what mentioned here: https://github.com/risingwavelabs/risingwave-docs/pull/2582#pullrequestreview-2285255657.

Currently we cannot achieve the same style of custom button as Tinybird and Neon, because RunLLM only supports placing the fix-styled button at one of the for corners but doesn't support customizing the button.

Before:

<img width="1484" alt="截屏2024-09-14 17 12 22" src="https://github.com/user-attachments/assets/42cfadb1-6722-44b7-be8d-62dde5d8d1d8">

After:

<img width="1484" alt="截屏2024-09-14 17 11 53" src="https://github.com/user-attachments/assets/b452ab6e-1b9b-4b7f-8e1a-3b81c9338a63">

## Related code PR

<!--
Provide a link to the relevant code PR here, if applicable.
-->

## Related doc issue

<!--
If this PR fixes/resolves the issue, please write "Resolve #xxx".
-->
Resolve 

<!--
❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.
-->

<!--
Edit the following sections when this PR is ready for review.
-->

## Rendered preview

<!--
Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation.
-->

## Checklist

- [x] I have checked the doc site preview, and the updated parts look good.
- [x] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
