### PR TITLE
Update sink-to-postgres.md: `upsert` also can issue `DELETEs` downstream

### DIFF
--- a/docs/guides/sink-to-postgres.md
+++ b/docs/guides/sink-to-postgres.md
@@ -118,7 +118,7 @@ All `WITH` options are required unless noted.
 |jdbc.query.timeout|Specifies the timeout for the operations to downstream. If not set, the default is 10 minutes.|
 |table.name | The table in the destination database you want to sink to. |
 |schema.name | Optional. The schema in the destination database you want to sink to. The default value is `public`. |
-|type| Sink data type. Supported types:<ul><li> `append-only`: Sink data as INSERT operations.</li><li> `upsert`: Sink data as UPDATE and INSERT operations. </li></ul>|
+|type| Sink data type. Supported types:<ul><li> `append-only`: Sink data as INSERT operations.</li><li> `upsert`: Sink data as UPDATE, INSERT and DELETE operations. </li></ul>|
 |primary_key| Required if `type` is `upsert`. The primary key of the sink, which should match the primary key of the downstream table. |
 
 ## Sink data from RisingWave to PostgreSQL

--- a/versioned_docs/version-2.0/guides/sink-to-postgres.md
+++ b/versioned_docs/version-2.0/guides/sink-to-postgres.md
@@ -118,7 +118,7 @@ All `WITH` options are required unless noted.
 |jdbc.query.timeout|Specifies the timeout for the operations to downstream. If not set, the default is 10 minutes.|
 |table.name | The table in the destination database you want to sink to. |
 |schema.name | Optional. The schema in the destination database you want to sink to. The default value is `public`. |
-|type| Sink data type. Supported types:<ul><li> `append-only`: Sink data as INSERT operations.</li><li> `upsert`: Sink data as UPDATE and INSERT operations. </li></ul>|
+|type| Sink data type. Supported types:<ul><li> `append-only`: Sink data as INSERT operations.</li><li> `upsert`: Sink data as UPDATE, INSERT and DELETE operations. </li></ul>|
 |primary_key| Required if `type` is `upsert`. The primary key of the sink, which should match the primary key of the downstream table. |
 
 ## Sink data from RisingWave to PostgreSQL


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Description

Upsert semantics allows `deletes` to be emitted downstream as well. We should clarify that to users.

<!--
Please describe:

1. The motivation of this PR;
2. What's changed and how is the document site is affected;
3. References that's worth listed.
-->

## Related code PR

<!--
Provide a link to the relevant code PR here, if applicable.
-->

## Related doc issue

<!--
If this PR fixes/resolves the issue, please write "Resolve #xxx".
-->
Resolve

<!--
❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.
-->

<!--
Edit the following sections when this PR is ready for review.
-->

## Rendered preview

<!--
Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation.
-->

## Checklist

- [ ] I have checked the doc site preview, and the updated parts look good.
- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
