### PR TITLE
Specify `t1` in guide

### DIFF
--- a/docs/troubleshoot/troubleshoot-high-latency.md
+++ b/docs/troubleshoot/troubleshoot-high-latency.md
@@ -78,7 +78,7 @@ INNER JOIN product_description
 ON orders.product_id = product_description.product_id
 ```
 
-Suppose `product_id = 1` is a hot-selling product, an update from stream `product_description` with `product_id=1` can match 100K rows from `t1`.
+Suppose `product_id = 1` is a hot-selling product, an update from stream `product_description` with `product_id=1` can match 100K rows from `orders`.
 
 We can split the MV into multiple MVs:
 

--- a/versioned_docs/version-1.10/troubleshoot/troubleshoot-high-latency.md
+++ b/versioned_docs/version-1.10/troubleshoot/troubleshoot-high-latency.md
@@ -74,7 +74,7 @@ INNER JOIN product_description
 ON orders.product_id = product_description.product_id
 ```
 
-Suppose `product_id = 1` is a hot-selling product, an update from stream `product_description` with `product_id=1` can match 100K rows from `t1`.
+Suppose `product_id = 1` is a hot-selling product, an update from stream `product_description` with `product_id=1` can match 100K rows from `orders`.
 
 We can split the MV into multiple MVs:
 

--- a/versioned_docs/version-2.0/troubleshoot/troubleshoot-high-latency.md
+++ b/versioned_docs/version-2.0/troubleshoot/troubleshoot-high-latency.md
@@ -74,7 +74,7 @@ INNER JOIN product_description
 ON orders.product_id = product_description.product_id
 ```
 
-Suppose `product_id = 1` is a hot-selling product, an update from stream `product_description` with `product_id=1` can match 100K rows from `t1`.
+Suppose `product_id = 1` is a hot-selling product, an update from stream `product_description` with `product_id=1` can match 100K rows from `orders`.
 
 We can split the MV into multiple MVs:
 


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Description

Specify `t1` in [Workaround for high join amplification](https://docs.risingwave.com/docs/next/troubleshoot-high-latency/#workaround-for-high-join-amplification)


## Related doc issue

<!--
If this PR fixes/resolves the issue, please write "Resolve #xxx".
-->
Resolve https://github.com/risingwavelabs/risingwave-docs/issues/2700

<!--
❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.
-->

<!--
Edit the following sections when this PR is ready for review.
-->

## Rendered preview

<!--
Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation.
-->

## Checklist

- [ ] I have checked the doc site preview, and the updated parts look good.
- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
