### PR TITLE
fix docs describing order by clause in `SELECT`

### DIFF
--- a/archived/versioned_docs/version-0.18.0/sql/commands/sql-select.md
+++ b/archived/versioned_docs/version-0.18.0/sql/commands/sql-select.md
@@ -1,7 +1,7 @@
 ---
 id: sql-select
 title: SELECT
-description: Retrieve data from a table or a materialized view. 
+description: Retrieve data from a table or a materialized view.
 slug: /sql-select
 ---
 <head>
@@ -18,15 +18,15 @@ SELECT [ ALL | DISTINCT ] [ * | expression [ AS output_name ] [ , expression [ A
     [ WHERE condition ]
     [ GROUP BY grouping_expression [ , grouping_expression ... ] ]
     [ HAVING condition ]
-    [ ORDER BY sort_expression [ ASC | DESC ] [ , ... ] ]
+    [ ORDER BY sort_expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ... ] ]
     [ LIMIT count_number ]
     [ OFFSET start [ ROW | ROWS ] ];
 ```
 Where `from_item` can be:
 ```sql
     table_name  [ [ AS ] alias [ ( column_alias_list ) ] ]
-    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
-    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
+    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ]
+    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ]
     from_item join_type from_item [ ON join_condition ]
 ```
 
@@ -38,7 +38,7 @@ Where `from_item` can be:
 |*alias*                    |A temporary alternative name for a table or materialized view in a query.|
 |*table_name*                    |A table or materialized view.|
 |*grouping_expression*      |<p>Values can be:</p><ul><li>Input column names</li><li>Input column expressions without subqueries or correlated columns</li></ul>|
-|**ORDER BY** clause        | The default sort order is **ASC**. Nulls options are not supported now. If the sort order is **ASC** or unspecified, nulls will be placed in front of non-null values. If the sort order is **DESC**, nulls will be placed after non-null values. This is different from the sort logic in PostgreSQL.|
+|**ORDER BY** clause        | By default, sorting is in ascending (ASC) order, with NULL values treated as the largest.|
 |*sort_expression*          |<p>Values can be:</p><ul><li>Output column names</li><li>Output column ordinal numbers</li><li>Hidden select expressions</li></ul>|
 |**LIMIT** clause           | When the ORDER BY clause is not present, the LIMIT clause cannot be used as part of a materialized view. |
 |*count_number*                    |The number of results you want to get. |
@@ -80,9 +80,9 @@ The table `company` includes the columns `company_id` and `taxi_id`, where `taxi
 
 The following query returns the total distance and duration of trips that are beyond the initial charge ($2.50) of each taxi from the company "Yellow Taxi" and "FabCab". 
 ```sql
-SELECT 
-    taxi.taxi_id, 
-    sum(trips.distance) AS total_distance, 
+SELECT
+    taxi.taxi_id,
+    sum(trips.distance) AS total_distance,
     sum(trips.duration) AS total_duration
 FROM taxi_trips AS trips
 LEFT JOIN taxi ON trips.id = taxi.trip_id

--- a/archived/versioned_docs/version-0.19.0/sql/commands/sql-select.md
+++ b/archived/versioned_docs/version-0.19.0/sql/commands/sql-select.md
@@ -1,7 +1,7 @@
 ---
 id: sql-select
 title: SELECT
-description: Retrieve data from a table or a materialized view. 
+description: Retrieve data from a table or a materialized view.
 slug: /sql-select
 ---
 <head>
@@ -20,7 +20,7 @@ SELECT [ ALL | DISTINCT ] [ * | expression [ AS output_name ] [ , expression [ A
     [ WHERE condition ]
     [ GROUP BY grouping_expression [ , grouping_expression ... ] ]
     [ HAVING condition ]
-    [ ORDER BY sort_expression [ ASC | DESC ] [ , ... ] ]
+    [ ORDER BY sort_expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ... ] ]
     [ LIMIT count_number ]
     [ OFFSET start [ ROW | ROWS ] ];
 ```
@@ -29,8 +29,8 @@ Where `from_item` can be:
 
 ```sql
     table_name  [ [ AS ] alias [ ( column_alias_list ) ] ]
-    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
-    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
+    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ]
+    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ]
     from_item join_type from_item [ ON join_condition ]
 ```
 
@@ -44,7 +44,7 @@ Where `from_item` can be:
 |*alias*                    |A temporary alternative name for a table or materialized view in a query.|
 |*table_name*                    |A table or materialized view.|
 |*grouping_expression*      |<p>Values can be:</p><ul><li>Input column names</li><li>Input column expressions without subqueries or correlated columns</li></ul>|
-|**ORDER BY** clause        | The default sort order is **ASC**. Nulls options are not supported now. If the sort order is **ASC** or unspecified, nulls will be placed in front of non-null values. If the sort order is **DESC**, nulls will be placed after non-null values. This is different from the sort logic in PostgreSQL.|
+|**ORDER BY** clause        | By default, sorting is in ascending (ASC) order, with NULL values treated as the largest.|
 |*sort_expression*          |<p>Values can be:</p><ul><li>Output column names</li><li>Output column ordinal numbers</li><li>Hidden select expressions</li></ul>|
 |*count_number*                    |The number of results you want to get. |
 |**OFFSET** clause          |The `OFFSET` clause can only be used with the `LIMIT` and `ORDER BY` clauses.|
@@ -95,9 +95,9 @@ The table `company` includes the columns `company_id` and `taxi_id`, where `taxi
 The following query returns the total distance and duration of trips that are beyond the initial charge ($2.50) of each taxi from the company "Yellow Taxi" and "FabCab".
 
 ```sql
-SELECT 
-    taxi.taxi_id, 
-    sum(trips.distance) AS total_distance, 
+SELECT
+    taxi.taxi_id,
+    sum(trips.distance) AS total_distance,
     sum(trips.duration) AS total_duration
 FROM taxi_trips AS trips
 LEFT JOIN taxi ON trips.id = taxi.trip_id

--- a/docs/sql/commands/sql-select.md
+++ b/docs/sql/commands/sql-select.md
@@ -1,7 +1,7 @@
 ---
 id: sql-select
 title: SELECT
-description: Retrieve data from a table or a materialized view. 
+description: Retrieve data from a table or a materialized view.
 slug: /sql-select
 ---
 <head>
