### PR TITLE
Fix input type error

### DIFF
--- a/versioned_docs/version-2.0/sql/udf/udf-python.md
+++ b/versioned_docs/version-2.0/sql/udf/udf-python.md
@@ -167,7 +167,7 @@ LANGUAGE python AS gcd USING LINK 'http://localhost:8815'; -- If you are running
 CREATE FUNCTION blocking(int) RETURNS int
 LANGUAGE python AS blocking USING LINK 'http://localhost:8815'; -- If you are running RisingWave using Docker, replace the address with 'http://host.docker.internal:8815'.
 
-CREATE FUNCTION key_value(bytea) RETURNS struct<key varchar, value varchar> -- the field names must exactly match the ones in Python decorator
+CREATE FUNCTION key_value(varchar) RETURNS struct<key varchar, value varchar> -- the field names must exactly match the ones in Python decorator
 LANGUAGE python AS key_value USING LINK 'http://localhost:8815'; -- If you are running RisingWave using Docker, replace the address with 'http://host.docker.internal:8815'.
 
 CREATE FUNCTION series(int) RETURNS TABLE (x int)


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Description
in `CREATE FUNCTION key_value(bytea) RETURN ...` , the function input variable type is wrong, it should be '`varchar`' instead of `bytea` as declared here:
``` python
@udf(input_types=['VARCHAR'], result_type='STRUCT<key: VARCHAR, value: VARCHAR>')
def key_value(pair: str):
```
<!--
Please describe:

1. The motivation of this PR;
2. What's changed and how is the document site is affected;
3. References that's worth listed.
-->

## Related code PR

<!--
Provide a link to the relevant code PR here, if applicable.
-->

## Related doc issue

<!--
If this PR fixes/resolves the issue, please write "Resolve #xxx".
-->
Resolve

<!--
❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.
-->

<!--
Edit the following sections when this PR is ready for review.
-->

## Rendered preview

<!--
Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation.
-->

## Checklist

- [ ] I have checked the doc site preview, and the updated parts look good.
- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
