### PR TITLE
Doc `aggregate:` to prefix scalar function

### DIFF
--- a/docs/sql/query-syntax/query-syntax-value-exp.md
+++ b/docs/sql/query-syntax/query-syntax-value-exp.md
@@ -27,7 +27,7 @@ aggregate_name ( [ expression [ , ... ] ] ) WITHIN GROUP ( order_by_clause ) [ F
 
 The `DISTINCT` keyword, which is only available in the second form, cannot be used together with an `ORDER BY` or `WITHIN GROUP` clause. Additionally, it's important to note that the `order_by_clause` is positioned differently in the first and fourth forms.
 
-In batch mode, `aggregate_name` can also be in the following form:
+`aggregate_name` can also be in the following form:
 
 ```sql
 AGGREGATE:function_name

--- a/docs/sql/udf/udf-java.md
+++ b/docs/sql/udf/udf-java.md
@@ -104,17 +104,6 @@ public class Gcd implements ScalarFunction {
 }
 ```
 
-You can transform a scalar function into an aggregate function by prefixing it with `AGGREGATE:`. This allows you to use the UDF in streaming aggregation queries.
-
-For example, the scalar function `as2` calculates the sum of an array of integers. By prefixing it with `AGGREGATE:`, you can use it as an aggregate function.
-
-```sql
-create function as2(int[]) returns bigint language sql as 'select array_sum($1)';
-select aggregate:as2(a) from (values (1), (2)) t(a);
------Result
-3
-```
-
 :::note Differences with Flink
 
 - The `ScalarFunction` is an interface instead of an abstract class.

--- a/docs/sql/udf/udf-java.md
+++ b/docs/sql/udf/udf-java.md
@@ -104,6 +104,17 @@ public class Gcd implements ScalarFunction {
 }
 ```
 
+You can transform a scalar function into an aggregate function by prefixing it with `AGGREGATE:`. This allows you to use the UDF in streaming aggregation queries.
+
+For example, the scalar function `as2` calculates the sum of an array of integers. By prefixing it with `AGGREGATE:`, you can use it as an aggregate function.
+
+```sql
+create function as2(int[]) returns bigint language sql as 'select array_sum($1)';
+select aggregate:as2(a) from (values (1), (2)) t(a);
+-----Result
+3
+```
+
 :::note Differences with Flink
 
 - The `ScalarFunction` is an interface instead of an abstract class.


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Description

Support using `aggregate:` as the prefix of scalar function

## Related code PR

https://github.com/risingwavelabs/risingwave/issues/18202
https://github.com/risingwavelabs/risingwave/pull/18203
https://github.com/risingwavelabs/risingwave/pull/18205


## Related doc issue

<!--
If this PR fixes/resolves the issue, please write "Resolve #xxx".
-->
Resolve https://github.com/risingwavelabs/risingwave-docs/issues/2520

<!--
❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.
-->

<!--
Edit the following sections when this PR is ready for review.
-->

## Rendered preview

<!--
Paste the preview link to the updated page(s) here. Edit this item after the preview site is ready. To find the updated pages, scroll down to locate and open the Amplify preview link and select the **dev** version of the documentation.
-->

## Checklist

- [ ] I have checked the doc site preview, and the updated parts look good.
- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