@@ -20,7 +20,7 @@ SELECT [ ALL | DISTINCT [ ON ( expression [, ...] ) ]] [ [table_name.]* [ EXCEPT
     [ WHERE condition ]
     [ GROUP BY grouping_expression [ , grouping_expression ... ] ]
     [ HAVING condition ]
-    [ ORDER BY sort_expression [ ASC | DESC ] [ , ... ] ]
+    [ ORDER BY sort_expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ... ] ]
     [ LIMIT count_number ]
     [ OFFSET start [ ROW | ROWS ] ];
 ```
@@ -29,8 +29,8 @@ Where `from_item` can be:
 
 ```sql
     table_name  [ [ AS ] alias [ ( column_alias_list ) ] ]
-    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
-    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
+    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ]
+    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ]
     from_item join_type from_item [ ON join_condition ]
 ```
 
@@ -46,7 +46,7 @@ Where `from_item` can be:
 |*alias*                    |A temporary alternative name for a table or materialized view in a query.|
 |*table_name*                    |A table or materialized view.|
 |*grouping_expression*      |<p>Values can be:</p><ul><li>Input column names</li><li>Input column expressions without subqueries or correlated columns</li></ul>|
-|**ORDER BY** clause        | The default sort order is **ASC**. Nulls options are not supported now. If the sort order is **ASC** or unspecified, nulls will be placed in front of non-null values. If the sort order is **DESC**, nulls will be placed after non-null values. This is different from the sort logic in PostgreSQL.|
+|**ORDER BY** clause        | The default sort order is **ASC**, and NULLs are considered largest. See [`ORDER BY` clause](../query-syntax/query-syntax-order-by-clause.md) for more details.|
 |*sort_expression*          |<p>Values can be:</p><ul><li>Output column names</li><li>Output column ordinal numbers</li><li>Hidden select expressions</li></ul>|
 |*count_number*                    |The number of results you want to get. |
 |**OFFSET** clause          |The `OFFSET` clause can only be used with the `LIMIT` and `ORDER BY` clauses.|
@@ -119,9 +119,9 @@ The table `company` includes the columns `company_id` and `taxi_id`, where `taxi
 The following query returns the total distance and duration of trips that are beyond the initial charge ($2.50) of each taxi from the company "Yellow Taxi" and "FabCab".
 
 ```sql
-SELECT 
-    taxi.taxi_id, 
-    sum(trips.distance) AS total_distance, 
+SELECT
+    taxi.taxi_id,
+    sum(trips.distance) AS total_distance,
     sum(trips.duration) AS total_duration
 FROM taxi_trips AS trips
 LEFT JOIN taxi ON trips.id = taxi.trip_id

--- a/docs/sql/commands/sql-select.md
+++ b/docs/sql/commands/sql-select.md
@@ -46,7 +46,7 @@ Where `from_item` can be:
 |*alias*                    |A temporary alternative name for a table or materialized view in a query.|
 |*table_name*                    |A table or materialized view.|
 |*grouping_expression*      |<p>Values can be:</p><ul><li>Input column names</li><li>Input column expressions without subqueries or correlated columns</li></ul>|
-|**ORDER BY** clause        | The default sort order is **ASC**, and NULLs are considered largest. See [`ORDER BY` clause](../query-syntax/query-syntax-order-by-clause.md) for more details.|
+|**ORDER BY** clause        | By default, sorting is in ascending (ASC) order, with NULL values treated as the largest. For more information, see [`ORDER BY` clause](../query-syntax/query-syntax-order-by-clause.md).|
 |*sort_expression*          |<p>Values can be:</p><ul><li>Output column names</li><li>Output column ordinal numbers</li><li>Hidden select expressions</li></ul>|
 |*count_number*                    |The number of results you want to get. |
 |**OFFSET** clause          |The `OFFSET` clause can only be used with the `LIMIT` and `ORDER BY` clauses.|

--- a/docs/sql/query-syntax/query-syntax-order-by-clause.md
+++ b/docs/sql/query-syntax/query-syntax-order-by-clause.md
@@ -15,16 +15,16 @@ Here is the basic syntax of the `ORDER BY` clause:
 ```sql title="Syntax"
 SELECT select_list
     FROM table_expression
-    ORDER BY sort_expression1 [ASC | DESC] [NULLS { FIRST | LAST }]
-             [, sort_expression2 [ASC | DESC] [NULLS { FIRST | LAST }] ...]
+    ORDER BY sort_expression1 [ ASC | DESC ] [ NULLS { FIRST | LAST } ]
+             [, sort_expression2 [ ASC | DESC ] [ NULLS { FIRST | LAST } ] ...]
 ```
 
 ## Examples
 
-Let's assume we have a table named "employees" with columns "employee_id", "employee_name", and "salary". 
+Let's assume we have a table named "employees" with columns "employee_id", "employee_name", and "salary".
 
 ```sql title="employees"
-employee_id | employee_name | salary 
+employee_id | employee_name | salary
 -------------+---------------+--------
            2 | Bob           |  60000
            4 | David         |  55000
@@ -37,7 +37,7 @@ employee_id | employee_name | salary
 CREATE TABLE employees (
     employee_id INT,
     employee_name VARCHAR,
-    salary INT           
+    salary INT
 );
 
 INSERT INTO employees (employee_id, employee_name, salary) VALUES
@@ -56,7 +56,7 @@ FROM employees
 ORDER BY salary DESC;
 
 ----RESULT
-employee_id | employee_name | salary 
+employee_id | employee_name | salary
 -------------+---------------+--------
            5 | Eve           |  75000
            3 | Charlie       |  70000
@@ -66,4 +66,4 @@ employee_id | employee_name | salary
 (5 rows)
 ```
 
-In this example, the result set displayed the employees' details sorted by their salaries in descending order, showing the highest-paid employees first. The `ORDER BY` clause helps in arranging data in a structured and meaningful way for easier interpretation and decision-making. 
+In this example, the result set displayed the employees' details sorted by their salaries in descending order, showing the highest-paid employees first. The `ORDER BY` clause helps in arranging data in a structured and meaningful way for easier interpretation and decision-making.

--- a/versioned_docs/version-1.0.0/sql/commands/sql-select.md
+++ b/versioned_docs/version-1.0.0/sql/commands/sql-select.md
@@ -1,7 +1,7 @@
 ---
 id: sql-select
 title: SELECT
-description: Retrieve data from a table or a materialized view. 
+description: Retrieve data from a table or a materialized view.
 slug: /sql-select
 ---
 <head>
@@ -20,7 +20,7 @@ SELECT [ ALL | DISTINCT ] [ [table_name.]* [ EXCEPT ( [table_name.]except_column
     [ WHERE condition ]
     [ GROUP BY grouping_expression [ , grouping_expression ... ] ]
     [ HAVING condition ]
-    [ ORDER BY sort_expression [ ASC | DESC ] [ , ... ] ]
+    [ ORDER BY sort_expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ... ] ]
     [ LIMIT count_number ]
     [ OFFSET start [ ROW | ROWS ] ];
 ```
@@ -29,8 +29,8 @@ Where `from_item` can be:
 
 ```sql
     table_name  [ [ AS ] alias [ ( column_alias_list ) ] ]
-    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
-    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
+    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ]
+    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ]
     from_item join_type from_item [ ON join_condition ]
 ```
 
@@ -45,7 +45,7 @@ Where `from_item` can be:
 |*alias*                    |A temporary alternative name for a table or materialized view in a query.|
 |*table_name*                    |A table or materialized view.|
 |*grouping_expression*      |<p>Values can be:</p><ul><li>Input column names</li><li>Input column expressions without subqueries or correlated columns</li></ul>|
-|**ORDER BY** clause        | The default sort order is **ASC**. Nulls options are not supported now. If the sort order is **ASC** or unspecified, nulls will be placed in front of non-null values. If the sort order is **DESC**, nulls will be placed after non-null values. This is different from the sort logic in PostgreSQL.|
+|**ORDER BY** clause        | By default, sorting is in ascending (ASC) order, with NULL values treated as the largest.|
 |*sort_expression*          |<p>Values can be:</p><ul><li>Output column names</li><li>Output column ordinal numbers</li><li>Hidden select expressions</li></ul>|
 |*count_number*                    |The number of results you want to get. |
 |**OFFSET** clause          |The `OFFSET` clause can only be used with the `LIMIT` and `ORDER BY` clauses.|
