### PR TITLE
Clarify pg cdc syntax for `CREATE TABLE`

### DIFF
--- a/docs/guides/ingest-from-postgres-cdc.md
+++ b/docs/guides/ingest-from-postgres-cdc.md
@@ -172,7 +172,7 @@ CREATE SOURCE [ IF NOT EXISTS ] source_name WITH (
 );
 ```
 
-Syntax for creating a CDC table. Note that a primary key is required and must be consistent with the upstream table.
+Syntax for creating a CDC table on top of this CDC Source. Note that a primary key is required and must be consistent with the upstream table. We  must also specify the Postgres table name (`pg_table_name`) which we are selecting from.
 
 ```sql
 CREATE TABLE [ IF NOT EXISTS ] table_name (
@@ -183,7 +183,7 @@ CREATE TABLE [ IF NOT EXISTS ] table_name (
 WITH (
     snapshot='true'
 )
-FROM source TABLE table_name;
+FROM source TABLE pg_table_name;
 ```
 
 To check the progress of backfilling historical data, find the corresponding internal table using the [`SHOW INTERNAL TABLES`](/sql/commands/sql-show-internal-tables.md) command and query from it.

--- a/versioned_docs/version-2.0/guides/ingest-from-postgres-cdc.md
+++ b/versioned_docs/version-2.0/guides/ingest-from-postgres-cdc.md
@@ -155,7 +155,7 @@ CREATE SOURCE [ IF NOT EXISTS ] source_name WITH (
 );
 ```
 
-Syntax for creating a CDC table. Note that a primary key is required and must be consistent with the upstream table.
+Syntax for creating a CDC table on top of this CDC Source. Note that a primary key is required and must be consistent with the upstream table. We  must also specify the Postgres table name (`pg_table_name`) which we are selecting from.
 
 ```sql
 CREATE TABLE [ IF NOT EXISTS ] table_name (
@@ -166,7 +166,7 @@ CREATE TABLE [ IF NOT EXISTS ] table_name (
 WITH (
     snapshot='true'
 )
-FROM source TABLE table_name;
+FROM source TABLE pg_table_name;
 ```
 
 To check the progress of backfilling historical data, find the corresponding internal table using the [`SHOW INTERNAL TABLES`](/sql/commands/sql-show-internal-tables.md) command and query from it.


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Description

`table_name` is shadowed in both the `CREATE TABLE <table_name>` and the subsequent `FROM source TABLE <table_name>`.

We disambiguate them in this PR.

<!--
Please describe:

1. The motivation of this PR;
2. What's changed and how is the document site is affected;
3. References that's worth listed.
-->

## Related code PR

<!--
Provide a link to the relevant code PR here, if applicable.
-->

## Related doc issue

<!--
If this PR fixes/resolves the issue, please write "Resolve #xxx".
-->
Resolve

<!--
❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.
-->

<!--
Edit the following sections when this PR is ready for review.
-->

## Rendered preview

<!--
Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation.
-->

## Checklist

- [ ] I have checked the doc site preview, and the updated parts look good.
- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
