### PR TITLE
Doc: support subscription cursor to be blocking

### DIFF
--- a/docs/transform/subscription.md
+++ b/docs/transform/subscription.md
@@ -122,11 +122,15 @@ FETCH NEXT/n FROM cursor_name WITH (timeout = 'xx');
 
     If the subscription has a large number of values and the fetch operation is set to retrieve many rows, the fetch operation might exceed the specified `timeout`. In this case, it will return all values currently fetched during the timeout process.
 
+    If `timeout` is not set for the case of large data sets, it is equivalent to `timeout = u64::MAX`.
+
 2. No new data:
 
     - Previously fetched rows: If you have already fetched more than one row, the fetch statement will not block. It will return all the values that have been fetched so far.
 
     - No values available: If no values are currently available, the fetch operation will block until new data becomes available or until the specified timeout is exceeded.
+
+    If `timeout` is not set for the case of no new data, it is equivalent to `timeout = 0`.
 
 #### Order of the fetched data
 


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Description

Divide `fetch from cursor` to be non-blocking and blocking

## Related code PR

https://github.com/risingwavelabs/risingwave/pull/18675

## Related doc issue

<!--
If this PR fixes/resolves the issue, please write "Resolve #xxx".
-->
Resolve https://github.com/risingwavelabs/risingwave-docs/issues/2672

<!--
❗️ Before you submit, please ensure you have selected the applicable software version from "Milestone" if this PR is version-specific and applied relevant labels to categorize the PR. Submit the PR as a draft if it's not ready for review.
-->

<!--
Edit the following sections when this PR is ready for review.
-->

## Rendered preview

https://pr-2736.d2fbku9n2b6wde.amplifyapp.com/docs/next/subscription/#fetch-from-cursor

## Checklist

- [ ] I have checked the doc site preview, and the updated parts look good.
- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