@@ -96,9 +96,9 @@ The table `company` includes the columns `company_id` and `taxi_id`, where `taxi
 The following query returns the total distance and duration of trips that are beyond the initial charge ($2.50) of each taxi from the company "Yellow Taxi" and "FabCab".
 
 ```sql
-SELECT 
-    taxi.taxi_id, 
-    sum(trips.distance) AS total_distance, 
+SELECT
+    taxi.taxi_id,
+    sum(trips.distance) AS total_distance,
     sum(trips.duration) AS total_duration
 FROM taxi_trips AS trips
 LEFT JOIN taxi ON trips.id = taxi.trip_id

--- a/versioned_docs/version-1.1/sql/commands/sql-select.md
+++ b/versioned_docs/version-1.1/sql/commands/sql-select.md
@@ -1,7 +1,7 @@
 ---
 id: sql-select
 title: SELECT
-description: Retrieve data from a table or a materialized view. 
+description: Retrieve data from a table or a materialized view.
 slug: /sql-select
 ---
 <head>
@@ -20,7 +20,7 @@ SELECT [ ALL | DISTINCT ] [ [table_name.]* [ EXCEPT ( [table_name.]except_column
     [ WHERE condition ]
     [ GROUP BY grouping_expression [ , grouping_expression ... ] ]
     [ HAVING condition ]
-    [ ORDER BY sort_expression [ ASC | DESC ] [ , ... ] ]
+    [ ORDER BY sort_expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ... ] ]
     [ LIMIT count_number ]
     [ OFFSET start [ ROW | ROWS ] ];
 ```
@@ -29,8 +29,8 @@ Where `from_item` can be:
 
 ```sql
     table_name  [ [ AS ] alias [ ( column_alias_list ) ] ]
-    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
-    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
+    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ]
+    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ]
     from_item join_type from_item [ ON join_condition ]
 ```
 
@@ -45,7 +45,7 @@ Where `from_item` can be:
 |*alias*                    |A temporary alternative name for a table or materialized view in a query.|
 |*table_name*                    |A table or materialized view.|
 |*grouping_expression*      |<p>Values can be:</p><ul><li>Input column names</li><li>Input column expressions without subqueries or correlated columns</li></ul>|
-|**ORDER BY** clause        | The default sort order is **ASC**. Nulls options are not supported now. If the sort order is **ASC** or unspecified, nulls will be placed in front of non-null values. If the sort order is **DESC**, nulls will be placed after non-null values. This is different from the sort logic in PostgreSQL.|
+|**ORDER BY** clause        | By default, sorting is in ascending (ASC) order, with NULL values treated as the largest.|
 |*sort_expression*          |<p>Values can be:</p><ul><li>Output column names</li><li>Output column ordinal numbers</li><li>Hidden select expressions</li></ul>|
 |*count_number*                    |The number of results you want to get. |
 |**OFFSET** clause          |The `OFFSET` clause can only be used with the `LIMIT` and `ORDER BY` clauses.|
@@ -96,9 +96,9 @@ The table `company` includes the columns `company_id` and `taxi_id`, where `taxi
 The following query returns the total distance and duration of trips that are beyond the initial charge ($2.50) of each taxi from the company "Yellow Taxi" and "FabCab".
 
 ```sql
-SELECT 
-    taxi.taxi_id, 
-    sum(trips.distance) AS total_distance, 
+SELECT
+    taxi.taxi_id,
+    sum(trips.distance) AS total_distance,
     sum(trips.duration) AS total_duration
 FROM taxi_trips AS trips
 LEFT JOIN taxi ON trips.id = taxi.trip_id

--- a/versioned_docs/version-1.10/sql/commands/sql-select.md
+++ b/versioned_docs/version-1.10/sql/commands/sql-select.md
@@ -1,7 +1,7 @@
 ---
 id: sql-select
 title: SELECT
-description: Retrieve data from a table or a materialized view. 
+description: Retrieve data from a table or a materialized view.
 slug: /sql-select
 ---
 <head>
@@ -20,7 +20,7 @@ SELECT [ ALL | DISTINCT [ ON ( expression [, ...] ) ]] [ [table_name.]* [ EXCEPT
     [ WHERE condition ]
     [ GROUP BY grouping_expression [ , grouping_expression ... ] ]
     [ HAVING condition ]
-    [ ORDER BY sort_expression [ ASC | DESC ] [ , ... ] ]
+    [ ORDER BY sort_expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ... ] ]
     [ LIMIT count_number ]
     [ OFFSET start [ ROW | ROWS ] ];
 ```
@@ -29,8 +29,8 @@ Where `from_item` can be:
 
 ```sql
     table_name  [ [ AS ] alias [ ( column_alias_list ) ] ]
-    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
-    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
+    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ]
+    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ]
     from_item join_type from_item [ ON join_condition ]
 ```
 
@@ -46,7 +46,7 @@ Where `from_item` can be:
 |*alias*                    |A temporary alternative name for a table or materialized view in a query.|
 |*table_name*                    |A table or materialized view.|
 |*grouping_expression*      |<p>Values can be:</p><ul><li>Input column names</li><li>Input column expressions without subqueries or correlated columns</li></ul>|
-|**ORDER BY** clause        | The default sort order is **ASC**. Nulls options are not supported now. If the sort order is **ASC** or unspecified, nulls will be placed in front of non-null values. If the sort order is **DESC**, nulls will be placed after non-null values. This is different from the sort logic in PostgreSQL.|
+|**ORDER BY** clause        | By default, sorting is in ascending (ASC) order, with NULL values treated as the largest. For more information, see [`ORDER BY` clause](../query-syntax/query-syntax-order-by-clause.md).|
 |*sort_expression*          |<p>Values can be:</p><ul><li>Output column names</li><li>Output column ordinal numbers</li><li>Hidden select expressions</li></ul>|
 |*count_number*                    |The number of results you want to get. |
 |**OFFSET** clause          |The `OFFSET` clause can only be used with the `LIMIT` and `ORDER BY` clauses.|
@@ -119,9 +119,9 @@ The table `company` includes the columns `company_id` and `taxi_id`, where `taxi
 The following query returns the total distance and duration of trips that are beyond the initial charge ($2.50) of each taxi from the company "Yellow Taxi" and "FabCab".
 
 ```sql
-SELECT 
-    taxi.taxi_id, 
-    sum(trips.distance) AS total_distance, 
+SELECT
+    taxi.taxi_id,
+    sum(trips.distance) AS total_distance,
     sum(trips.duration) AS total_duration
 FROM taxi_trips AS trips
 LEFT JOIN taxi ON trips.id = taxi.trip_id

--- a/versioned_docs/version-1.10/sql/query-syntax/query-syntax-order-by-clause.md
+++ b/versioned_docs/version-1.10/sql/query-syntax/query-syntax-order-by-clause.md
@@ -15,16 +15,16 @@ Here is the basic syntax of the `ORDER BY` clause:
 ```sql title="Syntax"
 SELECT select_list
     FROM table_expression
-    ORDER BY sort_expression1 [ASC | DESC] [NULLS { FIRST | LAST }]
-             [, sort_expression2 [ASC | DESC] [NULLS { FIRST | LAST }] ...]
+    ORDER BY sort_expression1 [ ASC | DESC ] [ NULLS { FIRST | LAST } ]
+             [, sort_expression2 [ ASC | DESC ] [ NULLS { FIRST | LAST } ] ...]
 ```
 
 ## Examples
 
