### PR TITLE
add new required APIs for GCP BYOC provisioning

### DIFF
--- a/cloud/project-byoc.md
+++ b/cloud/project-byoc.md
@@ -94,6 +94,8 @@ import TabItem from '@theme/TabItem';
     - **Cloud DNS API** for VPC private service connect setup.
     - **Kubernetes Engine API** for provisioning the GKE cluster the data plane is hosted.
     - **Cloud Resource Manager API** for IAM provisioning.
+    - **Service Networking API** for Cloud SQL (as meta store) connection.
+    - **Cloud SQL Admin API** for Cloud SQL (as meta store) provisioning
 
 - **Required permission for BYOC environment creation/deletion**
 


### PR DESCRIPTION
<!--Edit the Info section when creating this PR.-->

## Description

We are about to introduce pg metastore for BYOC, which requires additional APIs in user's GCP project

## Related code PR

https://github.com/risingwavelabs/terraform-risingwave-cloud-byoc/pull/890

## Related doc issue

N/A

## Rendered preview

https://github.com/risingwavelabs/risingwave-docs/blob/159b27311e9f53bd68111b1063d40f366f5a6219/cloud/project-byoc.md#resource-and-permission

## Checklist

- [x] I have checked the doc site preview, and the updated parts look good.
- [ ] I have acquired the approval from the owner (and optionally the reviewers) of the code PR and at least one tech writer (`emile-00`, `hengm3467`, & `WanYixian`).
