### PR TITLE
Update generate_series example to use `NOW()::timestamp` since timestamptz is not supported for generate_series

### DIFF
--- a/docs/sql/functions-operators/sql-function-set-returning.md
+++ b/docs/sql/functions-operators/sql-function-set-returning.md
@@ -89,7 +89,7 @@ Except for generating a static set of values, RisingWave also supports continuou
 CREATE MATERIALIZED VIEW mv AS
 SELECT * FROM generate_series(
   '2020-01-01 00:00:00',
-  now(),
+  now()::timestamp,
   interval '1 hour'
 );
 ```

--- a/docs/sql/functions-operators/sql-function-set-returning.md
+++ b/docs/sql/functions-operators/sql-function-set-returning.md
@@ -88,8 +88,8 @@ Except for generating a static set of values, RisingWave also supports continuou
 ```sql
 CREATE MATERIALIZED VIEW mv AS
 SELECT * FROM generate_series(
-  '2020-01-01 00:00:00',
-  now()::timestamp,
+  '2020-01-01 00:00:00'::timestamptz,
+  now(),
   interval '1 hour'
 );
 ```

--- a/versioned_docs/version-2.0/sql/functions-operators/sql-function-set-returning.md
+++ b/versioned_docs/version-2.0/sql/functions-operators/sql-function-set-returning.md
@@ -88,7 +88,7 @@ Except for generating a static set of values, RisingWave also supports continuou
 CREATE MATERIALIZED VIEW mv AS
 SELECT * FROM generate_series(
   '2020-01-01 00:00:00',
-  now(),
+  now()::timestamp,
   interval '1 hour'
 );
 ```

--- a/versioned_docs/version-2.0/sql/functions-operators/sql-function-set-returning.md
+++ b/versioned_docs/version-2.0/sql/functions-operators/sql-function-set-returning.md
@@ -87,8 +87,8 @@ Except for generating a static set of values, RisingWave also supports continuou
 ```sql
 CREATE MATERIALIZED VIEW mv AS
 SELECT * FROM generate_series(
-  '2020-01-01 00:00:00',
-  now()::timestamp,
+  '2020-01-01 00:00:00'::timestamptz,
+  now(),
   interval '1 hour'
 );
 ```


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Description

generate_series only works with timestamp, not timestamptz. The example in our doc fails due to this. Perhaps some regression? Not sure if `NOW()` changed to return `timestamptz` instead of `timestamp`.

```
dev=> create materialized view m1 as SELECT time::timestamptz FROM generate_series(
  '2020-01-01 00:00:00',
  now(),
  interval '1 hour'
) t(time);
ERROR:  Failed to run the query

Caused by:
  function generate_series(unknown, timestamp with time zone, interval) does not exist


dev=> create materialized view m1 as SELECT * FROM generate_series(
  '2020-01-01 00:00:00'::timestamptz,
  now(),
  interval '1 hour'
);
NOTICE:  Your session timezone is UTC. It was used in the interpretation of timestamps and dates in your query. If this is unintended, change your timezone to match that of your data's with `set timezone = [timezone]` or rewrite your query with an explicit timezone conversion, e.g. with `AT TIME ZONE`.

CREATE_MATERIALIZED_VIEW
```

<!--
Please describe:

1. The motivation of this PR;
2. What's changed and how is the document site is affected;
3. References that's worth listed.
-->

## Related code PR

<!--
Provide a link to the relevant code PR here, if applicable.
-->

## Related doc issue

<!--
If this PR fixes/resolves the issue, please write "Resolve #xxx".
-->
Resolve

<!--
❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.
-->

<!--
Edit the following sections when this PR is ready for review.
-->

## Rendered preview

<!--
Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation.
-->

## Checklist

- [ ] I have checked the doc site preview, and the updated parts look good.
- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