-Let's assume we have a table named "employees" with columns "employee_id", "employee_name", and "salary". 
+Let's assume we have a table named "employees" with columns "employee_id", "employee_name", and "salary".
 
 ```sql title="employees"
-employee_id | employee_name | salary 
+employee_id | employee_name | salary
 -------------+---------------+--------
            2 | Bob           |  60000
            4 | David         |  55000
@@ -37,7 +37,7 @@ employee_id | employee_name | salary
 CREATE TABLE employees (
     employee_id INT,
     employee_name VARCHAR,
-    salary INT           
+    salary INT
 );
 
 INSERT INTO employees (employee_id, employee_name, salary) VALUES
@@ -56,7 +56,7 @@ FROM employees
 ORDER BY salary DESC;
 
 ----RESULT
-employee_id | employee_name | salary 
+employee_id | employee_name | salary
 -------------+---------------+--------
            5 | Eve           |  75000
            3 | Charlie       |  70000
@@ -66,4 +66,4 @@ employee_id | employee_name | salary
 (5 rows)
 ```
 
-In this example, the result set displayed the employees' details sorted by their salaries in descending order, showing the highest-paid employees first. The `ORDER BY` clause helps in arranging data in a structured and meaningful way for easier interpretation and decision-making. 
+In this example, the result set displayed the employees' details sorted by their salaries in descending order, showing the highest-paid employees first. The `ORDER BY` clause helps in arranging data in a structured and meaningful way for easier interpretation and decision-making.

--- a/versioned_docs/version-1.2/sql/commands/sql-select.md
+++ b/versioned_docs/version-1.2/sql/commands/sql-select.md
@@ -1,7 +1,7 @@
 ---
 id: sql-select
 title: SELECT
-description: Retrieve data from a table or a materialized view. 
+description: Retrieve data from a table or a materialized view.
 slug: /sql-select
 ---
 <head>
@@ -20,7 +20,7 @@ SELECT [ ALL | DISTINCT ] [ [table_name.]* [ EXCEPT ( [table_name.]except_column
     [ WHERE condition ]
     [ GROUP BY grouping_expression [ , grouping_expression ... ] ]
     [ HAVING condition ]
-    [ ORDER BY sort_expression [ ASC | DESC ] [ , ... ] ]
+    [ ORDER BY sort_expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ... ] ]
     [ LIMIT count_number ]
     [ OFFSET start [ ROW | ROWS ] ];
 ```
@@ -29,8 +29,8 @@ Where `from_item` can be:
 
 ```sql
     table_name  [ [ AS ] alias [ ( column_alias_list ) ] ]
-    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
-    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
+    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ]
+    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ]
     from_item join_type from_item [ ON join_condition ]
 ```
 
@@ -45,7 +45,7 @@ Where `from_item` can be:
 |*alias*                    |A temporary alternative name for a table or materialized view in a query.|
 |*table_name*                    |A table or materialized view.|
 |*grouping_expression*      |<p>Values can be:</p><ul><li>Input column names</li><li>Input column expressions without subqueries or correlated columns</li></ul>|
-|**ORDER BY** clause        | The default sort order is **ASC**. Nulls options are not supported now. If the sort order is **ASC** or unspecified, nulls will be placed in front of non-null values. If the sort order is **DESC**, nulls will be placed after non-null values. This is different from the sort logic in PostgreSQL.|
+|**ORDER BY** clause        | By default, sorting is in ascending (ASC) order, with NULL values treated as the largest.|
 |*sort_expression*          |<p>Values can be:</p><ul><li>Output column names</li><li>Output column ordinal numbers</li><li>Hidden select expressions</li></ul>|
 |*count_number*                    |The number of results you want to get. |
 |**OFFSET** clause          |The `OFFSET` clause can only be used with the `LIMIT` and `ORDER BY` clauses.|
@@ -96,9 +96,9 @@ The table `company` includes the columns `company_id` and `taxi_id`, where `taxi
 The following query returns the total distance and duration of trips that are beyond the initial charge ($2.50) of each taxi from the company "Yellow Taxi" and "FabCab".
 
 ```sql
-SELECT 
-    taxi.taxi_id, 
-    sum(trips.distance) AS total_distance, 
+SELECT
+    taxi.taxi_id,
+    sum(trips.distance) AS total_distance,
     sum(trips.duration) AS total_duration
 FROM taxi_trips AS trips
 LEFT JOIN taxi ON trips.id = taxi.trip_id

--- a/versioned_docs/version-1.3/sql/commands/sql-select.md
+++ b/versioned_docs/version-1.3/sql/commands/sql-select.md
@@ -1,7 +1,7 @@
 ---
 id: sql-select
 title: SELECT
-description: Retrieve data from a table or a materialized view. 
+description: Retrieve data from a table or a materialized view.
 slug: /sql-select
 ---
 <head>
@@ -20,7 +20,7 @@ SELECT [ ALL | DISTINCT ] [ [table_name.]* [ EXCEPT ( [table_name.]except_column
     [ WHERE condition ]
     [ GROUP BY grouping_expression [ , grouping_expression ... ] ]
     [ HAVING condition ]
-    [ ORDER BY sort_expression [ ASC | DESC ] [ , ... ] ]
+    [ ORDER BY sort_expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ... ] ]
     [ LIMIT count_number ]
     [ OFFSET start [ ROW | ROWS ] ];
 ```
@@ -29,8 +29,8 @@ Where `from_item` can be:
 
 ```sql
     table_name  [ [ AS ] alias [ ( column_alias_list ) ] ]
-    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
-    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
+    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ]
+    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ]
     from_item join_type from_item [ ON join_condition ]
 ```
 
@@ -45,7 +45,7 @@ Where `from_item` can be:
 |*alias*                    |A temporary alternative name for a table or materialized view in a query.|
 |*table_name*                    |A table or materialized view.|
 |*grouping_expression*      |<p>Values can be:</p><ul><li>Input column names</li><li>Input column expressions without subqueries or correlated columns</li></ul>|
-|**ORDER BY** clause        | The default sort order is **ASC**. Nulls options are not supported now. If the sort order is **ASC** or unspecified, nulls will be placed in front of non-null values. If the sort order is **DESC**, nulls will be placed after non-null values. This is different from the sort logic in PostgreSQL.|
+|**ORDER BY** clause        | By default, sorting is in ascending (ASC) order, with NULL values treated as the largest.|
 |*sort_expression*          |<p>Values can be:</p><ul><li>Output column names</li><li>Output column ordinal numbers</li><li>Hidden select expressions</li></ul>|
 |*count_number*                    |The number of results you want to get. |
 |**OFFSET** clause          |The `OFFSET` clause can only be used with the `LIMIT` and `ORDER BY` clauses.|
@@ -96,9 +96,9 @@ The table `company` includes the columns `company_id` and `taxi_id`, where `taxi
 The following query returns the total distance and duration of trips that are beyond the initial charge ($2.50) of each taxi from the company "Yellow Taxi" and "FabCab".
 
 ```sql
-SELECT 
-    taxi.taxi_id, 
-    sum(trips.distance) AS total_distance, 
+SELECT
+    taxi.taxi_id,
+    sum(trips.distance) AS total_distance,
     sum(trips.duration) AS total_duration
 FROM taxi_trips AS trips
 LEFT JOIN taxi ON trips.id = taxi.trip_id

