### PR TITLE
Doc `create_table_if_not_exists` for Iceberg sink

### DIFF
--- a/docs/guides/sink-to-iceberg.md
+++ b/docs/guides/sink-to-iceberg.md
@@ -50,7 +50,7 @@ WITH (
 | catalog.url     | Conditional. The URL of the catalog. It is required when `catalog.type` is not `storage`. |
 | primary_key     | The primary key for an upsert sink. It is only applicable to the upsert mode. |
 | commit_checkpoint_interval | Optional. Commit every N checkpoints (N > 0). Default value is 10. <br/>The behavior of this field also depends on the `sink_decouple` setting:<ul><li>If `sink_decouple` is true (the default), the default value of `commit_checkpoint_interval` is 10.</li> <li>If `sink_decouple` is set to false, the default value of `commit_checkpoint_interval` is 1.</li> <li>If `sink_decouple` is set to false and `commit_checkpoint_interval` is set to larger than 1, an error will occur.</li></ul> |
-| create_table_if_not_exists | Optional. Supported in `storage` and `glue` catalogs. When set to `true`, it will automatically create a table for the Iceberg sink. |
+| create_table_if_not_exists | Optional. When set to `true`, it will automatically create a table for the Iceberg sink. |
 
 ## Data type mapping
 

--- a/docs/guides/sink-to-iceberg.md
+++ b/docs/guides/sink-to-iceberg.md
@@ -50,6 +50,7 @@ WITH (
 | catalog.url     | Conditional. The URL of the catalog. It is required when `catalog.type` is not `storage`. |
 | primary_key     | The primary key for an upsert sink. It is only applicable to the upsert mode. |
 | commit_checkpoint_interval | Optional. Commit every N checkpoints (N > 0). Default value is 10. <br/>The behavior of this field also depends on the `sink_decouple` setting:<ul><li>If `sink_decouple` is true (the default), the default value of `commit_checkpoint_interval` is 10.</li> <li>If `sink_decouple` is set to false, the default value of `commit_checkpoint_interval` is 1.</li> <li>If `sink_decouple` is set to false and `commit_checkpoint_interval` is set to larger than 1, an error will occur.</li></ul> |
+| create_table_if_not_exists | Optional. Supported in `storage` and `glue` catalogs. When set to `true`, it will automatically create a table for the Iceberg sink. |
 
 ## Data type mapping
 


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Description

 Iceberg sink supports `create_table_if_not_exists` in all catalogs.

## Related code PR

https://github.com/risingwavelabs/risingwave/pull/18362

## Related doc issue

Resolve https://github.com/risingwavelabs/risingwave-docs/issues/2568

<!--
❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.
-->

<!--
Edit the following sections when this PR is ready for review.
-->

## Rendered preview

<!--
Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation.
-->

## Checklist

- [ ] I have checked the doc site preview, and the updated parts look good.
- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
