### PR TITLE
Doc `max_packet_size` option to MQTT Source

### DIFF
--- a/docs/ingest/ingest-from-mqtt.md
+++ b/docs/ingest/ingest-from-mqtt.md
@@ -64,12 +64,12 @@ FORMAT PLAIN ENCODE data_encode; -- Format options: plain (encode BYTES and JSON
 |--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `url`              | Required. The URL of the broker to connect to, e.g., `tcp://localhost`. Must be prefixed with `tcp://`, `mqtt://`, `ssl://`, or `mqtts://` to denote the protocol. `mqtts://` and `ssl://` use native certificates if no CA is specified. |
 | `qos`              | Optional. The quality of service for publishing messages. Defaults to `at_most_once`. Options include `at_most_once`, `at_least_once`, or `exactly_once`.   |
-| `max_packet_size`              | Optional. The maximum message size for MQTT client.   |
 | `username`         | Optional. Username for the MQTT broker.                                                                                                                     |
 | `password`         | Optional. Password for the MQTT broker.                                                                                                                     |
 | `client_prefix`    | Optional. Prefix for the MQTT client ID. Defaults to "risingwave".                                                                                          |
 | `clean_start`      | Optional. Determines if all states from queues are removed when the client disconnects. If true, the broker clears all client states upon disconnect; if false, the broker retains the client state and resumes pending operations upon reconnection. |
 | `inflight_messages`| Optional. Maximum number of inflight messages. Defaults to 100.                                                                                             |
+| `max_packet_size`              | Optional. The maximum message size for the MQTT client.   |
 | `tls.client_cert`  | Optional. Path to the client's certificate file (PEM) or a string with the certificate content. Required for client authentication. Can use `fs://` prefix for file paths.                                          |
 | `tls.client_key`   | Optional. Path to the client's private key file (PEM) or a string with the private key content. Required for client authentication. Can use `fs://` prefix for file paths.                                           |
 | `topic`            | Required. The topic name to subscribe or publish to. Can include wildcard topics, e.g., `/topic/#`.                                                         |

--- a/docs/ingest/ingest-from-mqtt.md
+++ b/docs/ingest/ingest-from-mqtt.md
@@ -64,6 +64,7 @@ FORMAT PLAIN ENCODE data_encode; -- Format options: plain (encode BYTES and JSON
 |--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `url`              | Required. The URL of the broker to connect to, e.g., `tcp://localhost`. Must be prefixed with `tcp://`, `mqtt://`, `ssl://`, or `mqtts://` to denote the protocol. `mqtts://` and `ssl://` use native certificates if no CA is specified. |
 | `qos`              | Optional. The quality of service for publishing messages. Defaults to `at_most_once`. Options include `at_most_once`, `at_least_once`, or `exactly_once`.   |
+| `max_packet_size`              | Optional. The maximum message size for MQTT client.   |
 | `username`         | Optional. Username for the MQTT broker.                                                                                                                     |
 | `password`         | Optional. Password for the MQTT broker.                                                                                                                     |
 | `client_prefix`    | Optional. Prefix for the MQTT client ID. Defaults to "risingwave".                                                                                          |


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Description

Add `max_packet_size` into MQTT Source doc

## Related code PR

https://github.com/risingwavelabs/risingwave/pull/18520

## Related doc issue

<!--
If this PR fixes/resolves the issue, please write "Resolve #xxx".
-->
Resolve https://github.com/risingwavelabs/risingwave-docs/issues/2708

<!--
❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.
-->

<!--
Edit the following sections when this PR is ready for review.
-->

## Rendered preview

<!--
Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation.
-->

## Checklist

- [ ] I have checked the doc site preview, and the updated parts look good.
- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