--- a/versioned_docs/version-1.4/sql/commands/sql-select.md
+++ b/versioned_docs/version-1.4/sql/commands/sql-select.md
@@ -1,7 +1,7 @@
 ---
 id: sql-select
 title: SELECT
-description: Retrieve data from a table or a materialized view. 
+description: Retrieve data from a table or a materialized view.
 slug: /sql-select
 ---
 <head>
@@ -20,7 +20,7 @@ SELECT [ ALL | DISTINCT ] [ [table_name.]* [ EXCEPT ( [table_name.]except_column
     [ WHERE condition ]
     [ GROUP BY grouping_expression [ , grouping_expression ... ] ]
     [ HAVING condition ]
-    [ ORDER BY sort_expression [ ASC | DESC ] [ , ... ] ]
+    [ ORDER BY sort_expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ... ] ]
     [ LIMIT count_number ]
     [ OFFSET start [ ROW | ROWS ] ];
 ```
@@ -29,8 +29,8 @@ Where `from_item` can be:
 
 ```sql
     table_name  [ [ AS ] alias [ ( column_alias_list ) ] ]
-    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
-    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
+    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ]
+    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ]
     from_item join_type from_item [ ON join_condition ]
 ```
 
@@ -45,7 +45,7 @@ Where `from_item` can be:
 |*alias*                    |A temporary alternative name for a table or materialized view in a query.|
 |*table_name*                    |A table or materialized view.|
 |*grouping_expression*      |<p>Values can be:</p><ul><li>Input column names</li><li>Input column expressions without subqueries or correlated columns</li></ul>|
-|**ORDER BY** clause        | The default sort order is **ASC**. Nulls options are not supported now. If the sort order is **ASC** or unspecified, nulls will be placed in front of non-null values. If the sort order is **DESC**, nulls will be placed after non-null values. This is different from the sort logic in PostgreSQL.|
+|**ORDER BY** clause        | By default, sorting is in ascending (ASC) order, with NULL values treated as the largest.|
 |*sort_expression*          |<p>Values can be:</p><ul><li>Output column names</li><li>Output column ordinal numbers</li><li>Hidden select expressions</li></ul>|
 |*count_number*                    |The number of results you want to get. |
 |**OFFSET** clause          |The `OFFSET` clause can only be used with the `LIMIT` and `ORDER BY` clauses.|
@@ -96,9 +96,9 @@ The table `company` includes the columns `company_id` and `taxi_id`, where `taxi
 The following query returns the total distance and duration of trips that are beyond the initial charge ($2.50) of each taxi from the company "Yellow Taxi" and "FabCab".
 
 ```sql
-SELECT 
-    taxi.taxi_id, 
-    sum(trips.distance) AS total_distance, 
+SELECT
+    taxi.taxi_id,
+    sum(trips.distance) AS total_distance,
     sum(trips.duration) AS total_duration
 FROM taxi_trips AS trips
 LEFT JOIN taxi ON trips.id = taxi.trip_id

--- a/versioned_docs/version-1.5/sql/commands/sql-select.md
+++ b/versioned_docs/version-1.5/sql/commands/sql-select.md
@@ -1,7 +1,7 @@
 ---
 id: sql-select
 title: SELECT
-description: Retrieve data from a table or a materialized view. 
+description: Retrieve data from a table or a materialized view.
 slug: /sql-select
 ---
 <head>
@@ -20,7 +20,7 @@ SELECT [ ALL | DISTINCT ] [ [table_name.]* [ EXCEPT ( [table_name.]except_column
     [ WHERE condition ]
     [ GROUP BY grouping_expression [ , grouping_expression ... ] ]
     [ HAVING condition ]
-    [ ORDER BY sort_expression [ ASC | DESC ] [ , ... ] ]
+    [ ORDER BY sort_expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ... ] ]
     [ LIMIT count_number ]
     [ OFFSET start [ ROW | ROWS ] ];
 ```
@@ -29,8 +29,8 @@ Where `from_item` can be:
 
 ```sql
     table_name  [ [ AS ] alias [ ( column_alias_list ) ] ]
-    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
-    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
+    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ]
+    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ]
     from_item join_type from_item [ ON join_condition ]
 ```
 
@@ -45,7 +45,7 @@ Where `from_item` can be:
 |*alias*                    |A temporary alternative name for a table or materialized view in a query.|
 |*table_name*                    |A table or materialized view.|
 |*grouping_expression*      |<p>Values can be:</p><ul><li>Input column names</li><li>Input column expressions without subqueries or correlated columns</li></ul>|
-|**ORDER BY** clause        | The default sort order is **ASC**. Nulls options are not supported now. If the sort order is **ASC** or unspecified, nulls will be placed in front of non-null values. If the sort order is **DESC**, nulls will be placed after non-null values. This is different from the sort logic in PostgreSQL.|
+|**ORDER BY** clause        | By default, sorting is in ascending (ASC) order, with NULL values treated as the largest.|
 |*sort_expression*          |<p>Values can be:</p><ul><li>Output column names</li><li>Output column ordinal numbers</li><li>Hidden select expressions</li></ul>|
 |*count_number*                    |The number of results you want to get. |
 |**OFFSET** clause          |The `OFFSET` clause can only be used with the `LIMIT` and `ORDER BY` clauses.|
@@ -96,9 +96,9 @@ The table `company` includes the columns `company_id` and `taxi_id`, where `taxi
 The following query returns the total distance and duration of trips that are beyond the initial charge ($2.50) of each taxi from the company "Yellow Taxi" and "FabCab".
 
 ```sql
-SELECT 
-    taxi.taxi_id, 
-    sum(trips.distance) AS total_distance, 
+SELECT
+    taxi.taxi_id,
+    sum(trips.distance) AS total_distance,
     sum(trips.duration) AS total_duration
 FROM taxi_trips AS trips
 LEFT JOIN taxi ON trips.id = taxi.trip_id

--- a/versioned_docs/version-1.6/sql/commands/sql-select.md
+++ b/versioned_docs/version-1.6/sql/commands/sql-select.md
@@ -1,7 +1,7 @@
 ---
 id: sql-select
 title: SELECT
-description: Retrieve data from a table or a materialized view. 
+description: Retrieve data from a table or a materialized view.
 slug: /sql-select
 ---
 <head>
