### PR TITLE
remove aws privatelink from the beta list

### DIFF
--- a/docs/sql/commands/sql-create-connection.md
+++ b/docs/sql/commands/sql-create-connection.md
@@ -51,10 +51,6 @@ CREATE CONNECTION connection_name WITH (
 
 If you are using a cloud-hosted source or sink, such as AWS MSK, there might be connectivity issues when your service is located in a different VPC from where you have deployed RisingWave. To establish a secure, direct connection between these two different VPCs and allow RisingWave to read consumer messages from the broker or send messages to the broker, use the [AWS PrivateLink](https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-share-your-services.html) service.
 
-:::info Public Preview
-AWS PrivateLink connection is in the public preview stage, meaning it's nearing the final product but is not yet fully stable. If you encounter any issues or have feedback, please contact us through our [Slack channel](https://www.risingwave.com/slack). Your input is valuable in helping us improve the feature. For more information, see our [Public preview feature list](/product-lifecycle/#features-in-the-public-preview-stage).
-:::
-
 Follow the steps below to create an AWS PrivateLink connection.
 
 1. Create a [target group](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-target-group.html) for each broker. Set the **target type** as **IP addresses** and the **protocol** as **TCP**. Ensure that the VPC of the target group is the same as your cloud-hosted source.

--- a/src/pages/product-lifecycle.md
+++ b/src/pages/product-lifecycle.md
@@ -53,7 +53,6 @@ Below is a list of all features in the public preview phase:
 | [Emit on window close](/docs/current/emit-on-window-close/)      | 2023.8  | 1.1      |
 | [Read-only transactions](/docs/current/sql-start-transaction)| 2023.8  | 1.1      |
 | [AWS Kinesis sink](/docs/current/sink-to-aws-kinesis/)           | 2023.7  | 1.0     |
-| [AWS PrivateLink connection](/docs/current/sql-create-connection/) | 2023.5  | 0.19     |
 | [CDC Citus source](/docs/current/ingest-from-citus-cdc/)         | 2023.5  | 0.19     |
 | [Iceberg sink](/docs/current/sink-to-iceberg/)                   | 2023.4 | 0.18      |
 | [Pulsar source](/docs/current/ingest-from-pulsar/)               | 2022.12  | 0.1     |

--- a/versioned_docs/version-2.0/sql/commands/sql-create-connection.md
+++ b/versioned_docs/version-2.0/sql/commands/sql-create-connection.md
@@ -51,10 +51,6 @@ CREATE CONNECTION connection_name WITH (
 
 If you are using a cloud-hosted source or sink, such as AWS MSK, there might be connectivity issues when your service is located in a different VPC from where you have deployed RisingWave. To establish a secure, direct connection between these two different VPCs and allow RisingWave to read consumer messages from the broker or send messages to the broker, use the [AWS PrivateLink](https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-share-your-services.html) service.
 
-:::info Public Preview
-AWS PrivateLink connection is in the public preview stage, meaning it's nearing the final product but is not yet fully stable. If you encounter any issues or have feedback, please contact us through our [Slack channel](https://www.risingwave.com/slack). Your input is valuable in helping us improve the feature. For more information, see our [Public preview feature list](/product-lifecycle/#features-in-the-public-preview-stage).
-:::
-
 Follow the steps below to create an AWS PrivateLink connection.
 
 1. Create a [target group](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-target-group.html) for each broker. Set the **target type** as **IP addresses** and the **protocol** as **TCP**. Ensure that the VPC of the target group is the same as your cloud-hosted source.


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Description

Confirmed by @tabVersion, the support for aws privatelink can be considered stable. [GCP Private Service Connect](https://cloud.google.com/vpc/docs/private-service-connect) is not documented so we don't need to update. 
[Azure Private Link](https://learn.microsoft.com/en-us/azure/private-link/) is not supported yet.

## Related code PR

There's no PR that fully validates the stability of aws privatelink support, but we do have several customers running this feature in production.

## Related doc issue

<!--
If this PR fixes/resolves the issue, please write "Resolve #xxx".
-->
Resolve

<!--
❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.
-->

<!--
Edit the following sections when this PR is ready for review.
-->

## Rendered preview

<!--
Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation.
-->

## Checklist

- [ ] I have checked the doc site preview, and the updated parts look good.
- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