@@ -20,7 +20,7 @@ SELECT [ ALL | DISTINCT [ ON ( expression [, ...] ) ]] [ [table_name.]* [ EXCEPT
     [ WHERE condition ]
     [ GROUP BY grouping_expression [ , grouping_expression ... ] ]
     [ HAVING condition ]
-    [ ORDER BY sort_expression [ ASC | DESC ] [ , ... ] ]
+    [ ORDER BY sort_expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ... ] ]
     [ LIMIT count_number ]
     [ OFFSET start [ ROW | ROWS ] ];
 ```
@@ -29,8 +29,8 @@ Where `from_item` can be:
 
 ```sql
     table_name  [ [ AS ] alias [ ( column_alias_list ) ] ]
-    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
-    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
+    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ]
+    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ]
     from_item join_type from_item [ ON join_condition ]
 ```
 
@@ -46,7 +46,7 @@ Where `from_item` can be:
 |*alias*                    |A temporary alternative name for a table or materialized view in a query.|
 |*table_name*                    |A table or materialized view.|
 |*grouping_expression*      |<p>Values can be:</p><ul><li>Input column names</li><li>Input column expressions without subqueries or correlated columns</li></ul>|
-|**ORDER BY** clause        | The default sort order is **ASC**. Nulls options are not supported now. If the sort order is **ASC** or unspecified, nulls will be placed in front of non-null values. If the sort order is **DESC**, nulls will be placed after non-null values. This is different from the sort logic in PostgreSQL.|
+|**ORDER BY** clause        | By default, sorting is in ascending (ASC) order, with NULL values treated as the largest.|
 |*sort_expression*          |<p>Values can be:</p><ul><li>Output column names</li><li>Output column ordinal numbers</li><li>Hidden select expressions</li></ul>|
 |*count_number*                    |The number of results you want to get. |
 |**OFFSET** clause          |The `OFFSET` clause can only be used with the `LIMIT` and `ORDER BY` clauses.|
@@ -119,9 +119,9 @@ The table `company` includes the columns `company_id` and `taxi_id`, where `taxi
 The following query returns the total distance and duration of trips that are beyond the initial charge ($2.50) of each taxi from the company "Yellow Taxi" and "FabCab".
 
 ```sql
-SELECT 
-    taxi.taxi_id, 
-    sum(trips.distance) AS total_distance, 
+SELECT
+    taxi.taxi_id,
+    sum(trips.distance) AS total_distance,
     sum(trips.duration) AS total_duration
 FROM taxi_trips AS trips
 LEFT JOIN taxi ON trips.id = taxi.trip_id

--- a/versioned_docs/version-1.7/sql/commands/sql-select.md
+++ b/versioned_docs/version-1.7/sql/commands/sql-select.md
@@ -20,7 +20,7 @@ SELECT [ ALL | DISTINCT [ ON ( expression [, ...] ) ]] [ [table_name.]* [ EXCEPT
     [ WHERE condition ]
     [ GROUP BY grouping_expression [ , grouping_expression ... ] ]
     [ HAVING condition ]
-    [ ORDER BY sort_expression [ ASC | DESC ] [ , ... ] ]
+    [ ORDER BY sort_expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ... ] ]
     [ LIMIT count_number ]
     [ OFFSET start [ ROW | ROWS ] ];
 ```
@@ -29,8 +29,8 @@ Where `from_item` can be:
 
 ```sql
     table_name  [ [ AS ] alias [ ( column_alias_list ) ] ]
-    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
-    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
+    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ]
+    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ]
     from_item join_type from_item [ ON join_condition ]
 ```
 
@@ -46,7 +46,7 @@ Where `from_item` can be:
 |*alias*                    |A temporary alternative name for a table or materialized view in a query.|
 |*table_name*                    |A table or materialized view.|
 |*grouping_expression*      |<p>Values can be:</p><ul><li>Input column names</li><li>Input column expressions without subqueries or correlated columns</li></ul>|
-|**ORDER BY** clause        | The default sort order is **ASC**. Nulls options are not supported now. If the sort order is **ASC** or unspecified, nulls will be placed in front of non-null values. If the sort order is **DESC**, nulls will be placed after non-null values. This is different from the sort logic in PostgreSQL.|
+|**ORDER BY** clause        | By default, sorting is in ascending (ASC) order, with NULL values treated as the largest.|
 |*sort_expression*          |<p>Values can be:</p><ul><li>Output column names</li><li>Output column ordinal numbers</li><li>Hidden select expressions</li></ul>|
 |*count_number*                    |The number of results you want to get. |
 |**OFFSET** clause          |The `OFFSET` clause can only be used with the `LIMIT` and `ORDER BY` clauses.|
@@ -119,9 +119,9 @@ The table `company` includes the columns `company_id` and `taxi_id`, where `taxi
 The following query returns the total distance and duration of trips that are beyond the initial charge ($2.50) of each taxi from the company "Yellow Taxi" and "FabCab".
 
 ```sql
-SELECT 
-    taxi.taxi_id, 
-    sum(trips.distance) AS total_distance, 
+SELECT
+    taxi.taxi_id,
+    sum(trips.distance) AS total_distance,
     sum(trips.duration) AS total_duration
 FROM taxi_trips AS trips
 LEFT JOIN taxi ON trips.id = taxi.trip_id

--- a/versioned_docs/version-1.8/sql/commands/sql-select.md
+++ b/versioned_docs/version-1.8/sql/commands/sql-select.md
@@ -20,7 +20,7 @@ SELECT [ ALL | DISTINCT [ ON ( expression [, ...] ) ]] [ [table_name.]* [ EXCEPT
     [ WHERE condition ]
     [ GROUP BY grouping_expression [ , grouping_expression ... ] ]
     [ HAVING condition ]
-    [ ORDER BY sort_expression [ ASC | DESC ] [ , ... ] ]
+    [ ORDER BY sort_expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ... ] ]
     [ LIMIT count_number ]
     [ OFFSET start [ ROW | ROWS ] ];
 ```
@@ -29,8 +29,8 @@ Where `from_item` can be:
 
 ```sql
     table_name  [ [ AS ] alias [ ( column_alias_list ) ] ]
-    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
-    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
+    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ]
+    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ]
     from_item join_type from_item [ ON join_condition ]
 ```
 
@@ -46,7 +46,7 @@ Where `from_item` can be:
 |*alias*                    |A temporary alternative name for a table or materialized view in a query.|
 |*table_name*                    |A table or materialized view.|
 |*grouping_expression*      |<p>Values can be:</p><ul><li>Input column names</li><li>Input column expressions without subqueries or correlated columns</li></ul>|
-|**ORDER BY** clause        | The default sort order is **ASC**. Nulls options are not supported now. If the sort order is **ASC** or unspecified, nulls will be placed in front of non-null values. If the sort order is **DESC**, nulls will be placed after non-null values. This is different from the sort logic in PostgreSQL.|
+|**ORDER BY** clause        | By default, sorting is in ascending (ASC) order, with NULL values treated as the largest. For more information, see [`ORDER BY` clause](../query-syntax/query-syntax-order-by-clause.md).|
 |*sort_expression*          |<p>Values can be:</p><ul><li>Output column names</li><li>Output column ordinal numbers</li><li>Hidden select expressions</li></ul>|
 |*count_number*                    |The number of results you want to get. |
 |**OFFSET** clause          |The `OFFSET` clause can only be used with the `LIMIT` and `ORDER BY` clauses.|
@@ -119,9 +119,9 @@ The table `company` includes the columns `company_id` and `taxi_id`, where `taxi
 The following query returns the total distance and duration of trips that are beyond the initial charge ($2.50) of each taxi from the company "Yellow Taxi" and "FabCab".
 
 ```sql
-SELECT 
-    taxi.taxi_id, 
-    sum(trips.distance) AS total_distance, 
+SELECT
+    taxi.taxi_id,
+    sum(trips.distance) AS total_distance,
     sum(trips.duration) AS total_duration
 FROM taxi_trips AS trips
 LEFT JOIN taxi ON trips.id = taxi.trip_id

--- a/versioned_docs/version-1.8/sql/query-syntax/query-syntax-order-by-clause.md
+++ b/versioned_docs/version-1.8/sql/query-syntax/query-syntax-order-by-clause.md
@@ -15,16 +15,16 @@ Here is the basic syntax of the `ORDER BY` clause:
 ```sql title="Syntax"
 SELECT select_list
     FROM table_expression
-    ORDER BY sort_expression1 [ASC | DESC] [NULLS { FIRST | LAST }]
-             [, sort_expression2 [ASC | DESC] [NULLS { FIRST | LAST }] ...]
+    ORDER BY sort_expression1 [ ASC | DESC ] [ NULLS { FIRST | LAST } ]
+             [, sort_expression2 [ ASC | DESC ] [ NULLS { FIRST | LAST } ] ...]
 ```
 
 ## Examples
 
-Let's assume we have a table named "employees" with columns "employee_id", "employee_name", and "salary". 
+Let's assume we have a table named "employees" with columns "employee_id", "employee_name", and "salary".
 
 ```sql title="employees"
-employee_id | employee_name | salary 
+employee_id | employee_name | salary
 -------------+---------------+--------
            2 | Bob           |  60000
            4 | David         |  55000
@@ -37,7 +37,7 @@ employee_id | employee_name | salary
 CREATE TABLE employees (
     employee_id INT,
     employee_name VARCHAR,
-    salary INT           
+    salary INT
 );
 
 INSERT INTO employees (employee_id, employee_name, salary) VALUES
@@ -56,7 +56,7 @@ FROM employees
 ORDER BY salary DESC;
 
 ----RESULT
-employee_id | employee_name | salary 
+employee_id | employee_name | salary
 -------------+---------------+--------
            5 | Eve           |  75000
            3 | Charlie       |  70000
@@ -66,4 +66,4 @@ employee_id | employee_name | salary
 (5 rows)
 ```
 
-In this example, the result set displayed the employees' details sorted by their salaries in descending order, showing the highest-paid employees first. The `ORDER BY` clause helps in arranging data in a structured and meaningful way for easier interpretation and decision-making. 
+In this example, the result set displayed the employees' details sorted by their salaries in descending order, showing the highest-paid employees first. The `ORDER BY` clause helps in arranging data in a structured and meaningful way for easier interpretation and decision-making.

--- a/versioned_docs/version-1.9/sql/commands/sql-select.md
+++ b/versioned_docs/version-1.9/sql/commands/sql-select.md
@@ -20,7 +20,7 @@ SELECT [ ALL | DISTINCT [ ON ( expression [, ...] ) ]] [ [table_name.]* [ EXCEPT
     [ WHERE condition ]
     [ GROUP BY grouping_expression [ , grouping_expression ... ] ]
     [ HAVING condition ]
-    [ ORDER BY sort_expression [ ASC | DESC ] [ , ... ] ]
+    [ ORDER BY sort_expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ... ] ]
     [ LIMIT count_number ]
     [ OFFSET start [ ROW | ROWS ] ];
 ```
@@ -29,8 +29,8 @@ Where `from_item` can be:
 
 ```sql
     table_name  [ [ AS ] alias [ ( column_alias_list ) ] ]
-    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
-    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
+    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ]
+    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ]
     from_item join_type from_item [ ON join_condition ]
 ```
 
@@ -46,7 +46,7 @@ Where `from_item` can be:
 |*alias*                    |A temporary alternative name for a table or materialized view in a query.|
 |*table_name*                    |A table or materialized view.|
 |*grouping_expression*      |<p>Values can be:</p><ul><li>Input column names</li><li>Input column expressions without subqueries or correlated columns</li></ul>|
-|**ORDER BY** clause        | The default sort order is **ASC**. Nulls options are not supported now. If the sort order is **ASC** or unspecified, nulls will be placed in front of non-null values. If the sort order is **DESC**, nulls will be placed after non-null values. This is different from the sort logic in PostgreSQL.|
+|**ORDER BY** clause        | By default, sorting is in ascending (ASC) order, with NULL values treated as the largest. For more information, see [`ORDER BY` clause](../query-syntax/query-syntax-order-by-clause.md).|
 |*sort_expression*          |<p>Values can be:</p><ul><li>Output column names</li><li>Output column ordinal numbers</li><li>Hidden select expressions</li></ul>|
 |*count_number*                    |The number of results you want to get. |
 |**OFFSET** clause          |The `OFFSET` clause can only be used with the `LIMIT` and `ORDER BY` clauses.|
@@ -119,9 +119,9 @@ The table `company` includes the columns `company_id` and `taxi_id`, where `taxi
 The following query returns the total distance and duration of trips that are beyond the initial charge ($2.50) of each taxi from the company "Yellow Taxi" and "FabCab".
 
 ```sql
-SELECT 
-    taxi.taxi_id, 
-    sum(trips.distance) AS total_distance, 
+SELECT
+    taxi.taxi_id,
+    sum(trips.distance) AS total_distance,
     sum(trips.duration) AS total_duration
 FROM taxi_trips AS trips
 LEFT JOIN taxi ON trips.id = taxi.trip_id

--- a/versioned_docs/version-1.9/sql/query-syntax/query-syntax-order-by-clause.md
+++ b/versioned_docs/version-1.9/sql/query-syntax/query-syntax-order-by-clause.md
@@ -15,16 +15,16 @@ Here is the basic syntax of the `ORDER BY` clause:
 ```sql title="Syntax"
 SELECT select_list
     FROM table_expression
-    ORDER BY sort_expression1 [ASC | DESC] [NULLS { FIRST | LAST }]
-             [, sort_expression2 [ASC | DESC] [NULLS { FIRST | LAST }] ...]
+    ORDER BY sort_expression1 [ ASC | DESC ] [ NULLS { FIRST | LAST } ]
+             [, sort_expression2 [ ASC | DESC ] [ NULLS { FIRST | LAST } ] ...]
 ```
 
 ## Examples
 
-Let's assume we have a table named "employees" with columns "employee_id", "employee_name", and "salary". 
+Let's assume we have a table named "employees" with columns "employee_id", "employee_name", and "salary".
 
 ```sql title="employees"
-employee_id | employee_name | salary 
+employee_id | employee_name | salary
 -------------+---------------+--------
            2 | Bob           |  60000
            4 | David         |  55000
@@ -37,7 +37,7 @@ employee_id | employee_name | salary
 CREATE TABLE employees (
     employee_id INT,
     employee_name VARCHAR,
-    salary INT           
+    salary INT
 );
 
 INSERT INTO employees (employee_id, employee_name, salary) VALUES
@@ -56,7 +56,7 @@ FROM employees
 ORDER BY salary DESC;
 
 ----RESULT
-employee_id | employee_name | salary 
+employee_id | employee_name | salary
 -------------+---------------+--------
            5 | Eve           |  75000
            3 | Charlie       |  70000
@@ -66,4 +66,4 @@ employee_id | employee_name | salary
 (5 rows)
 ```
 
-In this example, the result set displayed the employees' details sorted by their salaries in descending order, showing the highest-paid employees first. The `ORDER BY` clause helps in arranging data in a structured and meaningful way for easier interpretation and decision-making. 
+In this example, the result set displayed the employees' details sorted by their salaries in descending order, showing the highest-paid employees first. The `ORDER BY` clause helps in arranging data in a structured and meaningful way for easier interpretation and decision-making.

--- a/versioned_docs/version-2.0/sql/commands/sql-select.md
+++ b/versioned_docs/version-2.0/sql/commands/sql-select.md
@@ -20,7 +20,7 @@ SELECT [ ALL | DISTINCT [ ON ( expression [, ...] ) ]] [ [table_name.]* [ EXCEPT
     [ WHERE condition ]
     [ GROUP BY grouping_expression [ , grouping_expression ... ] ]
     [ HAVING condition ]
-    [ ORDER BY sort_expression [ ASC | DESC ] [ , ... ] ]
+    [ ORDER BY sort_expression [ ASC | DESC ] [ NULLS { FIRST | LAST } ] [ , ... ] ]
     [ LIMIT count_number ]
     [ OFFSET start [ ROW | ROWS ] ];
 ```

--- a/versioned_docs/version-2.0/sql/commands/sql-select.md
+++ b/versioned_docs/version-2.0/sql/commands/sql-select.md
@@ -1,7 +1,7 @@
 ---
 id: sql-select
 title: SELECT
-description: Retrieve data from a table or a materialized view. 
+description: Retrieve data from a table or a materialized view.
 slug: /sql-select
 ---
 <head>
@@ -29,8 +29,8 @@ Where `from_item` can be:
 
 ```sql
     table_name  [ [ AS ] alias [ ( column_alias_list ) ] ]
-    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
-    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ] 
+    window_type ( table_name, col_name, interval_expression ) [ [ AS ] alias [ ( column_alias_list ) ] ]
+    ( SELECT ) [ [ AS ] alias [ ( column_alias_list ) ] ]
     from_item join_type from_item [ ON join_condition ]
 ```
 
@@ -46,7 +46,7 @@ Where `from_item` can be:
 |*alias*                    |A temporary alternative name for a table or materialized view in a query.|
 |*table_name*                    |A table or materialized view.|
 |*grouping_expression*      |<p>Values can be:</p><ul><li>Input column names</li><li>Input column expressions without subqueries or correlated columns</li></ul>|
-|**ORDER BY** clause        | The default sort order is **ASC**. Nulls options are not supported now. If the sort order is **ASC** or unspecified, nulls will be placed in front of non-null values. If the sort order is **DESC**, nulls will be placed after non-null values. This is different from the sort logic in PostgreSQL.|
+|**ORDER BY** clause        | The default sort order is **ASC**, and NULLs are considered largest. See [`ORDER BY` clause](../query-syntax/query-syntax-order-by-clause.md) for more details.|
 |*sort_expression*          |<p>Values can be:</p><ul><li>Output column names</li><li>Output column ordinal numbers</li><li>Hidden select expressions</li></ul>|
 |*count_number*                    |The number of results you want to get. |
 |**OFFSET** clause          |The `OFFSET` clause can only be used with the `LIMIT` and `ORDER BY` clauses.|
@@ -119,9 +119,9 @@ The table `company` includes the columns `company_id` and `taxi_id`, where `taxi
 The following query returns the total distance and duration of trips that are beyond the initial charge ($2.50) of each taxi from the company "Yellow Taxi" and "FabCab".
 
 ```sql
-SELECT 
-    taxi.taxi_id, 
-    sum(trips.distance) AS total_distance, 
+SELECT
+    taxi.taxi_id,
+    sum(trips.distance) AS total_distance,
     sum(trips.duration) AS total_duration
 FROM taxi_trips AS trips
 LEFT JOIN taxi ON trips.id = taxi.trip_id

--- a/versioned_docs/version-2.0/sql/commands/sql-select.md
+++ b/versioned_docs/version-2.0/sql/commands/sql-select.md
@@ -46,7 +46,7 @@ Where `from_item` can be:
 |*alias*                    |A temporary alternative name for a table or materialized view in a query.|
 |*table_name*                    |A table or materialized view.|
 |*grouping_expression*      |<p>Values can be:</p><ul><li>Input column names</li><li>Input column expressions without subqueries or correlated columns</li></ul>|
-|**ORDER BY** clause        | The default sort order is **ASC**, and NULLs are considered largest. See [`ORDER BY` clause](../query-syntax/query-syntax-order-by-clause.md) for more details.|
+|**ORDER BY** clause        | By default, sorting is in ascending (ASC) order, with NULL values treated as the largest. For more information, see [`ORDER BY` clause](../query-syntax/query-syntax-order-by-clause.md).|
 |*sort_expression*          |<p>Values can be:</p><ul><li>Output column names</li><li>Output column ordinal numbers</li><li>Hidden select expressions</li></ul>|
 |*count_number*                    |The number of results you want to get. |
 |**OFFSET** clause          |The `OFFSET` clause can only be used with the `LIMIT` and `ORDER BY` clauses.|

--- a/versioned_docs/version-2.0/sql/query-syntax/query-syntax-order-by-clause.md
+++ b/versioned_docs/version-2.0/sql/query-syntax/query-syntax-order-by-clause.md
@@ -15,16 +15,16 @@ Here is the basic syntax of the `ORDER BY` clause:
 ```sql title="Syntax"
 SELECT select_list
     FROM table_expression
-    ORDER BY sort_expression1 [ASC | DESC] [NULLS { FIRST | LAST }]
-             [, sort_expression2 [ASC | DESC] [NULLS { FIRST | LAST }] ...]
+    ORDER BY sort_expression1 [ ASC | DESC ] [ NULLS { FIRST | LAST } ]
+             [, sort_expression2 [ ASC | DESC ] [ NULLS { FIRST | LAST } ] ...]
 ```
 
 ## Examples
 
-Let's assume we have a table named "employees" with columns "employee_id", "employee_name", and "salary". 
+Let's assume we have a table named "employees" with columns "employee_id", "employee_name", and "salary".
 
 ```sql title="employees"
-employee_id | employee_name | salary 
+employee_id | employee_name | salary
 -------------+---------------+--------
            2 | Bob           |  60000
            4 | David         |  55000
@@ -37,7 +37,7 @@ employee_id | employee_name | salary
 CREATE TABLE employees (
     employee_id INT,
     employee_name VARCHAR,
-    salary INT           
+    salary INT
 );
 
 INSERT INTO employees (employee_id, employee_name, salary) VALUES
@@ -56,7 +56,7 @@ FROM employees
 ORDER BY salary DESC;
 
 ----RESULT
-employee_id | employee_name | salary 
+employee_id | employee_name | salary
 -------------+---------------+--------
            5 | Eve           |  75000
            3 | Charlie       |  70000
@@ -66,4 +66,4 @@ employee_id | employee_name | salary
 (5 rows)
 ```
 
-In this example, the result set displayed the employees' details sorted by their salaries in descending order, showing the highest-paid employees first. The `ORDER BY` clause helps in arranging data in a structured and meaningful way for easier interpretation and decision-making. 
+In this example, the result set displayed the employees' details sorted by their salaries in descending order, showing the highest-paid employees first. The `ORDER BY` clause helps in arranging data in a structured and meaningful way for easier interpretation and decision-making.


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Description

We've supported `NULLS FIRST | LAST` since v0.18, this PR fixes the description of `ORDER BY` clause in `SELECT` command.

## Related code PR

https://github.com/risingwavelabs/risingwave/commit/41323a9eccadcb02f9bc471bfb07fb4c332d7448

<!--
❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.
-->

<!--
Edit the following sections when this PR is ready for review.
-->

## Rendered preview

<!--
Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation.
-->

## Checklist

- [x] I have checked the doc site preview, and the updated parts look good.
- [x] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
